### PR TITLE
fix: scope contract snapshot queries to the returned page

### DIFF
--- a/crates/tycho-indexer/src/services/rpc.rs
+++ b/crates/tycho-indexer/src/services/rpc.rs
@@ -294,8 +294,7 @@ where
         // When addresses are given, the slice above already is the page, so the db must not
         // paginate again - its offset would be applied a second time and skip the whole page.
         // Without addresses the db owns pagination and also reports the total page count.
-        let db_pagination =
-            if paginated_addrs.is_some() { None } else { Some(&pagination_params) };
+        let db_pagination = if paginated_addrs.is_some() { None } else { Some(&pagination_params) };
 
         // Get the contract states from the database
         let account_data = self
@@ -1805,10 +1804,11 @@ mod tests {
             None,
         );
 
+        // The address and pagination arguments the gateway was called with.
+        type ObservedArgs = Option<(Option<Vec<Bytes>>, Option<PaginationParams>)>;
+
         let mut gw = MockGateway::new();
-        #[allow(clippy::type_complexity)]
-        let observed_args: Arc<Mutex<Option<(Option<Vec<Bytes>>, Option<PaginationParams>)>>> =
-            Arc::new(Mutex::new(None));
+        let observed_args: Arc<Mutex<ObservedArgs>> = Arc::new(Mutex::new(None));
         let args_writer = observed_args.clone();
         let response = expected.clone();
         gw.expect_get_contracts()

--- a/crates/tycho-indexer/src/services/rpc.rs
+++ b/crates/tycho-indexer/src/services/rpc.rs
@@ -291,6 +291,12 @@ where
             );
         }
 
+        // When addresses are given, the slice above already is the page, so the db must not
+        // paginate again - its offset would be applied a second time and skip the whole page.
+        // Without addresses the db owns pagination and also reports the total page count.
+        let db_pagination =
+            if paginated_addrs.is_some() { None } else { Some(&pagination_params) };
+
         // Get the contract states from the database
         let account_data = self
             .db_gateway
@@ -299,7 +305,7 @@ where
                 paginated_addrs.as_deref(),
                 Some(&db_version),
                 true,
