### PR TITLE
feat: add exponential backoff with jitter to client retries

### DIFF
--- a/crates/tycho-client/CLAUDE.md
+++ b/crates/tycho-client/CLAUDE.md
@@ -7,6 +7,7 @@ Consumer library implementing the snapshot + deltas pattern for real-time protoc
 ```
 rpc.rs              HTTP snapshot client — fetches protocol state at a block height
 deltas.rs           WebSocket client — streams real-time state deltas
+retry.rs            RetryConfiguration — how the WS reconnect and sync retry loops space attempts
 stream.rs           Builder entry point — wires RPC + WS clients into a TychoStream
 feed/
   mod.rs            BlockSynchronizer — aligns N synchronizers by block, emits FeedMessage
@@ -39,6 +40,15 @@ TychoStreamBuilder (stream.rs)
    block, then promoted to `InFlight`.
 3. `BlockSynchronizer` waits for all synchronizers, then emits a `FeedMessage` per block
 4. Synchronizers classified as `Started | Ready | Delayed | Stale | Advanced | Ended`; stale ones are kept but skipped
+
+## Retries
+
+Both the WS reconnect loop (`deltas.rs`) and the sync retry loop (`synchronizer.rs`) are paced by a
+`RetryConfiguration` (`retry.rs`). The defaults are exponential with full jitter, capped at 60s:
+a failed sync run re-requests the entire snapshot, so retrying at a fixed rate — in lockstep with
+every other client dropped by the same event — is what turns a brief server outage into sustained
+load. Configure via `TychoStreamBuilder::websockets_retry_config` /
+`state_synchronizer_retry_config`.
 
 ## CLI
 

--- a/crates/tycho-client/Cargo.toml
+++ b/crates/tycho-client/Cargo.toml
@@ -33,6 +33,7 @@ chrono.workspace = true
 hex.workspace = true
 tracing-appender.workspace = true
 lru.workspace = true
+rand.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 reqwest = { version = "0.12.7", features = ["json", "zstd"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = [
@@ -47,8 +48,10 @@ zstd = "0.13"
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+# `test-util` enables tokio's paused clock, so retry-backoff tests assert on virtual time instead
+# of sleeping.
+tokio = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
-rand.workspace = true
 mockall.workspace = true
 mockito.workspace = true
 tracing-subscriber = "0.3.17"

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -47,7 +47,7 @@ use tokio::{
         oneshot, Mutex, MutexGuard, Notify,
     },
     task::JoinHandle,
-    time::sleep,
+    time::{sleep, Instant},
 };
 use tokio_tungstenite::{
     connect_async,
@@ -65,7 +65,28 @@ use tycho_common::{
 use uuid::Uuid;
 use zstd;
 
-use crate::{client_metadata::CLIENT_METADATA_HEADER, TYCHO_SERVER_VERSION};
+use crate::{
+    client_metadata::CLIENT_METADATA_HEADER, retry::RetryConfiguration, TYCHO_SERVER_VERSION,
+};
+
+/// Ceiling for a single reconnect delay, see `stream::MAX_RETRY_COOLDOWN`.
+const DEFAULT_MAX_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// A connection that stayed up at least this long counts as a success: the next drop starts the
+/// backoff from scratch. Without such a threshold, a server that accepts connections and
+/// immediately drops them (a crash loop) would reset the backoff on every attempt and be
+/// reconnected to at full rate.
+const STABLE_CONNECTION_THRESHOLD: Duration = Duration::from_secs(30);
+
+/// Number of consecutive failures to pace the next reconnect with, given how long the connection
+/// that just dropped had been up. Uses tokio's clock so tests can drive it without waiting.
+fn next_consecutive_failures(current: u64, connected_at: Instant) -> u64 {
+    if connected_at.elapsed() >= STABLE_CONNECTION_THRESHOLD {
+        0
+    } else {
+        current + 1
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum DeltasError {
@@ -176,10 +197,8 @@ pub struct WsDeltasClient {
     uri: Uri,
     /// Authorization key for the websocket connection.
     auth_key: Option<String>,
-    /// Maximum amount of reconnects to try before giving up.
-    max_reconnects: u64,
-    /// Duration to wait before attempting to reconnect
-    retry_cooldown: Duration,
+    /// How many reconnects to attempt before giving up, and how long to wait between them.
+    retry_config: RetryConfiguration,
     /// The client will buffer this many messages incoming from the websocket
     /// before starting to drop them.
     ws_buffer_size: usize,
@@ -443,7 +462,8 @@ fn build_ws_handshake_request(
 
 /// Tycho client websocket implementation.
 impl WsDeltasClient {
-    // Construct a new client with 5 reconnection attempts.
+    /// Constructs a new client with 5 reconnection attempts, backing off exponentially with
+    /// jitter from 500ms.
     pub fn new(ws_uri: &str, auth_key: Option<&str>) -> Result<Self, DeltasError> {
         let uri = ws_uri
             .parse::<Uri>()
@@ -455,19 +475,39 @@ impl WsDeltasClient {
             ws_buffer_size: 256,
             subscription_buffer_size: 256,
             conn_notify: Arc::new(Notify::new()),
-            max_reconnects: 5,
-            retry_cooldown: Duration::from_millis(500),
+            retry_config: RetryConfiguration::exponential(
+                5,
+                Duration::from_millis(500),
+                DEFAULT_MAX_RETRY_COOLDOWN,
+            ),
             dead: Arc::new(AtomicBool::new(false)),
             client_metadata_header: None,
         })
     }
 
-    // Construct a new client with a custom number of reconnection attempts.
+    /// Constructs a new client that waits a fixed `retry_cooldown` between reconnects.
+    ///
+    /// Prefer [`Self::new_with_retry_config`] with
+    /// [`RetryConfiguration::exponential`]: a fixed cooldown keeps every client of a fleet
+    /// reconnecting in lockstep for the whole duration of a server outage.
     pub fn new_with_reconnects(
         ws_uri: &str,
         auth_key: Option<&str>,
         max_reconnects: u64,
         retry_cooldown: Duration,
+    ) -> Result<Self, DeltasError> {
+        Self::new_with_retry_config(
+            ws_uri,
+            auth_key,
+            RetryConfiguration::constant(max_reconnects, retry_cooldown),
+        )
+    }
+
+    /// Constructs a new client with custom reconnect pacing.
+    pub fn new_with_retry_config(
+        ws_uri: &str,
+        auth_key: Option<&str>,
+        retry_config: RetryConfiguration,
     ) -> Result<Self, DeltasError> {
         let uri = ws_uri
             .parse::<Uri>()
@@ -480,8 +520,7 @@ impl WsDeltasClient {
             ws_buffer_size: 128,
             subscription_buffer_size: 128,
             conn_notify: Arc::new(Notify::new()),
-            max_reconnects,
-            retry_cooldown,
+            retry_config,
             dead: Arc::new(AtomicBool::new(false)),
             client_metadata_header: None,
         })
@@ -511,8 +550,7 @@ impl WsDeltasClient {
             ws_buffer_size,
             subscription_buffer_size,
             conn_notify: Arc::new(Notify::new()),
-            max_reconnects: 5,
-            retry_cooldown: Duration::from_millis(0),
+            retry_config: RetryConfiguration::constant(5, Duration::ZERO),
             dead: Arc::new(AtomicBool::new(false)),
             client_metadata_header: None,
         })
@@ -908,12 +946,19 @@ impl DeltasClient for WsDeltasClient {
         let this = self.clone();
         let jh = tokio::spawn(async move {
             let mut retry_count = 0;
+            // Counts only *consecutive* failures, so the backoff decays once the server is healthy
+            // again. `retry_count` keeps its lifetime-budget meaning against `max_attempts`.
+            let mut consecutive_failures = 0;
             let mut result = Err(DeltasError::NotConnected);
 
-            'retry: while retry_count < this.max_reconnects {
+            'retry: while retry_count < this.retry_config.max_attempts() {
                 info!(?ws_uri, retry_count, "Connecting to WebSocket server");
                 if retry_count > 0 {
-                    sleep(this.retry_cooldown).await;
+                    let cooldown = this
+                        .retry_config
+                        .delay(consecutive_failures);
+                    debug!(?cooldown, consecutive_failures, "Waiting before reconnecting");
+                    sleep(cooldown).await;
                 }
 
                 let request = build_ws_handshake_request(
@@ -927,6 +972,7 @@ impl DeltasClient for WsDeltasClient {
                     Err(e) => {
                         // Prepare for reconnection
                         retry_count += 1;
+                        consecutive_failures += 1;
                         let mut guard = this.inner.as_ref().lock().await;
                         *guard = None;
 
@@ -963,6 +1009,7 @@ impl DeltasClient for WsDeltasClient {
                 info!("Connection Successful: TychoWebsocketClient started");
                 this.conn_notify.notify_waiters();
                 result = Ok(());
+                let connected_at = Instant::now();
 
                 // If no WS frame arrives within this window the TCP connection is
                 // considered stalled (e.g. network cut without a TCP RST/FIN). The OS
@@ -977,6 +1024,8 @@ impl DeltasClient for WsDeltasClient {
                                     warn!("No WS frame received for {IDLE_TIMEOUT:?}, \
                                            treating connection as stalled; Reconnecting...");
                                     retry_count += 1;
+                                    consecutive_failures =
+                                        next_consecutive_failures(consecutive_failures, connected_at);
                                     let mut guard = this.inner.as_ref().lock().await;
                                     *guard = None;
                                     break; // break inner loop → reconnect
@@ -1001,12 +1050,15 @@ impl DeltasClient for WsDeltasClient {
                         ) {
                             // Prepare for reconnection
                             retry_count += 1;
+                            consecutive_failures =
+                                next_consecutive_failures(consecutive_failures, connected_at);
                             let mut guard = this.inner.as_ref().lock().await;
                             *guard = None;
 
                             warn!(
                                 ?error,
                                 ?retry_count,
+                                consecutive_failures,
                                 "Connection dropped unexpectedly; Reconnecting..."
                             );
                             break;
@@ -1021,7 +1073,7 @@ impl DeltasClient for WsDeltasClient {
             }
             debug!(
                 retry_count,
-                max_reconnects=?this.max_reconnects,
+                max_reconnects = this.retry_config.max_attempts(),
                 "Reconnection loop ended"
             );
             // Clean up before exiting
@@ -1029,7 +1081,7 @@ impl DeltasClient for WsDeltasClient {
             *guard = None;
 
             // Check if max retries has been reached.
-            if retry_count >= this.max_reconnects {
+            if retry_count >= this.retry_config.max_attempts() {
                 error!("Max reconnection attempts reached; Exiting");
                 this.dead.store(true, Ordering::SeqCst);
                 this.conn_notify.notify_waiters(); // Notify that the task is done
@@ -1708,6 +1760,52 @@ mod tests {
 
         // Should not take too long (max ~300ms for 3 attempts with some tolerance)
         assert!(elapsed < Duration::from_millis(500), "Took too long: {:?}", elapsed);
+    }
+
+    /// Runs on tokio's paused clock: the reconnect sleeps are auto-advanced, so the elapsed
+    /// virtual time is exactly the sum of the cooldowns the loop asked for, measured without
+    /// waiting for them.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn test_ws_client_exponential_backoff_grows_and_caps() {
+        let (addr, _) = mock_bad_connection_tycho_ws(false).await;
+        // 5 attempts means 4 cooldowns, bounded by 1s, 2s, 4s and 4s (capped).
+        let client = WsDeltasClient::new_with_retry_config(
+            &format!("ws://{addr}"),
+            None,
+            RetryConfiguration::exponential(5, Duration::from_secs(1), Duration::from_secs(4)),
+        )
+        .unwrap();
+
+        let start = Instant::now();
+        let connect_result = client.connect().await;
+        let elapsed = start.elapsed();
+
+        assert!(connect_result.is_err(), "Expected connection to fail after retries");
+        // Full jitter draws from [0, bound], so only the upper bound is deterministic. A constant
+        // 1s cooldown would take 4s; the growth is what pushes the ceiling to 11s.
+        assert!(
+            elapsed <= Duration::from_secs(11),
+            "cooldowns must stay within the configured bounds, waited {elapsed:?}"
+        );
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn test_stable_connection_resets_backoff() {
+        let connected_at = Instant::now();
+        tokio::time::advance(STABLE_CONNECTION_THRESHOLD).await;
+        assert_eq!(
+            next_consecutive_failures(7, connected_at),
+            0,
+            "a connection that stayed up must reset the backoff"
+        );
+
+        let connected_at = Instant::now();
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert_eq!(
+            next_consecutive_failures(7, connected_at),
+            8,
+            "a connection that dropped straight away must keep backing off"
+        );
     }
 
     #[test_log::test(tokio::test)]

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -33,6 +33,7 @@ use crate::{
         component_tracker::{ComponentFilter, ComponentTracker},
         BlockHeader, HeaderLike,
     },
+    retry::RetryConfiguration,
     rpc::{
         RPCClient, RPCError, SnapshotParameters, TracedEntryPointsPaginatedParams,
         RPC_CLIENT_CONCURRENCY,
@@ -119,8 +120,8 @@ pub struct ProtocolStateSynchronizer<R: RPCClient, D: DeltasClient> {
     retrieve_balances: bool,
     rpc_client: R,
     deltas_client: D,
-    max_retries: u64,
-    retry_cooldown: Duration,
+    /// How many times a failed sync run is restarted, and how long to wait in between.
+    retry_config: RetryConfiguration,
     include_snapshots: bool,
     component_tracker: ComponentTracker<R>,
     last_synced_block: Option<BlockHeader>,
@@ -404,7 +405,12 @@ where
     R: RPCClient + Clone + Send + Sync + 'static,
     D: DeltasClient + Clone + Send + Sync + 'static,
 {
-    /// Creates a new state synchronizer.
+    /// Creates a new state synchronizer that waits a fixed `retry_cooldown` between sync
+    /// attempts.
+    ///
+    /// Prefer [`Self::new_with_retry_config`] with [`RetryConfiguration::exponential`]: a failing
+    /// sync run re-requests the whole snapshot, so a fixed cooldown keeps that load on the server
+    /// at a constant rate for as long as the failure lasts.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         extractor_id: ExtractorIdentity,
@@ -412,6 +418,34 @@ where
         component_filter: ComponentFilter,
         max_retries: u64,
         retry_cooldown: Duration,
+        include_snapshots: bool,
+        include_tvl: bool,
+        compression: bool,
+        rpc_client: R,
+        deltas_client: D,
+        timeout: u64,
+    ) -> Self {
+        Self::new_with_retry_config(
+            extractor_id,
+            retrieve_balances,
+            component_filter,
+            RetryConfiguration::constant(max_retries, retry_cooldown),
+            include_snapshots,
+            include_tvl,
+            compression,
+            rpc_client,
+            deltas_client,
+            timeout,
+        )
+    }
+
+    /// Creates a new state synchronizer with custom retry pacing.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_retry_config(
+        extractor_id: ExtractorIdentity,
+        retrieve_balances: bool,
+        component_filter: ComponentFilter,
+        retry_config: RetryConfiguration,
         include_snapshots: bool,
         include_tvl: bool,
         compression: bool,
@@ -431,8 +465,7 @@ where
                 component_filter,
                 rpc_client,
             ),
-            max_retries,
-            retry_cooldown,
+            retry_config,
             last_synced_block: None,
             timeout,
             include_tvl,
@@ -1114,7 +1147,7 @@ where
             let mut current_end_rx = end_rx;
             let mut final_error = None;
 
-            while retry_count < self.max_retries {
+            while retry_count < self.retry_config.max_attempts() {
                 info!(extractor_id=%&self.extractor_id, retry_count, "(Re)starting synchronization loop");
 
                 let prev_block = self
@@ -1169,14 +1202,19 @@ where
                         }
                     }
                 }
-                sleep(self.retry_cooldown).await;
                 // A run that processed blocks is a healthy run — reset the counter so
-                // transient failures after a long successful period get a fresh retry budget.
+                // transient failures after a long successful period get a fresh retry budget, and
+                // so the backoff does not carry over into it.
                 if made_progress {
                     retry_count = 0;
                 } else {
                     retry_count += 1;
                 }
+                let cooldown = self
+                    .retry_config
+                    .delay(retry_count.saturating_sub(1));
+                debug!(extractor_id=%&self.extractor_id, ?cooldown, retry_count, "Waiting before restarting synchronization");
+                sleep(cooldown).await;
             }
             if let Some(e) = final_error {
                 warn!(extractor_id=%&self.extractor_id, retry_count, error=%e, "Max retries exceeded");
@@ -3136,6 +3174,79 @@ mod test {
         // The task should complete (not hang) after max retries
         let task_result = tokio::time::timeout(Duration::from_secs(2), jh).await;
         assert!(task_result.is_ok(), "Synchronizer task should complete after max retries");
+    }
+
+    /// Drives the retry loop against a deltas client that always fails, and returns how much
+    /// (virtual) time the loop spent sleeping between attempts. Runs on a paused clock, so the
+    /// cooldowns are auto-advanced rather than waited out.
+    async fn measure_retry_cooldowns(retry_config: RetryConfiguration) -> Duration {
+        let mut rpc_client = make_mock_client();
+        rpc_client
+            .expect_get_protocol_components()
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
+
+        let mut deltas_client = MockDeltasClient::new();
+        // A transport error is transient, so every attempt is retried until the budget is spent.
+        deltas_client
+            .expect_subscribe()
+            .returning(|_, _| Err(DeltasError::TransportError("server is down".to_string())));
+        deltas_client
+            .expect_unsubscribe()
+            .returning(|_| Ok(()));
+
+        let mut state_sync = ProtocolStateSynchronizer::new_with_retry_config(
+            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
+            true,
+            ComponentFilter::with_tvl_range(0.0, 1000.0),
+            retry_config,
+            true,
+            false,
+            true,
+            ArcRPCClient(Arc::new(rpc_client)),
+            ArcDeltasClient(Arc::new(deltas_client)),
+            1000_u64,
+        );
+        state_sync
+            .initialize()
+            .await
+            .expect("Init should succeed");
+
+        let start = tokio::time::Instant::now();
+        let (handle, mut rx) = state_sync.start().await;
+        let (jh, _close_tx) = handle.split();
+
+        let res = rx.recv().await.expect("channel open");
+        assert!(res.is_err(), "the synchronizer must report the error that exhausted its retries");
+        jh.await
+            .expect("synchronizer task should complete after max retries");
+
+        start.elapsed()
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn test_constant_retry_cooldown_is_flat() {
+        let elapsed =
+            measure_retry_cooldowns(RetryConfiguration::constant(4, Duration::from_secs(10))).await;
+
+        // 4 attempts, each followed by a fixed 10s cooldown.
+        assert_eq!(elapsed, Duration::from_secs(40));
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn test_exponential_retry_cooldown_stays_within_bounds() {
+        let elapsed = measure_retry_cooldowns(RetryConfiguration::exponential(
+            4,
+            Duration::from_secs(10),
+            Duration::from_secs(40),
+        ))
+        .await;
+
+        // Cooldowns are drawn from [0, 10s], [0, 20s], [0, 40s] and [0, 40s] — only the upper
+        // bound is deterministic under full jitter.
+        assert!(
+            elapsed <= Duration::from_secs(110),
+            "cooldowns must stay within the configured bounds, waited {elapsed:?}"
+        );
     }
 
     #[test_log::test(tokio::test)]

--- a/crates/tycho-client/src/lib.rs
+++ b/crates/tycho-client/src/lib.rs
@@ -29,6 +29,7 @@ pub mod cli;
 pub mod client_metadata;
 pub mod deltas;
 pub mod feed;
+pub mod retry;
 pub mod rpc;
 pub mod stream;
 
@@ -37,4 +38,5 @@ pub mod stream;
 extern crate pretty_assertions;
 
 pub use deltas::{DeltasError, WsDeltasClient};
+pub use retry::RetryConfiguration;
 pub use rpc::{HttpRPCClient, RPCError, SnapshotParameters};

--- a/crates/tycho-client/src/retry.rs
+++ b/crates/tycho-client/src/retry.rs
@@ -1,0 +1,196 @@
+//! Retry pacing shared by the websocket client and the state synchronizers.
+//!
+//! Both retry loops reconnect or re-bootstrap against the same server, so how they space their
+//! attempts decides how much load a server outage generates. A constant cooldown makes every
+//! client in a fleet retry in lockstep at a fixed rate for as long as the outage lasts: the
+//! attempts stay perfectly correlated (they were all dropped by the same event) and the rate never
+//! decays, so the server is hit hardest exactly while it is recovering.
+//!
+//! [`RetryConfiguration::exponential`] addresses both halves of that: the delay doubles per
+//! consecutive failure (decaying rate) and each delay is drawn uniformly from `[0, bound]`
+//! (decorrelation). Full jitter — rather than a fixed delay with a small random offset — is what
+//! spreads clients that failed at the same instant across the whole window.
+
+use std::time::Duration;
+
+use rand::Rng;
+
+/// How a retry loop spaces its attempts.
+///
+/// Non-exhaustive: new pacing strategies may be added, so match on it via the accessors rather
+/// than on its variants.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub enum RetryConfiguration {
+    Constant(ConstantRetryConfiguration),
+    Exponential(ExponentialRetryConfiguration),
+}
+
+impl RetryConfiguration {
+    /// A fixed delay between attempts.
+    ///
+    /// Prefer [`RetryConfiguration::exponential`]: a fixed delay keeps retries of all clients
+    /// correlated and does not decay while the server is down.
+    pub fn constant(max_attempts: u64, cooldown: Duration) -> Self {
+        RetryConfiguration::Constant(ConstantRetryConfiguration { max_attempts, cooldown })
+    }
+
+    /// Exponentially growing delay with full jitter.
+    ///
+    /// Attempt `n` (0-based) waits a uniformly random duration in
+    /// `[0, min(initial_cooldown * 2^n, max_cooldown)]`.
+    pub fn exponential(
+        max_attempts: u64,
+        initial_cooldown: Duration,
+        max_cooldown: Duration,
+    ) -> Self {
+        RetryConfiguration::Exponential(ExponentialRetryConfiguration {
+            max_attempts,
+            initial_cooldown,
+            max_cooldown,
+        })
+    }
+
+    /// How many attempts the loop makes before giving up.
+    pub fn max_attempts(&self) -> u64 {
+        match self {
+            RetryConfiguration::Constant(c) => c.max_attempts,
+            RetryConfiguration::Exponential(c) => c.max_attempts,
+        }
+    }
+
+    /// The delay used for the first retry, ignoring jitter and growth.
+    ///
+    /// Only meaningful for comparing two configurations against each other.
+    pub fn initial_cooldown(&self) -> Duration {
+        match self {
+            RetryConfiguration::Constant(c) => c.cooldown,
+            RetryConfiguration::Exponential(c) => c.initial_cooldown,
+        }
+    }
+
+    /// Returns the same pacing with a different attempt budget.
+    pub fn with_max_attempts(&self, max_attempts: u64) -> Self {
+        match self {
+            RetryConfiguration::Constant(c) => {
+                RetryConfiguration::constant(max_attempts, c.cooldown)
+            }
+            RetryConfiguration::Exponential(c) => {
+                RetryConfiguration::exponential(max_attempts, c.initial_cooldown, c.max_cooldown)
+            }
+        }
+    }
+
+    /// Upper bound of the delay before `attempt` (0-based, i.e. the delay after the first failure
+    /// is `attempt == 0`). Deterministic — the jitter is applied by [`Self::delay`].
+    pub fn delay_bound(&self, attempt: u64) -> Duration {
+        match self {
+            RetryConfiguration::Constant(c) => c.cooldown,
+            RetryConfiguration::Exponential(c) => {
+                // Clamping the exponent keeps `2^attempt` in range; any attempt beyond it is
+                // capped by `max_cooldown` regardless.
+                let factor = 2u32.saturating_pow(attempt.min(31) as u32);
+                c.initial_cooldown
+                    .checked_mul(factor)
+                    .unwrap_or(c.max_cooldown)
+                    .min(c.max_cooldown)
+            }
+        }
+    }
+
+    /// Delay to wait before `attempt` (0-based).
+    pub fn delay(&self, attempt: u64) -> Duration {
+        let bound = self.delay_bound(attempt);
+        match self {
+            RetryConfiguration::Constant(_) => bound,
+            RetryConfiguration::Exponential(_) => {
+                let bound_millis = bound.as_millis().min(u64::MAX as u128) as u64;
+                Duration::from_millis(rand::thread_rng().gen_range(0..=bound_millis))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConstantRetryConfiguration {
+    pub(crate) max_attempts: u64,
+    pub(crate) cooldown: Duration,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExponentialRetryConfiguration {
+    pub(crate) max_attempts: u64,
+    pub(crate) initial_cooldown: Duration,
+    pub(crate) max_cooldown: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_delay_does_not_grow() {
+        let config = RetryConfiguration::constant(5, Duration::from_secs(3));
+
+        assert_eq!(config.max_attempts(), 5);
+        for attempt in 0..10 {
+            assert_eq!(config.delay(attempt), Duration::from_secs(3));
+        }
+    }
+
+    #[test]
+    fn test_exponential_bound_doubles_then_caps() {
+        let config =
+            RetryConfiguration::exponential(32, Duration::from_secs(3), Duration::from_secs(60));
+
+        assert_eq!(config.delay_bound(0), Duration::from_secs(3));
+        assert_eq!(config.delay_bound(1), Duration::from_secs(6));
+        assert_eq!(config.delay_bound(2), Duration::from_secs(12));
+        assert_eq!(config.delay_bound(3), Duration::from_secs(24));
+        assert_eq!(config.delay_bound(4), Duration::from_secs(48));
+        // 96s would exceed the cap.
+        assert_eq!(config.delay_bound(5), Duration::from_secs(60));
+        // Far beyond the point where `2^attempt` would overflow.
+        assert_eq!(config.delay_bound(1_000), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_exponential_delay_is_jittered_within_bound() {
+        let config =
+            RetryConfiguration::exponential(32, Duration::from_secs(1), Duration::from_secs(60));
+
+        // Sampling the same attempt repeatedly must stay within the bound and must not always
+        // return the same value — that decorrelation is the point of the jitter.
+        let samples: Vec<_> = (0..100)
+            .map(|_| config.delay(4))
+            .collect();
+        let bound = config.delay_bound(4);
+        assert!(samples.iter().all(|d| *d <= bound), "jittered delay must not exceed the bound");
+        assert!(
+            samples.iter().any(|d| *d != samples[0]),
+            "100 samples all equal - jitter is not being applied"
+        );
+    }
+
+    #[test]
+    fn test_zero_cooldown_is_supported() {
+        let config = RetryConfiguration::exponential(3, Duration::ZERO, Duration::ZERO);
+
+        assert_eq!(config.delay(0), Duration::ZERO);
+        assert_eq!(config.delay(7), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_with_max_attempts_keeps_pacing() {
+        let exponential =
+            RetryConfiguration::exponential(32, Duration::from_secs(2), Duration::from_secs(60))
+                .with_max_attempts(8);
+        assert_eq!(exponential.max_attempts(), 8);
+        assert_eq!(exponential.delay_bound(3), Duration::from_secs(16));
+
+        let constant =
+            RetryConfiguration::constant(32, Duration::from_secs(2)).with_max_attempts(8);
+        assert_eq!(constant.max_attempts(), 8);
+        assert_eq!(constant.delay_bound(3), Duration::from_secs(2));
+    }
+}

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -16,6 +16,11 @@ use tycho_common::{
     },
 };
 
+// Re-exported from their own module for backwards compatibility: consumers import these from
+// `tycho_client::stream`.
+pub use crate::retry::{
+    ConstantRetryConfiguration, ExponentialRetryConfiguration, RetryConfiguration,
+};
 use crate::{
     client_metadata::serialize_client_metadata,
     deltas::DeltasClient,
@@ -27,6 +32,11 @@ use crate::{
     HttpRPCClient, WsDeltasClient,
 };
 
+/// Ceiling for a single retry delay. Long enough that a client waiting out a multi-minute outage
+/// stops contributing meaningful load, short enough that it recovers within a block or two of the
+/// server coming back.
+const MAX_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+
 #[derive(Error, Debug)]
 pub enum StreamError {
     #[error("Error during stream set up: {0}")]
@@ -37,24 +47,6 @@ pub enum StreamError {
 
     #[error("BlockSynchronizer error: {0}")]
     BlockSynchronizerError(String),
-}
-
-#[non_exhaustive]
-#[derive(Clone, Debug)]
-pub enum RetryConfiguration {
-    Constant(ConstantRetryConfiguration),
-}
-
-impl RetryConfiguration {
-    pub fn constant(max_attempts: u64, cooldown: Duration) -> Self {
-        RetryConfiguration::Constant(ConstantRetryConfiguration { max_attempts, cooldown })
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ConstantRetryConfiguration {
-    max_attempts: u64,
-    cooldown: Duration,
 }
 
 /// Loads and validates the custom-chain config once, before the stream starts. A missing or
@@ -105,13 +97,15 @@ impl TychoStreamBuilder {
             timeout,
             startup_timeout: Duration::from_secs(block_time * max_missed_blocks),
             max_missed_blocks,
-            state_sync_retry_config: RetryConfiguration::constant(
+            state_sync_retry_config: RetryConfiguration::exponential(
                 32,
                 Duration::from_secs(max(block_time / 4, 2)),
+                MAX_RETRY_COOLDOWN,
             ),
-            websockets_retry_config: RetryConfiguration::constant(
+            websockets_retry_config: RetryConfiguration::exponential(
                 128,
                 Duration::from_secs(max(block_time / 6, 1)),
+                MAX_RETRY_COOLDOWN,
             ),
             no_state: false,
             auth_key: None,
@@ -186,10 +180,12 @@ impl TychoStreamBuilder {
     }
 
     fn warn_on_potential_timing_issues(&self) {
-        let (RetryConfiguration::Constant(state_config), RetryConfiguration::Constant(ws_config)) =
-            (&self.state_sync_retry_config, &self.websockets_retry_config);
-
-        if ws_config.cooldown >= state_config.cooldown {
+        if self
+            .websockets_retry_config
+            .initial_cooldown() >=
+            self.state_sync_retry_config
+                .initial_cooldown()
+        {
             warn!(
                 "Websocket cooldown should be < than state syncronizer cooldown \
                 to avoid spending retries due to disconnected websocket."
@@ -271,12 +267,11 @@ impl TychoStreamBuilder {
     }
 
     /// Overrides the maximum number of retry attempts for state synchronizer startup.
-    /// The retry cooldown is derived from the chain's block time and is not affected.
+    /// The retry pacing is derived from the chain's block time and is not affected.
     pub fn max_retries(mut self, max_retries: u64) -> Self {
-        let cooldown = match &self.state_sync_retry_config {
-            RetryConfiguration::Constant(c) => c.cooldown,
-        };
-        self.state_sync_retry_config = RetryConfiguration::constant(max_retries, cooldown);
+        self.state_sync_retry_config = self
+            .state_sync_retry_config
+            .with_max_attempts(max_retries);
         self
     }
 
@@ -336,14 +331,11 @@ impl TychoStreamBuilder {
         };
 
         // Initialize the WebSocket client
-        let ws_client = match &self.websockets_retry_config {
-            RetryConfiguration::Constant(config) => WsDeltasClient::new_with_reconnects(
-                &tycho_ws_url,
-                auth_key.as_deref(),
-                config.max_attempts,
-                config.cooldown,
-            ),
-        }
+        let ws_client = WsDeltasClient::new_with_retry_config(
+            &tycho_ws_url,
+            auth_key.as_deref(),
+            self.websockets_retry_config.clone(),
+        )
         .map_err(|e| StreamError::SetUpError(e.to_string()))?
         .with_client_metadata_header(metadata_header.clone());
         let rpc_client = HttpRPCClient::new(
@@ -390,23 +382,20 @@ impl TychoStreamBuilder {
             info!("Registering exchange: {}", name);
             let id = ExtractorIdentity { chain: self.chain, name: name.clone() };
             let uses_dci = dci_protocols.contains(&name);
-            let sync = match &self.state_sync_retry_config {
-                RetryConfiguration::Constant(retry_config) => ProtocolStateSynchronizer::new(
-                    id.clone(),
-                    true,
-                    filter,
-                    retry_config.max_attempts,
-                    retry_config.cooldown,
-                    !self.no_state,
-                    self.include_tvl,
-                    self.compression,
-                    rpc_client.clone(),
-                    ws_client.clone(),
-                    self.block_time + self.timeout,
-                )
-                .with_dci(uses_dci)
-                .with_partial_blocks(self.partial_blocks),
-            };
+            let sync = ProtocolStateSynchronizer::new_with_retry_config(
+                id.clone(),
+                true,
+                filter,
+                self.state_sync_retry_config.clone(),
+                !self.no_state,
+                self.include_tvl,
+                self.compression,
+                rpc_client.clone(),
+                ws_client.clone(),
+                self.block_time + self.timeout,
+            )
+            .with_dci(uses_dci)
+            .with_partial_blocks(self.partial_blocks);
             block_sync = block_sync.register_synchronizer(id, sync);
         }
 
@@ -562,12 +551,45 @@ mod tests {
     #[test]
     fn test_retry_configuration_constant() {
         let config = RetryConfiguration::constant(5, Duration::from_secs(10));
-        match config {
-            RetryConfiguration::Constant(c) => {
-                assert_eq!(c.max_attempts, 5);
-                assert_eq!(c.cooldown, Duration::from_secs(10));
-            }
-        }
+        assert_eq!(config.max_attempts(), 5);
+        assert_eq!(config.delay(0), Duration::from_secs(10));
+        assert_eq!(config.delay(4), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_default_retry_configs_back_off() {
+        let builder = TychoStreamBuilder::new("localhost:4242", Chain::Ethereum);
+
+        // 12s blocks: the state synchronizer starts at 3s and the websocket at 2s, and both grow
+        // until they hit the shared ceiling.
+        let state = &builder.state_sync_retry_config;
+        assert_eq!(state.delay_bound(0), Duration::from_secs(3));
+        assert_eq!(state.delay_bound(1), Duration::from_secs(6));
+        assert_eq!(state.delay_bound(10), MAX_RETRY_COOLDOWN);
+
+        let ws = &builder.websockets_retry_config;
+        assert_eq!(ws.delay_bound(0), Duration::from_secs(2));
+        assert_eq!(ws.delay_bound(1), Duration::from_secs(4));
+        assert_eq!(ws.delay_bound(10), MAX_RETRY_COOLDOWN);
+    }
+
+    #[test]
+    fn test_max_retries_keeps_backoff() {
+        let builder = TychoStreamBuilder::new("localhost:4242", Chain::Ethereum).max_retries(4);
+
+        assert_eq!(
+            builder
+                .state_sync_retry_config
+                .max_attempts(),
+            4
+        );
+        assert_eq!(
+            builder
+                .state_sync_retry_config
+                .delay_bound(1),
+            Duration::from_secs(6),
+            "overriding the attempt budget must not fall back to a constant cooldown"
+        );
     }
 
     #[test]
@@ -581,14 +603,12 @@ mod tests {
             .state_synchronizer_retry_config(&state_config);
 
         // Verify configs are stored correctly by checking they match expected values
-        match (&builder.websockets_retry_config, &builder.state_sync_retry_config) {
-            (RetryConfiguration::Constant(ws), RetryConfiguration::Constant(state)) => {
-                assert_eq!(ws.max_attempts, 10);
-                assert_eq!(ws.cooldown, Duration::from_secs(2));
-                assert_eq!(state.max_attempts, 20);
-                assert_eq!(state.cooldown, Duration::from_secs(5));
-            }
-        }
+        let ws = &builder.websockets_retry_config;
+        let state = &builder.state_sync_retry_config;
+        assert_eq!(ws.max_attempts(), 10);
+        assert_eq!(ws.delay(0), Duration::from_secs(2));
+        assert_eq!(state.max_attempts(), 20);
+        assert_eq!(state.delay(0), Duration::from_secs(5));
     }
 
     #[test]


### PR DESCRIPTION
## What

Both retry loops in `tycho-client` waited a fixed cooldown between attempts:

- the WS reconnect loop — `max(block_time/6, 1)s`, so 2s on Ethereum (`deltas.rs`)
- the state synchronizer restart loop — `max(block_time/4, 2)s`, so 3s on Ethereum (`synchronizer.rs`)

A failed synchronizer run re-requests the whole snapshot (for a DCI protocol like `uniswap_v4_hooks`: ~260 traced-entrypoint requests, ~73 protocol-state pages and several contract-state pages of up to 275MiB). With a fixed cooldown, every client dropped by the same event — an auth-proxy restart, a server deploy — retries in lockstep at a constant rate for as long as the failure lasts, and the rate never decays.

## Changes

- `RetryConfiguration` moves from `stream.rs` into a new `retry.rs` and gains an `Exponential` variant. It is re-exported from `stream.rs`, so existing imports keep working.
- `RetryConfiguration::exponential(max_attempts, initial_cooldown, max_cooldown)`: the delay bound doubles per consecutive failure up to the cap, and each delay is drawn uniformly from `[0, bound]` (full jitter), which is what decorrelates clients that failed at the same instant.
- Both loops now take a `RetryConfiguration` instead of a `(max_attempts, cooldown)` pair, via `WsDeltasClient::new_with_retry_config` and `ProtocolStateSynchronizer::new_with_retry_config`.
- `TychoStreamBuilder` defaults to exponential with a 60s cap, keeping the existing per-chain initial cooldowns and attempt budgets. On Ethereum the synchronizer's delay bound goes 3s, 6s, 12s, 24s, 48s, 60s… instead of a flat 3s. Configure with the existing `websockets_retry_config` / `state_synchronizer_retry_config` setters; `max_retries` now keeps the pacing it overrides the budget of.
- Reset semantics: the synchronizer already resets its counter on a run that made progress, which now also resets the backoff. The WS client resets after a connection that stayed up for 30s, so a server that accepts connections and immediately drops them still backs off rather than reconnecting at full rate.
- `new_with_reconnects` and `ProtocolStateSynchronizer::new` keep their fixed-cooldown behaviour and are documented to prefer the new constructors.

## Tests

`cargo test -p tycho-client` (156 passed), `cargo clippy -p tycho-client --all-targets` clean, `tycho-simulation` and `tycho-integration-test` still compile.

- `retry.rs` unit tests cover the delay math: doubling, capping, the overflow-safe exponent, jitter staying within the bound and varying across samples, and zero cooldowns.
- `test_constant_retry_cooldown_is_flat` / `test_exponential_retry_cooldown_stays_within_bounds` drive the synchronizer's retry loop against an always-failing deltas client.
- `test_ws_client_exponential_backoff_grows_and_caps` drives the reconnect loop against a server that drops connections.
- These run on tokio's paused clock and assert on virtual time, so they measure the cooldowns without sleeping. `tokio`'s `test-util` feature was added as a dev-dependency for that. The pre-existing fixed-cooldown timing tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)