### PR TITLE
feat: add EVM RPC node capability test script

### DIFF
--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -1,5 +1,29 @@
 # Getting started
 
+## Testing an EVM node's RPC capabilities
+
+Before pointing the indexer at a new chain or node provider, check that the node supports every
+JSON-RPC method the indexer uses. `test-evm-rpc-capabilities.sh` is chain-agnostic — it discovers a
+historical block and calls Multicall3, which is deployed at the same address on virtually every EVM
+chain.
+
+```bash
+RPC_URL=https://... TRACE_RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh
+```
+
+`TRACE_RPC_URL` is optional and falls back to `RPC_URL`, exactly as the indexer does. Checks are
+grouped by feature: `--core-only` covers what any deployment needs, `--dci-only` covers dynamic
+contract indexing. DCI needs capabilities on both endpoints — the hooks DCI runs its slot detectors
+on `RPC_URL`, only the entrypoint tracer uses `TRACE_RPC_URL`. Run `--help` for the full list of
+environment variables (block offset, batch sizes, test contract).
+
+The script exits non-zero when a required capability is missing. `eth_gasPrice` and
+`eth_maxPriorityFeePerGas` are reported as warnings: the indexer itself does not call them, and
+either one satisfies downstream consumers. The header comment lists each method alongside the
+component that needs it.
+
+---
+
 ## Migrating a PR from a related repo
 
 When a PR is open in a related repository (`tycho-protocol-sdk`, `tycho-simulation`,

--- a/scripts/test-evm-rpc-capabilities.sh
+++ b/scripts/test-evm-rpc-capabilities.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+#
+# Test RPC node capabilities required by tycho-indexer.
+# Chain-agnostic: auto-discovers a historical block and uses Multicall3
+# (deployed on virtually every EVM chain at the same address).
+#
+# Usage:
+#   RPC_URL=https://... ./scripts/test-rpc-capabilities.sh
+#   RPC_URL=https://... ./scripts/test-rpc-capabilities.sh --trace-only
+#   RPC_URL=https://... ./scripts/test-rpc-capabilities.sh --main-only
+#
+# Optional env vars:
+#   BLOCK_OFFSET  — how many blocks back from latest to use as historical (default: 100000)
+#   TEST_CONTRACT — override the contract address used for tests (default: Multicall3)
+#
+# Exit codes:
+#   0 - all tests passed
+#   1 - one or more tests failed
+#
+# ==========================================================================
+# RPC Node Requirements for tycho-indexer
+# ==========================================================================
+#
+# The node MUST be an archive node (full historical state access).
+#
+# --- RPC_URL (main RPC) ---
+#
+# Standard methods:
+#   eth_blockNumber                         — current chain tip
+#   eth_gasPrice                            — legacy gas price
+#   eth_maxPriorityFeePerGas                — EIP-1559 priority fee
+#   eth_getBlockByNumber                    — block header at any height
+#   eth_getBalance                          — native balance at any block number
+#   eth_getCode                             — contract bytecode at any block number
+#   eth_getStorageAt                        — single storage slot at any block number
+#
+# eth_call (all must work on latest, historical block number, AND block hash):
+#   eth_call                                — basic contract calls
+#   eth_call + state overrides              — code, balance, state, stateDiff
+#                                             (slot detector, Euler Hooks DCI lens deployment)
+#
+# Debug / trace methods:
+#   debug_storageRangeAt                    — full storage dump at a block hash
+#   trace_callMany                          — token quality analysis (Parity trace API)
+#
+# Batching:
+#   JSON-RPC batch requests                 — used extensively for parallelism
+#
+# --- TRACE_RPC_URL (DCI tracer, falls back to RPC_URL if unset) ---
+#
+# Entry point tracing (all at historical block hash):
+#   eth_createAccessList                    — discover touched contracts/slots
+#   eth_createAccessList + state overrides  — code, balance, stateDiff
+#   debug_traceCall (prestateTracer)        — pre-state diffs
+#   debug_traceCall + stateOverrides        — code, balance, stateDiff
+#
+# Batched pairs (sent as single batch request):
+#   eth_createAccessList + debug_traceCall  — DCI trace_and_access_list
+#   debug_traceCall + eth_call              — slot detector trace
+#   eth_call + stateDiff (x N)             — slot detector validation
+#
+# ==========================================================================
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+: "${RPC_URL:?RPC_URL environment variable must be set}"
+
+BLOCK_OFFSET="${BLOCK_OFFSET:-100000}"
+
+# Multicall3: deployed at the same address on virtually every EVM chain
+# See https://www.multicall3.com/deployments
+DEFAULT_CONTRACT="0xcA11bde05977b3631167028862bE2a173976CA11"
+CONTRACT="${TEST_CONTRACT:-$DEFAULT_CONTRACT}"
+
+# Multicall3 function selectors (work on any chain)
+GET_BLOCK_NUMBER_SIG="0x42cbb15c"  # getBlockNumber() → uint256
+GET_BASEFEE_SIG="0x3e64a696"       # getBasefee() → uint256
+
+# Arbitrary address padded to 32 bytes (for calldata args)
+PADDED_ADDR="000000000000000000000000cA11bde05977b3631167028862bE2a173976CA11"
+
+# Minimal EVM bytecode (returns 32 zero bytes) for code override tests
+MINIMAL_BYTECODE="0x60006000526020600060003960206000f3"
+
+# Arbitrary address for code-override tests (never deployed on any chain)
+LENS_ADDR="0x0000000000000000000000000000000000001337"
+
+# Slot zero (used for storage override tests)
+SLOT_ZERO="0x0000000000000000000000000000000000000000000000000000000000000000"
+OVERRIDE_VAL="0x00000000000000000000000000000000000000000000000000000000deadbeef"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+SKIP=0
+MODE="all"
+
+for arg in "$@"; do
+    case "$arg" in
+        --trace-only) MODE="trace" ;;
+        --main-only)  MODE="main" ;;
+    esac
+done
+
+rpc_call() {
+    local method="$1"
+    local params="$2"
+    curl -s -X POST "$RPC_URL" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$method\",\"params\":$params}" \
+        2>/dev/null || echo '{"error":"curl request failed"}'
+}
+
+rpc_batch() {
+    local body="$1"
+    curl -s -X POST "$RPC_URL" \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        2>/dev/null || echo '[]'
+}
+
+has_result() {
+    echo "$1" | jq -e '.result != null' >/dev/null 2>&1
+}
+
+has_error() {
+    echo "$1" | jq -e '.error != null' >/dev/null 2>&1
+}
+
+check() {
+    local name="$1"
+    local resp="$2"
+    if has_result "$resp" && ! has_error "$resp"; then
+        printf "  %-65s \033[32mPASS\033[0m\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        local err
+        err=$(echo "$resp" | jq -r '.error // empty' 2>/dev/null || echo "$resp")
+        printf "  %-65s \033[31mFAIL\033[0m\n" "$name"
+        printf "    -> %s\n" "$err"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_batch() {
+    local name="$1"
+    local resp="$2"
+    local count="$3"
+
+    local actual
+    actual=$(echo "$resp" | jq 'length' 2>/dev/null || echo "0")
+    local all_ok
+    all_ok=$(echo "$resp" | jq "[.[] | select(.result != null)] | length" 2>/dev/null || echo "0")
+
+    if [ "$actual" -ge "$count" ] && [ "$all_ok" -ge "$count" ]; then
+        printf "  %-65s \033[32mPASS\033[0m\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        local errs
+        errs=$(echo "$resp" | jq '[.[] | select(.error != null) | .error]' 2>/dev/null || echo "$resp")
+        printf "  %-65s \033[31mFAIL\033[0m\n" "$name"
+        printf "    -> got %s/%s ok, errors: %s\n" "$all_ok" "$count" "$errs"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+section() {
+    echo ""
+    echo "=== $1 ==="
+}
+
+# ---------------------------------------------------------------------------
+# Discover chain info and historical block
+# ---------------------------------------------------------------------------
+echo "Target RPC: $RPC_URL"
+echo "Test contract: $CONTRACT"
+echo ""
+
+echo "Fetching latest block..."
+LATEST_RESP=$(rpc_call "eth_blockNumber" "[]")
+LATEST_HEX=$(echo "$LATEST_RESP" | jq -r '.result')
+LATEST_DEC=$(printf "%d" "$LATEST_HEX")
+echo "Latest block: $LATEST_HEX ($LATEST_DEC)"
+
+HIST_DEC=$((LATEST_DEC - BLOCK_OFFSET))
+HIST_HEX=$(printf "0x%x" "$HIST_DEC")
+echo "Historical block (latest - $BLOCK_OFFSET): $HIST_HEX ($HIST_DEC)"
+
+echo "Fetching historical block hash..."
+BLOCK_RESP=$(rpc_call "eth_getBlockByNumber" "[\"$HIST_HEX\", false]")
+HIST_HASH=$(echo "$BLOCK_RESP" | jq -r '.result.hash')
+if [ -z "$HIST_HASH" ] || [ "$HIST_HASH" = "null" ]; then
+    echo "ERROR: Could not fetch block $HIST_HEX — is this an archive node?"
+    exit 1
+fi
+echo "Historical block hash: $HIST_HASH"
+
+# Simple call data used across tests: Multicall3.getBlockNumber() (no args)
+CALL_DATA="$GET_BLOCK_NUMBER_SIG"
+
+echo ""
+
+# ===================================================================
+# RPC_URL requirements (main RPC client)
+# ===================================================================
+if [ "$MODE" = "all" ] || [ "$MODE" = "main" ]; then
+
+section "Standard JSON-RPC (eth_*)"
+
+R=$(rpc_call "eth_blockNumber" "[]")
+check "eth_blockNumber" "$R"
+
+R=$(rpc_call "eth_gasPrice" "[]")
+check "eth_gasPrice" "$R"
+
+R=$(rpc_call "eth_maxPriorityFeePerGas" "[]")
+check "eth_maxPriorityFeePerGas" "$R"
+
+# --- Historical block data ---
+section "Historical block data (archive node)"
+
+R=$(rpc_call "eth_getBlockByNumber" "[\"$HIST_HEX\", false]")
+check "eth_getBlockByNumber (historical)" "$R"
+
+R=$(rpc_call "eth_getBalance" "[\"$CONTRACT\", \"$HIST_HEX\"]")
+check "eth_getBalance (historical)" "$R"
+
+R=$(rpc_call "eth_getCode" "[\"$CONTRACT\", \"$HIST_HEX\"]")
+check "eth_getCode (historical)" "$R"
+
+R=$(rpc_call "eth_getStorageAt" "[\"$CONTRACT\", \"0x0\", \"$HIST_HEX\"]")
+check "eth_getStorageAt (historical)" "$R"
+
+# --- eth_call ---
+section "eth_call"
+
+R=$(rpc_call "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"latest\"]")
+check "eth_call (latest)" "$R"
+
+R=$(rpc_call "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HEX\"]")
+check "eth_call (historical block number)" "$R"
+
+R=$(rpc_call "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\"]")
+check "eth_call (historical block hash)" "$R"
+
+# --- eth_call with state overrides ---
+section "eth_call with state overrides"
+
+# All override types in one call at historical block hash:
+# - stateDiff on existing contract (SlotDetector)
+# - code + state on fresh address (Euler Hooks DCI lens deployment)
+# - balance override (entrypoint tracer)
+R=$(rpc_call "eth_call" "[{\"to\":\"$LENS_ADDR\",\"data\":\"0x\"}, \"$HIST_HASH\", {\"$LENS_ADDR\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"state\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}},\"$CONTRACT\":{\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}]")
+check "eth_call + overrides: code/balance/state/stateDiff (hist hash)" "$R"
+
+# Same at historical block number (Euler Hooks DCI uses block number, not hash)
+R=$(rpc_call "eth_call" "[{\"to\":\"$LENS_ADDR\",\"data\":\"0x\"}, \"$HIST_HEX\", {\"$LENS_ADDR\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"state\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}},\"$CONTRACT\":{\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}]")
+check "eth_call + overrides: code/balance/state/stateDiff (hist num)" "$R"
+
+# --- debug_storageRangeAt ---
+section "debug_storageRangeAt"
+
+R=$(rpc_call "debug_storageRangeAt" "[\"$HIST_HASH\", 0, \"$CONTRACT\", \"$SLOT_ZERO\", 10]")
+check "debug_storageRangeAt (historical block hash)" "$R"
+
+# --- trace_callMany ---
+section "trace_callMany"
+
+R=$(rpc_call "trace_callMany" "[[[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"},[\"trace\"]]],\"latest\"]")
+check "trace_callMany (latest)" "$R"
+
+R=$(rpc_call "trace_callMany" "[[[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"},[\"trace\"]]],\"$HIST_HEX\"]")
+check "trace_callMany (historical)" "$R"
+
+# --- JSON-RPC batching ---
+section "JSON-RPC batching"
+
+BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"eth_getCode","params":["'"$CONTRACT"'","'"$HIST_HEX"'"]},
+  {"jsonrpc":"2.0","id":2,"method":"eth_getBalance","params":["'"$CONTRACT"'","'"$HIST_HEX"'"]}
+]'
+R=$(rpc_batch "$BATCH_BODY")
+check_batch "JSON-RPC batch (eth_getCode + eth_getBalance)" "$R" 2
+
+BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["'"$CONTRACT"'","0x0","'"$HIST_HEX"'"]},
+  {"jsonrpc":"2.0","id":2,"method":"eth_getStorageAt","params":["'"$CONTRACT"'","0x1","'"$HIST_HEX"'"]}
+]'
+R=$(rpc_batch "$BATCH_BODY")
+check_batch "JSON-RPC batch (eth_getStorageAt x2)" "$R" 2
+
+fi  # end main-only / all
+
+# ===================================================================
+# TRACE_RPC_URL requirements (DCI tracer + service tracer)
+# Also used by RPC_URL for the service-side tracer and slot detector.
+# ===================================================================
+if [ "$MODE" = "all" ] || [ "$MODE" = "trace" ]; then
+
+section "eth_createAccessList"
+
+R=$(rpc_call "eth_createAccessList" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\"]")
+check "eth_createAccessList (historical block hash)" "$R"
+
+R=$(rpc_call "eth_createAccessList" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\", {\"$CONTRACT\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}]")
+check "eth_createAccessList + overrides (historical)" "$R"
+
+section "debug_traceCall (prestateTracer)"
+
+R=$(rpc_call "debug_traceCall" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true}]")
+check "debug_traceCall prestateTracer (historical block hash)" "$R"
+
+R=$(rpc_call "debug_traceCall" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true,\"stateOverrides\":{\"$CONTRACT\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}}]")
+check "debug_traceCall prestateTracer + overrides (historical)" "$R"
+
+section "Batched trace_and_access_list (eth_createAccessList + debug_traceCall)"
+
+BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"eth_createAccessList","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'"]},
+  {"jsonrpc":"2.0","id":2,"method":"debug_traceCall","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"tracer":"prestateTracer","enableReturnData":true}]}
+]'
+R=$(rpc_batch "$BATCH_BODY")
+check_batch "Batch: eth_createAccessList + debug_traceCall" "$R" 2
+
+section "Batched slot_detector_trace (debug_traceCall + eth_call)"
+
+BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"debug_traceCall","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"tracer":"prestateTracer","enableReturnData":true}]},
+  {"jsonrpc":"2.0","id":2,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'"]}
+]'
+R=$(rpc_batch "$BATCH_BODY")
+check_batch "Batch: debug_traceCall + eth_call (slot detector)" "$R" 2
+
+section "Batched slot_detector_tests (eth_call + stateDiff)"
+
+BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"'"$CONTRACT"'":{"stateDiff":{"'"$SLOT_ZERO"'":"'"$OVERRIDE_VAL"'"}}}]},
+  {"jsonrpc":"2.0","id":2,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"'"$CONTRACT"'":{"stateDiff":{"'"$SLOT_ZERO"'":"'"$OVERRIDE_VAL"'"}}}]}
+]'
+R=$(rpc_batch "$BATCH_BODY")
+check_batch "Batch: eth_call + stateDiff override (slot detector tests)" "$R" 2
+
+fi  # end trace-only / all
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "==========================================="
+printf "Results: \033[32m%d passed\033[0m, \033[31m%d failed\033[0m, \033[33m%d skipped\033[0m\n" "$PASS" "$FAIL" "$SKIP"
+echo "==========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Some RPC methods are not supported. Review failures above."
+    exit 1
+fi