-                Some(&pagination_params),
+                db_pagination,
             )
             .await
             .map_err(|err| {
@@ -1515,7 +1521,7 @@ pub async fn health() -> Result<HttpResponse, RpcError> {
 // reliably when it is placed on the macro invocation itself.
 #[allow(clippy::extra_unused_lifetimes)]
 mod tests {
-    use std::{collections::HashMap, env, str::FromStr};
+    use std::{collections::HashMap, env, str::FromStr, sync::Mutex};
 
     use actix_web::{test, App};
     use chrono::{NaiveDateTime, TimeDelta};
@@ -1776,6 +1782,74 @@ mod tests {
         assert_eq!(state.accounts.len(), 2);
         assert_eq!(state.accounts[0], expected.into());
         assert_eq!(state.accounts[1], buf_expected.into());
+        assert_eq!(state.pagination.total, 2);
+    }
+
+    /// The requested address list is sliced to the page before the db call, so the db must not
+    /// apply the offset a second time - doing so skipped every account on pages after the first.
+    #[tokio::test]
+    async fn test_get_contract_state_second_page() {
+        let first_page_addr = Bytes::from_str("6B175474E89094C44Da98b954EedeAC495271d0F").unwrap();
+        let second_page_addr = Bytes::from_str("388C818CA8B9251b393131C08a736A67ccB19297").unwrap();
+        let expected = Account::new(
+            Chain::Ethereum,
+            second_page_addr.clone(),
+            "account1".to_owned(),
+            evm_contract_slots([(0, 2)]),
+            Bytes::from(101u8).lpad(32, 0),
+            HashMap::new(),
+            Bytes::from("C1C1C1"),
+            Bytes::zero(32),
+            Bytes::zero(32),
+            Bytes::zero(32),
+            None,
+        );
+
+        let mut gw = MockGateway::new();
+        #[allow(clippy::type_complexity)]
+        let observed_args: Arc<Mutex<Option<(Option<Vec<Bytes>>, Option<PaginationParams>)>>> =
+            Arc::new(Mutex::new(None));
+        let args_writer = observed_args.clone();
+        let response = expected.clone();
+        gw.expect_get_contracts()
+            .return_once(move |_, addresses, _, _, pagination| {
+                *args_writer.lock().unwrap() =
+                    Some((addresses.map(|a| a.to_vec()), pagination.cloned()));
+                Box::pin(async move { Ok(WithTotal { entity: vec![response], total: Some(1) }) })
+            });
+
+        let req_handler = RpcHandler::new(
+            gw,
+            None,
+            MockEntryPointTracer::new(),
+            PlansConfig::default(),
+            vec![],
+            vec![],
+        );
+
+        let request = dto::StateRequestBody {
+            contract_ids: Some(vec![first_page_addr, second_page_addr.clone()]),
+            protocol_system: "uniswap_v2".to_string(),
+            version: dto::VersionParam { timestamp: Some(Utc::now().naive_utc()), block: None },
+            chain: dto::Chain::Ethereum,
+            pagination: dto::PaginationParams { page: 1, page_size: 1 },
+        };
+        let state = req_handler
+            .get_contract_state_inner(request)
+            .await
+            .unwrap();
+
+        let (addresses, pagination) = observed_args
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("get_contracts was not called");
+        assert_eq!(addresses, Some(vec![second_page_addr]));
+        assert_eq!(pagination, None);
+
+        assert_eq!(state.accounts.len(), 1);
+        assert_eq!(state.accounts[0], expected.into());
+        // Paging is over the requested address list, so the total is its length.
         assert_eq!(state.pagination.total, 2);
     }
 

--- a/crates/tycho-storage/src/postgres/contract.rs
+++ b/crates/tycho-storage/src/postgres/contract.rs
@@ -790,6 +790,17 @@ impl PostgresGateway {
         Ok(account)
     }
 
+    /// Retrieve contracts, optionally filtered by address and paginated.
+    ///
+    /// Pagination is applied to the accounts matching `ids` (or, if `ids` is None, to all accounts
+    /// that have code at `version`), ordered by their database id. Balances, code and slots are
+    /// only read for the accounts on the returned page. Callers must therefore pass the full
+    /// address list in `ids` and let this method cut the page - pre-slicing `ids` while also
+    /// passing `pagination_params` would apply the offset twice.
+    ///
+    /// The returned `total` is the number of accounts matching the filters at `version`, so the
+    /// caller can tell how many pages exist. Note that on the `ids` path an account that has no
+    /// code at `version` is counted but not returned.
     #[instrument(level = Level::DEBUG, skip(self, ids, conn))]
     pub async fn get_contracts(
         &self,
@@ -859,15 +870,21 @@ impl PostgresGateway {
                 .collect::<Vec<_>>()
         };
 
-        let mut all_balances = self
-            .get_account_balances(chain, ids, version, true, conn)
-            .await?;
-
-        // take all ids and query both code and storage
+        // Everything below must be restricted to the accounts on this page. Passing the request's
+        // `ids` here instead would read the whole chain's balances and slots on every page, since
+        // a full snapshot request has `ids = None`.
         let account_ids = accounts
             .iter()
             .map(|a| a.id)
             .collect::<HashSet<_>>();
+        let page_addresses = accounts
+            .iter()
+            .map(|a| a.address.clone())
+            .collect::<Vec<_>>();
+
+        let mut all_balances = self
+            .get_account_balances(chain, Some(&page_addresses), version, true, conn)
+            .await?;
 
         let codes = {
             use schema::contract_code::dsl::*;
@@ -921,7 +938,7 @@ impl PostgresGateway {
 
         let slots = if include_slots {
             Some(
-                self.get_contract_slots(chain, ids, version, conn)
+                self.get_contract_slots(chain, Some(&page_addresses), version, conn)
                     .await?,
             )
         } else {
@@ -2223,6 +2240,38 @@ mod test {
         assert!(result.entity.len() <= 1);
         assert_eq!(result.total, Some(exp_total));
         assert_eq!(result.entity, exp);
+    }
+
+    /// Walks all pages of a full snapshot request. Each page must carry the balances and slots of
+    /// its own accounts only, and the total must stay the number of matching accounts.
+    #[tokio::test]
+    async fn test_get_contracts_pages_cover_all_accounts() {
+        let mut conn = setup_db().await;
+        setup_data(&mut conn).await;
+        let gw = EVMGateway::from_connection(&mut conn).await;
+
+        let mut pages = Vec::new();
+        for page in 0..3 {
+            let result = gw
+                .get_contracts(
+                    &Chain::Ethereum,
+                    None,
+                    None,
+                    true,
+                    Some(&PaginationParams { page, page_size: 1 }),
+                    &mut conn,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.total, Some(2));
+            pages.push(result.entity);
+        }
+
+        // c2 is deleted at the latest version, so only c0 and c1 are returned.
+        assert_eq!(pages[0], vec![account_c0(2)]);
+        assert_eq!(pages[1], vec![account_c1(2)]);
+        assert_eq!(pages[2], Vec::<Account>::new());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What this changes

`get_contracts` applies LIMIT/OFFSET to the `account` query, but then passed the request's original `ids` to `get_account_balances` and `get_contract_slots`. When `ids` is `None` — which is what a full snapshot request sends — both of those read the entire chain's balances and slots on every page. They now receive the addresses of the accounts on the returned page, so the work per page is proportional to the page.

For a 1200-account page against 10.5M live storage slots, the slots query went from reading the whole `contract_storage` set to reading only the page's accounts. The `codes` query in between already used the paginated account ids.

Second change, in the RPC layer: `get_contract_state_inner` slices `contract_ids` to the requested page before calling the gateway, and also passed the real `pagination_params` to it. The database then applied the offset a second time to a list that was already at most one page long, so any request with explicit `contract_ids` and `page > 0` came back with no accounts from the database. It now passes `None` when it has already sliced the list; the response `total` is unaffected because for the ids path it is the length of the requested address list.

`tycho-client` was never affected by that second bug: `get_contract_state_paginated` chunks ids client-side and always sends `page = 0`. Callers using the HTTP API directly with `contract_ids` plus paging were.

## Semantics of `total`

- No `contract_ids`: the count of accounts that have code at the requested version, from the count query.
- With `contract_ids`: the number of requested addresses, set by the RPC layer.

The gateway docstring now states that callers must pass the full address list and let the gateway cut the page, since the two cannot be combined.

## Tests

- `test_get_contract_state_second_page` (tycho-indexer, mock gateway, no database needed) asserts the gateway receives the page's address and no pagination params. It fails on the previous code with `Some(PaginationParams { page: 1, page_size: 1 })` instead of `None`.
- `test_get_contracts_pages_cover_all_accounts` (tycho-storage) walks all pages of a full snapshot request and checks each page returns its own accounts and a stable total. Page > 0 had no coverage before.

Verified: `cargo clippy -p tycho-storage --lib` and `cargo clippy -p tycho-indexer --lib --tests` are clean; 339 tycho-indexer lib tests pass. The tycho-storage tests and 8 tycho-indexer tests could not run in my environment (no Postgres, and a substreams spkg fixture that needs git-lfs), so the new storage test has not been executed against a database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)