### PR TITLE
feat: upgrade evm_version to osaka

### DIFF
--- a/crates/tycho-execution/contracts/foundry.toml
+++ b/crates/tycho-execution/contracts/foundry.toml
@@ -2,7 +2,7 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-evm_version = 'cancun'
+evm_version = 'osaka'
 optimizer = true
 optimizer_runs = 200
 via_ir = true
@@ -12,7 +12,7 @@ fs_permissions = [{ access = "read", path = "./test/assets" }, { access = "write
 src = 'src'
 out = 'out'
 libs = ['lib']
-evm_version = 'cancun'
+evm_version = 'osaka'
 optimizer = true
 optimizer_runs = 1000
 via_ir = true

--- a/crates/tycho-execution/contracts/test/protocols/EkuboV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/EkuboV3.t.sol
@@ -62,11 +62,6 @@ contract EkuboV3ExecutorTest is Constants, TestUtils {
 
     modifier setUpFork(uint256 blockNumber) {
         vm.createSelectFork(vm.rpcUrl("mainnet"), blockNumber);
-        // Forks always use the default hardfork https://github.com/foundry-rs/foundry/issues/13040
-        // vm.setEvmVersion not exposed in forge-std 1.9.5 — use low-level cheatcode call
-        address(vm)
-            .call(abi.encodeWithSignature("setEvmVersion(string)", "osaka"));
-
         _;
     }
 
@@ -200,11 +195,6 @@ contract TychoRouterForEkuboV3Test is TychoRouterTestSetup {
 
     function setUp() public virtual override {
         super.setUp();
-
-        // Forks always use the default hardfork (foundry-rs/foundry#13040).
-        // vm.setEvmVersion not exposed in forge-std 1.9.5 — use low-level cheatcode call
-        address(vm)
-            .call(abi.encodeWithSignature("setEvmVersion(string)", "osaka"));
 
         // Remove delegations
         vm.etch(ALICE, "");


### PR DESCRIPTION
Draft for now: CI installs Foundry from the `stable` [channel](https://github.com/foundry-rs/foundry/releases/tag/stable), which has not yet been updated to v1.7.0. This PR depends on v1.7.0 Osaka behavior, so CI can still fail on the current stable build.