--- a/scripts/test-evm-rpc-capabilities.sh
+++ b/scripts/test-evm-rpc-capabilities.sh
@@ -5,17 +5,21 @@
 # (deployed on virtually every EVM chain at the same address).
 #
 # Usage:
-#   RPC_URL=https://... ./scripts/test-rpc-capabilities.sh
-#   RPC_URL=https://... ./scripts/test-rpc-capabilities.sh --trace-only
-#   RPC_URL=https://... ./scripts/test-rpc-capabilities.sh --main-only
+#   RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh
+#   RPC_URL=https://... TRACE_RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh
+#   RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh --core-only
+#   RPC_URL=https://... TRACE_RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh --dci-only
 #
 # Optional env vars:
-#   BLOCK_OFFSET  — how many blocks back from latest to use as historical (default: 100000)
-#   TEST_CONTRACT — override the contract address used for tests (default: Multicall3)
+#   TRACE_RPC_URL   — DCI tracer endpoint (default: RPC_URL, same as the indexer)
+#   BLOCK_OFFSET    — how many blocks back from latest to use as historical (default: 100000)
+#   TEST_CONTRACT   — override the contract address used for tests (default: Multicall3)
+#   MAX_BATCH_SIZE  — requests per batch (default: 50, the indexer's default)
+#   STORAGE_BATCH_SIZE — eth_getStorageAt requests per batch (default: 1000, indexer's default)
 #
 # Exit codes:
-#   0 - all tests passed
-#   1 - one or more tests failed
+#   0 - all required capabilities present (warnings allowed)
+#   1 - one or more required capabilities missing
 #
 # ==========================================================================
 # RPC Node Requirements for tycho-indexer
@@ -23,44 +27,60 @@
 #
 # The node MUST be an archive node (full historical state access).
 #
-# --- RPC_URL (main RPC) ---
+# Requirements split by feature, not by endpoint: core indexing always runs against RPC_URL,
+# while DCI needs capabilities on *both* RPC_URL and TRACE_RPC_URL (see the DCI section).
+#
+# --- Core indexing — RPC_URL (crates/tycho-ethereum/src/rpc/mod.rs) ---
 #
 # Standard methods:
 #   eth_blockNumber                         — current chain tip
-#   eth_gasPrice                            — legacy gas price
-#   eth_maxPriorityFeePerGas                — EIP-1559 priority fee
-#   eth_getBlockByNumber                    — block header at any height
+#   eth_getBlockByNumber                    — block header at any height (and `latest`)
 #   eth_getBalance                          — native balance at any block number
 #   eth_getCode                             — contract bytecode at any block number
 #   eth_getStorageAt                        — single storage slot at any block number
+#                                             (AccountExtractor, selected slots)
+#   debug_storageRangeAt                    — full storage dump at a block hash, 100k entries per
+#                                             page. Needed by `initialized_accounts` in
+#                                             extractors.yaml and by DCI account snapshots
+#                                             (AccountExtractor)
 #
-# eth_call (all must work on latest, historical block number, AND block hash):
-#   eth_call                                — basic contract calls
-#   eth_call + state overrides              — code, balance, state, stateDiff
-#                                             (slot detector, Euler Hooks DCI lens deployment)
+# eth_call (on `latest` AND on a historical block number):
+#   eth_call                                — token symbol/decimals, DCI metadata calls
+#   eth_call + state overrides              — code, balance, state, stateDiff, 30M gas limit.
+#                                             EthCallDetector injects the Analyzer and Forwarder
+#                                             bytecode to grade every unknown token
 #
-# Debug / trace methods:
-#   debug_storageRangeAt                    — full storage dump at a block hash
-#   trace_callMany                          — token quality analysis (Parity trace API)
+# Batching (defaults from RPCBatchingConfig::enabled_with_defaults):
+#   50 requests per batch, 1000 for eth_getStorageAt
+#     eth_getCode + eth_getBalance          — AccountExtractor
+#     eth_getStorageAt x N                  — AccountExtractor
 #
-# Batching:
-#   JSON-RPC batch requests                 — used extensively for parallelism
+# Optional:
+#   eth_gasPrice / eth_maxPriorityFeePerGas — FeePriceGetter, for downstream consumers. Only one
+#                                             is needed; get_gas_price falls back to eth_gasPrice.
 #
-# --- TRACE_RPC_URL (DCI tracer, falls back to RPC_URL if unset) ---
+# --- DCI — RPC_URL (crates/tycho-ethereum/src/services/entrypoint_tracer/) ---
 #
-# Entry point tracing (all at historical block hash):
+# The Uniswap V4 hooks DCI builds its slot detectors on the *main* client, so these are
+# required on RPC_URL even when TRACE_RPC_URL points elsewhere
+# (extractor/dynamic_contract_indexer/hooks/hooks_dci_builder.rs).
+#
+#   debug_traceCall (prestateTracer)        — BalanceSlotDetector / AllowanceSlotDetector
+#   debug_traceCall + eth_call in one batch — slot detector trace (needs batch >= 2)
+#   eth_call + stateDiff x N in one batch   — slot detector tests
+#
+# --- DCI — TRACE_RPC_URL (entrypoint tracer, falls back to RPC_URL if unset) ---
+#
+# All at a historical block hash (entrypoint_tracer/tracer.rs):
 #   eth_createAccessList                    — discover touched contracts/slots
 #   eth_createAccessList + state overrides  — code, balance, stateDiff
 #   debug_traceCall (prestateTracer)        — pre-state diffs
 #   debug_traceCall + stateOverrides        — code, balance, stateDiff
-#
-# Batched pairs (sent as single batch request):
-#   eth_createAccessList + debug_traceCall  — DCI trace_and_access_list
-#   debug_traceCall + eth_call              — slot detector trace
-#   eth_call + stateDiff (x N)             — slot detector validation
+#   both in one batch                       — trace_and_access_list requires batching
 #
 # ==========================================================================
 
+# `-e` is deliberately omitted: a failing capability check must not abort the run.
 set -uo pipefail
 
 # ---------------------------------------------------------------------------
@@ -68,24 +88,39 @@ set -uo pipefail
 # ---------------------------------------------------------------------------
 : "${RPC_URL:?RPC_URL environment variable must be set}"
 
+# The indexer falls back to RPC_URL when TRACE_RPC_URL is unset (extractor/factory.rs).
+TRACE_URL="${TRACE_RPC_URL:-$RPC_URL}"
+
 BLOCK_OFFSET="${BLOCK_OFFSET:-100000}"
+
+# Mirrors RPCBatchingConfig::enabled_with_defaults()
+MAX_BATCH_SIZE="${MAX_BATCH_SIZE:-50}"
+STORAGE_BATCH_SIZE="${STORAGE_BATCH_SIZE:-1000}"
+
+# Mirrors debug_storage_range_at's page size
+STORAGE_RANGE_LIMIT=100000
+
+# Mirrors EthCallDetector::GAS_LIMIT (30M)
+CALL_GAS_LIMIT="0x1c9c380"
 
 # Multicall3: deployed at the same address on virtually every EVM chain
 # See https://www.multicall3.com/deployments
 DEFAULT_CONTRACT="0xcA11bde05977b3631167028862bE2a173976CA11"
 CONTRACT="${TEST_CONTRACT:-$DEFAULT_CONTRACT}"
 
-# Multicall3 function selectors (work on any chain)
-GET_BLOCK_NUMBER_SIG="0x42cbb15c"  # getBlockNumber() → uint256
-GET_BASEFEE_SIG="0x3e64a696"       # getBasefee() → uint256
+# Multicall3.getBlockNumber() → uint256; works on any chain
+CALL_DATA="0x42cbb15c"
 
-# Arbitrary address padded to 32 bytes (for calldata args)
-PADDED_ADDR="000000000000000000000000cA11bde05977b3631167028862bE2a173976CA11"
+# Call object used by the trace tests. `gas` is set explicitly: without it a node
+# charges the sender its whole RPC gas cap, and the default sender (0x0) fails the
+# funding check before the method under test is ever exercised.
+TRACE_TX="{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\",\"gas\":\"$CALL_GAS_LIMIT\"}"
 
 # Minimal EVM bytecode (returns 32 zero bytes) for code override tests
 MINIMAL_BYTECODE="0x60006000526020600060003960206000f3"
 
-# Arbitrary address for code-override tests (never deployed on any chain)
+# Arbitrary address for code-override tests (never deployed on any chain).
+# Same address the Euler Hooks DCI deploys its lens to via state override.
 LENS_ADDR="0x0000000000000000000000000000000000001337"
 
 # Slot zero (used for storage override tests)
@@ -97,28 +132,38 @@ OVERRIDE_VAL="0x00000000000000000000000000000000000000000000000000000000deadbeef
 # ---------------------------------------------------------------------------
 PASS=0
 FAIL=0
-SKIP=0
+WARN=0
 MODE="all"
 
 for arg in "$@"; do
     case "$arg" in
-        --trace-only) MODE="trace" ;;
-        --main-only)  MODE="main" ;;
+        --core-only) MODE="core" ;;
+        --dci-only) MODE="dci" ;;
+        -h | --help)
+            sed -n '3,22p' "$0"
+            exit 0
+            ;;
+        *)
+            printf "Unknown argument: %s (try --help)\n" "$arg" >&2
+            exit 2
+            ;;
     esac
 done
 
 rpc_call() {
-    local method="$1"
-    local params="$2"
-    curl -s -X POST "$RPC_URL" \
+    local url="$1"
+    local method="$2"
+    local params="$3"
+    curl -s -X POST "$url" \
         -H "Content-Type: application/json" \
         -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$method\",\"params\":$params}" \
         2>/dev/null || echo '{"error":"curl request failed"}'
 }
 
 rpc_batch() {
-    local body="$1"
-    curl -s -X POST "$RPC_URL" \
+    local url="$1"
+    local body="$2"
+    curl -s -X POST "$url" \
         -H "Content-Type: application/json" \
         -d "$body" \
         2>/dev/null || echo '[]'
@@ -132,6 +177,10 @@ has_error() {
     echo "$1" | jq -e '.error != null' >/dev/null 2>&1
 }
 
+error_of() {
+    echo "$1" | jq -rc '.error // empty' 2>/dev/null || echo "$1"
+}
+
 check() {
     local name="$1"
     local resp="$2"
@@ -139,11 +188,24 @@ check() {
         printf "  %-65s \033[32mPASS\033[0m\n" "$name"
         PASS=$((PASS + 1))
     else
-        local err
-        err=$(echo "$resp" | jq -r '.error // empty' 2>/dev/null || echo "$resp")
         printf "  %-65s \033[31mFAIL\033[0m\n" "$name"
-        printf "    -> %s\n" "$err"
+        printf "    -> %s\n" "$(error_of "$resp")"
         FAIL=$((FAIL + 1))
+    fi
+}
+
+# Same as check(), but a missing capability is reported as a warning and does
+# not fail the run. Used for methods the indexer does not depend on.
+check_optional() {
+    local name="$1"
+    local resp="$2"
+    if has_result "$resp" && ! has_error "$resp"; then
+        printf "  %-65s \033[32mPASS\033[0m\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  %-65s \033[33mWARN\033[0m\n" "$name"
+        printf "    -> %s\n" "$(error_of "$resp")"
+        WARN=$((WARN + 1))
     fi
 }
 
@@ -152,9 +214,8 @@ check_batch() {
     local resp="$2"
     local count="$3"
 
-    local actual
+    local actual all_ok
     actual=$(echo "$resp" | jq 'length' 2>/dev/null || echo "0")
-    local all_ok
     all_ok=$(echo "$resp" | jq "[.[] | select(.result != null)] | length" 2>/dev/null || echo "0")
 
     if [ "$actual" -ge "$count" ] && [ "$all_ok" -ge "$count" ]; then
@@ -162,7 +223,7 @@ check_batch() {
         PASS=$((PASS + 1))
     else
         local errs
-        errs=$(echo "$resp" | jq '[.[] | select(.error != null) | .error]' 2>/dev/null || echo "$resp")
+        errs=$(echo "$resp" | jq -c '[.[] | select(.error != null) | .error] | unique' 2>/dev/null || echo "$resp")
         printf "  %-65s \033[31mFAIL\033[0m\n" "$name"
         printf "    -> got %s/%s ok, errors: %s\n" "$all_ok" "$count" "$errs"
         FAIL=$((FAIL + 1))
@@ -174,189 +235,220 @@ section() {
     echo "=== $1 ==="
 }
 
+# Collects newline-delimited JSON request objects from stdin into a batch array.
+as_batch() {
+    jq -sc '.'
+}
+
+# Alternating eth_getCode / eth_getBalance batch at the historical block number.
+code_and_balance_batch() {
+    local n="$1" i method
+    for ((i = 0; i < n; i++)); do
+        if [ $((i % 2)) -eq 0 ]; then method="eth_getCode"; else method="eth_getBalance"; fi
+        printf '{"jsonrpc":"2.0","id":%d,"method":"%s","params":["%s","%s"]}\n' \
+            "$((i + 1))" "$method" "$CONTRACT" "$HIST_HEX"
+    done | as_batch
+}
+
+storage_slot_batch() {
+    local n="$1" i
+    for ((i = 0; i < n; i++)); do
+        printf '{"jsonrpc":"2.0","id":%d,"method":"eth_getStorageAt","params":["%s","0x%x","%s"]}\n' \
+            "$((i + 1))" "$CONTRACT" "$i" "$HIST_HEX"
+    done | as_batch
+}
+
+# Batch of eth_call + stateDiff overrides, the shape slot_detector_tests sends.
+state_diff_call_batch() {
+    local n="$1" i
+    for ((i = 0; i < n; i++)); do
+        printf '{"jsonrpc":"2.0","id":%d,"method":"eth_call","params":[{"to":"%s","data":"%s"},"latest",{"%s":{"stateDiff":{"%s":"%s"}}}]}\n' \
+            "$((i + 1))" "$CONTRACT" "$CALL_DATA" "$CONTRACT" "$SLOT_ZERO" "$OVERRIDE_VAL"
+    done | as_batch
+}
+
 # ---------------------------------------------------------------------------
 # Discover chain info and historical block
 # ---------------------------------------------------------------------------
-echo "Target RPC: $RPC_URL"
+echo "Target RPC:    $RPC_URL"
+echo "Trace RPC:     $TRACE_URL"
 echo "Test contract: $CONTRACT"
 echo ""
 
 echo "Fetching latest block..."
-LATEST_RESP=$(rpc_call "eth_blockNumber" "[]")
-LATEST_HEX=$(echo "$LATEST_RESP" | jq -r '.result')
-LATEST_DEC=$(printf "%d" "$LATEST_HEX")
+LATEST_RESP=$(rpc_call "$RPC_URL" "eth_blockNumber" "[]")
+LATEST_HEX=$(echo "$LATEST_RESP" | jq -r '.result // empty')
+if [ -z "$LATEST_HEX" ]; then
+    printf "ERROR: eth_blockNumber failed: %s\n" "$(error_of "$LATEST_RESP")"
+    exit 1
+fi
+LATEST_DEC=$((LATEST_HEX))
 echo "Latest block: $LATEST_HEX ($LATEST_DEC)"
 
 HIST_DEC=$((LATEST_DEC - BLOCK_OFFSET))
+if [ "$HIST_DEC" -lt 1 ]; then
+    # Young chain: fall back to the midpoint of its history.
+    HIST_DEC=$((LATEST_DEC / 2))
+    [ "$HIST_DEC" -lt 1 ] && HIST_DEC=1
+    echo "Chain is shorter than BLOCK_OFFSET=$BLOCK_OFFSET, using block $HIST_DEC instead"
+fi
 HIST_HEX=$(printf "0x%x" "$HIST_DEC")
-echo "Historical block (latest - $BLOCK_OFFSET): $HIST_HEX ($HIST_DEC)"
+echo "Historical block: $HIST_HEX ($HIST_DEC)"
 
 echo "Fetching historical block hash..."
-BLOCK_RESP=$(rpc_call "eth_getBlockByNumber" "[\"$HIST_HEX\", false]")
-HIST_HASH=$(echo "$BLOCK_RESP" | jq -r '.result.hash')
-if [ -z "$HIST_HASH" ] || [ "$HIST_HASH" = "null" ]; then
+BLOCK_RESP=$(rpc_call "$RPC_URL" "eth_getBlockByNumber" "[\"$HIST_HEX\", false]")
+HIST_HASH=$(echo "$BLOCK_RESP" | jq -r '.result.hash // empty')
+if [ -z "$HIST_HASH" ]; then
     echo "ERROR: Could not fetch block $HIST_HEX — is this an archive node?"
+    printf "    -> %s\n" "$(error_of "$BLOCK_RESP")"
     exit 1
 fi
 echo "Historical block hash: $HIST_HASH"
 
-# Simple call data used across tests: Multicall3.getBlockNumber() (no args)
-CALL_DATA="$GET_BLOCK_NUMBER_SIG"
-
 echo ""
 
 # ===================================================================
-# RPC_URL requirements (main RPC client)
+# Core indexing (RPC_URL)
 # ===================================================================
-if [ "$MODE" = "all" ] || [ "$MODE" = "main" ]; then
+if [ "$MODE" = "all" ] || [ "$MODE" = "core" ]; then
 
-section "Standard JSON-RPC (eth_*)"
+    section "Standard JSON-RPC (eth_*)"
 
-R=$(rpc_call "eth_blockNumber" "[]")
-check "eth_blockNumber" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_blockNumber" "[]")
+    check "eth_blockNumber" "$R"
 
-R=$(rpc_call "eth_gasPrice" "[]")
-check "eth_gasPrice" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_getBlockByNumber" "[\"latest\", false]")
+    check "eth_getBlockByNumber (latest)" "$R"
 
-R=$(rpc_call "eth_maxPriorityFeePerGas" "[]")
-check "eth_maxPriorityFeePerGas" "$R"
+    # get_gas_price() prefers eth_maxPriorityFeePerGas and falls back to eth_gasPrice,
+    # so either one satisfies FeePriceGetter. Both are optional for the indexer itself.
+    R=$(rpc_call "$RPC_URL" "eth_maxPriorityFeePerGas" "[]")
+    check_optional "eth_maxPriorityFeePerGas (EIP-1559 fee price)" "$R"
 
-# --- Historical block data ---
-section "Historical block data (archive node)"
+    R=$(rpc_call "$RPC_URL" "eth_gasPrice" "[]")
+    check_optional "eth_gasPrice (legacy fee price fallback)" "$R"
 
-R=$(rpc_call "eth_getBlockByNumber" "[\"$HIST_HEX\", false]")
-check "eth_getBlockByNumber (historical)" "$R"
+    section "Historical block data (archive node)"
 
-R=$(rpc_call "eth_getBalance" "[\"$CONTRACT\", \"$HIST_HEX\"]")
-check "eth_getBalance (historical)" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_getBlockByNumber" "[\"$HIST_HEX\", false]")
+    check "eth_getBlockByNumber (historical)" "$R"
 
-R=$(rpc_call "eth_getCode" "[\"$CONTRACT\", \"$HIST_HEX\"]")
-check "eth_getCode (historical)" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_getBalance" "[\"$CONTRACT\", \"$HIST_HEX\"]")
+    check "eth_getBalance (historical)" "$R"
 
-R=$(rpc_call "eth_getStorageAt" "[\"$CONTRACT\", \"0x0\", \"$HIST_HEX\"]")
-check "eth_getStorageAt (historical)" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_getCode" "[\"$CONTRACT\", \"$HIST_HEX\"]")
+    check "eth_getCode (historical)" "$R"
 
-# --- eth_call ---
-section "eth_call"
+    R=$(rpc_call "$RPC_URL" "eth_getStorageAt" "[\"$CONTRACT\", \"0x0\", \"$HIST_HEX\"]")
+    check "eth_getStorageAt (historical)" "$R"
 
-R=$(rpc_call "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"latest\"]")
-check "eth_call (latest)" "$R"
+    section "debug_storageRangeAt (full storage dumps)"
 
-R=$(rpc_call "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HEX\"]")
-check "eth_call (historical block number)" "$R"
+    R=$(rpc_call "$RPC_URL" "debug_storageRangeAt" \
+        "[\"$HIST_HASH\", 0, \"$CONTRACT\", \"$SLOT_ZERO\", $STORAGE_RANGE_LIMIT]")
+    check "debug_storageRangeAt ($STORAGE_RANGE_LIMIT entries, hist hash)" "$R"
 
-R=$(rpc_call "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\"]")
-check "eth_call (historical block hash)" "$R"
+    section "eth_call"
 
-# --- eth_call with state overrides ---
-section "eth_call with state overrides"
+    R=$(rpc_call "$RPC_URL" "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"latest\"]")
+    check "eth_call (latest)" "$R"
 
-# All override types in one call at historical block hash:
-# - stateDiff on existing contract (SlotDetector)
-# - code + state on fresh address (Euler Hooks DCI lens deployment)
-# - balance override (entrypoint tracer)
-R=$(rpc_call "eth_call" "[{\"to\":\"$LENS_ADDR\",\"data\":\"0x\"}, \"$HIST_HASH\", {\"$LENS_ADDR\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"state\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}},\"$CONTRACT\":{\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}]")
-check "eth_call + overrides: code/balance/state/stateDiff (hist hash)" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_call" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HEX\"]")
+    check "eth_call (historical block number)" "$R"
 
-# Same at historical block number (Euler Hooks DCI uses block number, not hash)
-R=$(rpc_call "eth_call" "[{\"to\":\"$LENS_ADDR\",\"data\":\"0x\"}, \"$HIST_HEX\", {\"$LENS_ADDR\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"state\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}},\"$CONTRACT\":{\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}]")
-check "eth_call + overrides: code/balance/state/stateDiff (hist num)" "$R"
+    section "eth_call with state overrides"
 
-# --- debug_storageRangeAt ---
-section "debug_storageRangeAt"
+    # All override types in one call, plus the 30M gas limit EthCallDetector uses:
+    # - code + state on a fresh address (token analyzer bytecode, Euler Hooks DCI lens)
+    # - balance override (entrypoint tracer)
+    # - stateDiff on an existing contract (slot detector)
+    OVERRIDES="{\"$LENS_ADDR\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xde0b6b3a7640000\",\"state\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}},\"$CONTRACT\":{\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}"
+    CALL_OBJ="{\"to\":\"$LENS_ADDR\",\"data\":\"0x\",\"gas\":\"$CALL_GAS_LIMIT\"}"
 
-R=$(rpc_call "debug_storageRangeAt" "[\"$HIST_HASH\", 0, \"$CONTRACT\", \"$SLOT_ZERO\", 10]")
-check "debug_storageRangeAt (historical block hash)" "$R"
+    R=$(rpc_call "$RPC_URL" "eth_call" "[$CALL_OBJ, \"latest\", $OVERRIDES]")
+    check "eth_call + overrides: code/balance/state/stateDiff (latest)" "$R"
 
-# --- trace_callMany ---
-section "trace_callMany"
+    R=$(rpc_call "$RPC_URL" "eth_call" "[$CALL_OBJ, \"$HIST_HEX\", $OVERRIDES]")
+    check "eth_call + overrides: code/balance/state/stateDiff (hist num)" "$R"
 
-R=$(rpc_call "trace_callMany" "[[[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"},[\"trace\"]]],\"latest\"]")
-check "trace_callMany (latest)" "$R"
+    section "JSON-RPC batching (indexer defaults: $MAX_BATCH_SIZE, $STORAGE_BATCH_SIZE for storage)"
 
-R=$(rpc_call "trace_callMany" "[[[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"},[\"trace\"]]],\"$HIST_HEX\"]")
-check "trace_callMany (historical)" "$R"
+    R=$(rpc_batch "$RPC_URL" "$(code_and_balance_batch "$MAX_BATCH_SIZE")")
+    check_batch "Batch x$MAX_BATCH_SIZE: eth_getCode + eth_getBalance" "$R" "$MAX_BATCH_SIZE"
 
-# --- JSON-RPC batching ---
-section "JSON-RPC batching"
+    R=$(rpc_batch "$RPC_URL" "$(storage_slot_batch "$STORAGE_BATCH_SIZE")")
+    check_batch "Batch x$STORAGE_BATCH_SIZE: eth_getStorageAt" "$R" "$STORAGE_BATCH_SIZE"
 
-BATCH_BODY='[
-  {"jsonrpc":"2.0","id":1,"method":"eth_getCode","params":["'"$CONTRACT"'","'"$HIST_HEX"'"]},
-  {"jsonrpc":"2.0","id":2,"method":"eth_getBalance","params":["'"$CONTRACT"'","'"$HIST_HEX"'"]}
-]'
-R=$(rpc_batch "$BATCH_BODY")
-check_batch "JSON-RPC batch (eth_getCode + eth_getBalance)" "$R" 2
-
-BATCH_BODY='[
-  {"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["'"$CONTRACT"'","0x0","'"$HIST_HEX"'"]},
-  {"jsonrpc":"2.0","id":2,"method":"eth_getStorageAt","params":["'"$CONTRACT"'","0x1","'"$HIST_HEX"'"]}
-]'
-R=$(rpc_batch "$BATCH_BODY")
-check_batch "JSON-RPC batch (eth_getStorageAt x2)" "$R" 2
-
-fi  # end main-only / all
+fi # end core-only / all
 
 # ===================================================================
-# TRACE_RPC_URL requirements (DCI tracer + service tracer)
-# Also used by RPC_URL for the service-side tracer and slot detector.
+# Dynamic Contract Indexing
 # ===================================================================
-if [ "$MODE" = "all" ] || [ "$MODE" = "trace" ]; then
+if [ "$MODE" = "all" ] || [ "$MODE" = "dci" ]; then
 
-section "eth_createAccessList"
+    # The Uniswap V4 hooks DCI builds its slot detectors on the main client, so
+    # these run against RPC_URL even when TRACE_RPC_URL points somewhere else.
+    section "DCI slot detectors — main RPC"
 
-R=$(rpc_call "eth_createAccessList" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\"]")
-check "eth_createAccessList (historical block hash)" "$R"
+    R=$(rpc_call "$RPC_URL" "debug_traceCall" \
+        "[$TRACE_TX, \"latest\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true}]")
+    check "debug_traceCall prestateTracer (latest)" "$R"
 
-R=$(rpc_call "eth_createAccessList" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\", {\"$CONTRACT\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}]")
-check "eth_createAccessList + overrides (historical)" "$R"
-
-section "debug_traceCall (prestateTracer)"
-
-R=$(rpc_call "debug_traceCall" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true}]")
-check "debug_traceCall prestateTracer (historical block hash)" "$R"
-
-R=$(rpc_call "debug_traceCall" "[{\"to\":\"$CONTRACT\",\"data\":\"$CALL_DATA\"}, \"$HIST_HASH\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true,\"stateOverrides\":{\"$CONTRACT\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xDE0B6B3A7640000\",\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}}]")
-check "debug_traceCall prestateTracer + overrides (historical)" "$R"
-
-section "Batched trace_and_access_list (eth_createAccessList + debug_traceCall)"
-
-BATCH_BODY='[
-  {"jsonrpc":"2.0","id":1,"method":"eth_createAccessList","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'"]},
-  {"jsonrpc":"2.0","id":2,"method":"debug_traceCall","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"tracer":"prestateTracer","enableReturnData":true}]}
+    BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"debug_traceCall","params":['"$TRACE_TX"',"latest",{"tracer":"prestateTracer","enableReturnData":true}]},
+  {"jsonrpc":"2.0","id":2,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"latest"]}
 ]'
-R=$(rpc_batch "$BATCH_BODY")
-check_batch "Batch: eth_createAccessList + debug_traceCall" "$R" 2
+    R=$(rpc_batch "$RPC_URL" "$BATCH_BODY")
+    check_batch "Batch: debug_traceCall + eth_call (slot detector trace)" "$R" 2
 
-section "Batched slot_detector_trace (debug_traceCall + eth_call)"
+    R=$(rpc_batch "$RPC_URL" "$(state_diff_call_batch "$MAX_BATCH_SIZE")")
+    check_batch "Batch x$MAX_BATCH_SIZE: eth_call + stateDiff (slot detector tests)" "$R" "$MAX_BATCH_SIZE"
 
-BATCH_BODY='[
-  {"jsonrpc":"2.0","id":1,"method":"debug_traceCall","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"tracer":"prestateTracer","enableReturnData":true}]},
-  {"jsonrpc":"2.0","id":2,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'"]}
+    section "DCI entrypoint tracer — trace RPC"
+
+    R=$(rpc_call "$TRACE_URL" "eth_createAccessList" \
+        "[$TRACE_TX, \"$HIST_HASH\"]")
+    check "eth_createAccessList (historical block hash)" "$R"
+
+    TRACE_OVERRIDES="{\"$CONTRACT\":{\"code\":\"$MINIMAL_BYTECODE\",\"balance\":\"0xde0b6b3a7640000\",\"stateDiff\":{\"$SLOT_ZERO\":\"$OVERRIDE_VAL\"}}}"
+
+    R=$(rpc_call "$TRACE_URL" "eth_createAccessList" \
+        "[$TRACE_TX, \"$HIST_HASH\", $TRACE_OVERRIDES]")
+    check "eth_createAccessList + overrides (historical)" "$R"
+
+    R=$(rpc_call "$TRACE_URL" "debug_traceCall" \
+        "[$TRACE_TX, \"$HIST_HASH\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true}]")
+    check "debug_traceCall prestateTracer (historical block hash)" "$R"
+
+    R=$(rpc_call "$TRACE_URL" "debug_traceCall" \
+        "[$TRACE_TX, \"$HIST_HASH\", {\"tracer\":\"prestateTracer\",\"enableReturnData\":true,\"stateOverrides\":$TRACE_OVERRIDES}]")
+    check "debug_traceCall prestateTracer + overrides (historical)" "$R"
+
+    BATCH_BODY='[
+  {"jsonrpc":"2.0","id":1,"method":"eth_createAccessList","params":['"$TRACE_TX"',"'"$HIST_HASH"'"]},
+  {"jsonrpc":"2.0","id":2,"method":"debug_traceCall","params":['"$TRACE_TX"',"'"$HIST_HASH"'",{"tracer":"prestateTracer","enableReturnData":true}]}
 ]'
-R=$(rpc_batch "$BATCH_BODY")
-check_batch "Batch: debug_traceCall + eth_call (slot detector)" "$R" 2
+    R=$(rpc_batch "$TRACE_URL" "$BATCH_BODY")
+    check_batch "Batch: createAccessList + traceCall (trace_and_access_list)" "$R" 2
 
-section "Batched slot_detector_tests (eth_call + stateDiff)"
-
-BATCH_BODY='[
-  {"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"'"$CONTRACT"'":{"stateDiff":{"'"$SLOT_ZERO"'":"'"$OVERRIDE_VAL"'"}}}]},
-  {"jsonrpc":"2.0","id":2,"method":"eth_call","params":[{"to":"'"$CONTRACT"'","data":"'"$CALL_DATA"'"},"'"$HIST_HASH"'",{"'"$CONTRACT"'":{"stateDiff":{"'"$SLOT_ZERO"'":"'"$OVERRIDE_VAL"'"}}}]}
-]'
-R=$(rpc_batch "$BATCH_BODY")
-check_batch "Batch: eth_call + stateDiff override (slot detector tests)" "$R" 2
-
-fi  # end trace-only / all
+fi # end dci-only / all
 
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
 echo "==========================================="
-printf "Results: \033[32m%d passed\033[0m, \033[31m%d failed\033[0m, \033[33m%d skipped\033[0m\n" "$PASS" "$FAIL" "$SKIP"
+printf "Results: \033[32m%d passed\033[0m, \033[31m%d failed\033[0m, \033[33m%d warnings\033[0m\n" \
+    "$PASS" "$FAIL" "$WARN"
 echo "==========================================="
 
 if [ "$FAIL" -gt 0 ]; then
     echo ""
-    echo "Some RPC methods are not supported. Review failures above."
+    echo "Required RPC capabilities are missing. Review failures above."
     exit 1
+fi
+
+if [ "$WARN" -gt 0 ]; then
+    echo ""
+    echo "All required capabilities present. Warnings are for methods the indexer does not depend on."
 fi


### PR DESCRIPTION
## Summary
- Adds `scripts/test-evm-rpc-capabilities.sh` — a chain-agnostic bash script that validates all JSON-RPC methods required by tycho-indexer
- Auto-discovers a historical block and uses Multicall3 (`0xcA11...CA11`) so it works on any EVM chain (Ethereum, Base, Arbitrum, Unichain, etc.)
- Tests both `RPC_URL` and `TRACE_RPC_URL` requirements including state overrides (`code`, `balance`, `state`, `stateDiff`), batching, debug/trace APIs
- Includes a requirements reference at the top of the file for quick lookup

### Usage
```bash
RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh              # test all
RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh --main-only   # RPC_URL only
RPC_URL=https://... ./scripts/test-evm-rpc-capabilities.sh --trace-only  # TRACE_RPC_URL only
```
## Example

```
Fetching latest block...
Latest block: 0x179364c (24720972)
Historical block (latest - 100000): 0x177afac (24620972)
Fetching historical block hash...
Historical block hash: 0xfb86f9e00fa343bcd70d8ba0b8951d796ea0fedd9ee7798d353f51e1216c1607


=== Standard JSON-RPC (eth_*) ===
  eth_blockNumber                                                   PASS
  eth_gasPrice                                                      PASS
  eth_maxPriorityFeePerGas                                          PASS

=== Historical block data (archive node) ===
  eth_getBlockByNumber (historical)                                 PASS
  eth_getBalance (historical)                                       PASS
  eth_getCode (historical)                                          PASS
  eth_getStorageAt (historical)                                     PASS

=== eth_call ===
  eth_call (latest)                                                 PASS
  eth_call (historical block number)                                PASS
  eth_call (historical block hash)                                  PASS

=== eth_call with state overrides ===
  eth_call + overrides: code/balance/state/stateDiff (hist hash)    PASS
  eth_call + overrides: code/balance/state/stateDiff (hist num)     PASS

=== debug_storageRangeAt ===
  debug_storageRangeAt (historical block hash)                      PASS

=== trace_callMany ===
  trace_callMany (latest)                                           PASS
  trace_callMany (historical)                                       PASS

=== JSON-RPC batching ===
  JSON-RPC batch (eth_getCode + eth_getBalance)                     PASS
  JSON-RPC batch (eth_getStorageAt x2)                              PASS

=== eth_createAccessList ===
  eth_createAccessList (historical block hash)                      PASS
  eth_createAccessList + overrides (historical)                     PASS

=== debug_traceCall (prestateTracer) ===
  debug_traceCall prestateTracer (historical block hash)            PASS
  debug_traceCall prestateTracer + overrides (historical)           PASS

=== Batched trace_and_access_list (eth_createAccessList + debug_traceCall) ===
  Batch: eth_createAccessList + debug_traceCall                     PASS

=== Batched slot_detector_trace (debug_traceCall + eth_call) ===
  Batch: debug_traceCall + eth_call (slot detector)                 PASS

=== Batched slot_detector_tests (eth_call + stateDiff) ===
  Batch: eth_call + stateDiff override (slot detector tests)        PASS

===========================================
Results: 24 passed, 0 failed, 0 skipped
===========================================
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)