### PR TITLE
refactor: read current contract slots from live partition

### DIFF
--- a/crates/tycho-storage/src/postgres/contract.rs
+++ b/crates/tycho-storage/src/postgres/contract.rs
@@ -18,7 +18,7 @@ use tycho_common::{
         AccountToContractStoreDeltas, Address, Balance, Chain, ChangeType, Code, ContractId,
         ContractStoreDeltas, PaginationParams, StoreKey, StoreVal, TxHash,
     },
-    storage::{BlockOrTimestamp, StorageError, Version, WithTotal},
+    storage::{BlockIdentifier, BlockOrTimestamp, StorageError, Version, VersionKind, WithTotal},
     Bytes,
 };
 
@@ -622,6 +622,32 @@ impl PostgresGateway {
     /// might change to use VersionResult, but for now we keep it simple. Using
     /// anything else then Version::Last is currently not supported.
     ///
+    /// Requests that are not pinned to a specific block can be served from the current state.
+    ///
+    /// Returns the version to read at, or `None` if the request asks for whatever is newest. Only
+    /// `None` (meaning "now") and [BlockIdentifier::Latest] qualify. A request that names a block
+    /// by number or hash stays pinned even when that block happens to be the chain head, because
+    /// the head may move on between resolving the version and running the query - such a request
+    /// must keep reading the historical partitions.
+    ///
+    /// Note [BlockIdentifier::Latest] cannot be built from a client's version parameter (see
+    /// `BlockOrTimestamp::TryFrom<&dto::VersionParam>`); the RPC layer produces it in
+    /// `calculate_versions` when it downgrades an uncommitted or unseen version to "latest
+    /// committed" and applies the pending deltas buffer on top.
+    fn pinned_version(at: Option<&Version>) -> Option<&Version> {
+        let Some(version) = at else {
+            // No version means "now", which is always newer than the chain head.
+            return None;
+        };
+        if matches!(
+            version,
+            Version(BlockOrTimestamp::Block(BlockIdentifier::Latest(_)), VersionKind::Last)
+        ) {
+            return None;
+        }
+        Some(version)
+    }
+
     /// # Parameters
     /// - `chain` The chain for which to retrieve slots for.
     /// - `contracts` Optionally allows filtering by contract address.
@@ -635,35 +661,68 @@ impl PostgresGateway {
         at: Option<&Version>,
         conn: &mut AsyncPgConnection,
     ) -> Result<HashMap<Address, ContractStoreDeltas>, StorageError> {
-        let version_ts = match &at {
-            Some(version) => maybe_lookup_version_ts(version, conn).await?,
-            None => Utc::now().naive_utc(),
-        };
+        let chain_id = self.get_chain_id(chain)?;
 
-        let slots = {
-            use schema::{account, contract_storage::dsl::*};
+        let slots = match Self::pinned_version(at) {
+            None => {
+                // The current state lives entirely in the default partition, which holds exactly
+                // one row per (account_id, slot) - enforced by
+                // contract_storage_default_unique_pk. Reading it directly avoids both the Append
+                // over every historical partition and the DISTINCT ON sort below, which spills to
+                // disk once a page covers more slots than work_mem can hold.
+                use schema::{account, contract_storage_default::dsl::*};
 
-            let chain_id = self.get_chain_id(chain)?;
-            let mut q = contract_storage
-                .inner_join(account::table)
-                .filter(account::chain_id.eq(chain_id))
-                .filter(
-                    valid_from
-                        .le(version_ts)
-                        .and(valid_to.gt(version_ts)),
-                )
-                .order_by((account::id, slot, valid_from.desc(), ordinal.desc()))
-                .select((account::id, slot, value))
-                .distinct_on((account::id, slot))
-                .into_boxed();
-            if let Some(addresses) = contracts {
-                #[allow(clippy::mutable_key_type)]
-                let filter_val: HashSet<_> = addresses.iter().collect();
-                q = q.filter(account::address.eq_any(filter_val));
+                // Live rows carry valid_to = MAX_TS. The predicate is still needed because an
+                // archived row whose valid_to has no matching partition also lands here (see
+                // docs/for-solvers/self-hosted-evm-chain.md), as do rows whose account was
+                // deleted by `delete_contract`.
+                //
+                // There is deliberately no valid_from predicate: if a block commits between the
+                // version being resolved and this query running, filtering on valid_from would
+                // drop every slot that block touched, since the superseded row has already moved
+                // out of this partition. Without it the query returns the newer value instead,
+                // which is a valid answer for a request that asked for "latest".
+                // TODO: confirm this is the tradeoff we want before removing the scaffold label.
+                let mut q = contract_storage_default
+                    .inner_join(account::table)
+                    .filter(account::chain_id.eq(chain_id))
+                    .filter(valid_to.gt(*MAX_VERSION_TS))
+                    .select((account::id, slot, value))
+                    .into_boxed();
+                if let Some(addresses) = contracts {
+                    #[allow(clippy::mutable_key_type)]
+                    let filter_val: HashSet<_> = addresses.iter().collect();
+                    q = q.filter(account::address.eq_any(filter_val));
+                }
+                q.get_results::<(i64, Bytes, Option<Bytes>)>(conn)
+                    .await
+                    .map_err(PostgresError::from)?
             }
-            q.get_results::<(i64, Bytes, Option<Bytes>)>(conn)
-                .await
-                .map_err(PostgresError::from)?
+            Some(version) => {
+                use schema::{account, contract_storage::dsl::*};
+
+                let version_ts = maybe_lookup_version_ts(version, conn).await?;
+                let mut q = contract_storage
+                    .inner_join(account::table)
+                    .filter(account::chain_id.eq(chain_id))
+                    .filter(
+                        valid_from
+                            .le(version_ts)
+                            .and(valid_to.gt(version_ts)),
+                    )
+                    .order_by((account::id, slot, valid_from.desc(), ordinal.desc()))
+                    .select((account::id, slot, value))
+                    .distinct_on((account::id, slot))
+                    .into_boxed();
+                if let Some(addresses) = contracts {
+                    #[allow(clippy::mutable_key_type)]
+                    let filter_val: HashSet<_> = addresses.iter().collect();
+                    q = q.filter(account::address.eq_any(filter_val));
+                }
+                q.get_results::<(i64, Bytes, Option<Bytes>)>(conn)
+                    .await
+                    .map_err(PostgresError::from)?
+            }
         };
         let accounts = orm::Account::get_addresses_by_id(slots.iter().map(|(cid, _, _)| cid), conn)
             .await
@@ -2512,6 +2571,45 @@ mod test {
             .unwrap();
 
         assert_eq!(res, exp);
+    }
+
+    /// The default-partition read must agree with the versioned read at the chain head, both for a
+    /// full snapshot and for a filtered request.
+    #[rstest]
+    #[case::all_contracts(None)]
+    #[case::single_contract(Some(vec![Bytes::from("6B175474E89094C44Da98b954EedeAC495271d0F")]))]
+    #[tokio::test]
+    async fn test_get_slots_latest_matches_head_block(#[case] addresses: Option<Vec<Address>>) {
+        let mut conn = setup_db().await;
+        setup_data(&mut conn).await;
+        let gw = EVMGateway::from_connection(&mut conn).await;
+        let addresses: Option<&[Address]> = addresses.as_deref();
+
+        let latest = gw
+            .get_contract_slots(&Chain::Ethereum, addresses, None, &mut conn)
+            .await
+            .unwrap();
+        let head_block = Version(
+            BlockOrTimestamp::Block(BlockIdentifier::Latest(Chain::Ethereum)),
+            VersionKind::Last,
+        );
+        let at_head = gw
+            .get_contract_slots(&Chain::Ethereum, addresses, Some(&head_block), &mut conn)
+            .await
+            .unwrap();
+        // Block 3 is the chain head in the fixture and carries no changes of its own.
+        let pinned_head = gw
+            .get_contract_slots(
+                &Chain::Ethereum,
+                addresses,
+                Some(&Version::from_block_number(Chain::Ethereum, 3)),
+                &mut conn,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(latest, pinned_head);
+        assert_eq!(at_head, pinned_head);
     }
 
     #[tokio::test]

--- a/crates/tycho-storage/src/postgres/contract.rs
+++ b/crates/tycho-storage/src/postgres/contract.rs
@@ -614,14 +614,6 @@ impl PostgresGateway {
         Ok(())
     }
 
-    /// Retrieve contract slots.
-    ///
-    /// Retrieve the storage slots of contracts at a given time/version.
-    ///
-    /// Will return the slots state after the given block/timestamp. Later we
-    /// might change to use VersionResult, but for now we keep it simple. Using
-    /// anything else then Version::Last is currently not supported.
-    ///
     /// Requests that are not pinned to a specific block can be served from the current state.
     ///
     /// Returns the version to read at, or `None` if the request asks for whatever is newest. Only
@@ -648,6 +640,14 @@ impl PostgresGateway {
         Some(version)
     }
 
+    /// Retrieve contract slots.
+    ///
+    /// Retrieve the storage slots of contracts at a given time/version.
+    ///
+    /// Will return the slots state after the given block/timestamp. Later we
+    /// might change to use VersionResult, but for now we keep it simple. Using
+    /// anything else then Version::Last is currently not supported.
+    ///
     /// # Parameters
     /// - `chain` The chain for which to retrieve slots for.
     /// - `contracts` Optionally allows filtering by contract address.


### PR DESCRIPTION
**Scaffold for discussion, not ready to merge.** The query and the plumbing compile and are covered by an equivalence test, but the concurrency semantics called out below need a decision first.

## What this changes

`get_contract_slots` reads the partitioned parent `contract_storage` with `valid_from <= ts AND valid_to > ts`, then deduplicates with `DISTINCT ON (account.id, slot) ORDER BY (account.id, slot, valid_from DESC, ordinal DESC)`. That forces an Append across every partition whose range overlaps the predicate plus a global sort, which spills to disk with `work_mem` at 4MB once a page covers a large slot set.

Rows for the current state are exactly the rows with `valid_to = MAX_TS`, and they all live in `contract_storage_default`, which has a unique constraint on `(account_id, slot)` (`contract_storage_default_unique_pk`). So for a request that is not pinned to a block there is one candidate row per slot in one partition: no Append, no sort, no `DISTINCT ON`.

The decision is made by a new `pinned_version` helper, which maps a version to `None` when the request asks for whatever is newest:

- `at = None` (used by the extractor) means "now".
- `Version(BlockOrTimestamp::Block(BlockIdentifier::Latest(_)), VersionKind::Last)`.

Everything else — a block by number or hash, or a timestamp — stays on the existing versioned query.

## Why this is safe for a committed but older block

`BlockIdentifier::Latest` cannot come from a client. `BlockOrTimestamp::TryFrom<&dto::VersionParam>` only produces `Hash` or `Number`, so `Latest` exists only where the RPC layer creates it in `calculate_versions`: for `CommitStatus::Uncommitted`, and for `Unseen` with a timestamp request. In both of those the version has been deliberately downgraded to "latest committed" and the pending deltas buffer is applied on top afterwards.

A request that resolves to `CommitStatus::Committed` keeps the client's own version. If that names a block by number or hash, `pinned_version` returns it and the fast path is not used, even when that block happens to be the current head. That is the case right after a batch commit: the head moved on, the client's block is now older, and the query must still read the historical partitions to answer for it. The fast path is unreachable there by construction rather than by a timestamp comparison, which is why no head-timestamp lookup is needed.

The cost of being conservative: a client that explicitly asks for the head block by number does not get the fast path. The common full snapshot request does, because `VersionParam::default()` is a timestamp of "now", which resolves to `Unseen` and therefore to `Latest`.

## Open question: a commit landing mid-request

The fast path deliberately has no `valid_from` predicate. If a block commits between the version being resolved and the query running, a `valid_from <= ts` filter would drop every slot that block touched — the superseded row has already moved out of the default partition, and the replacement has a newer `valid_from`. A missing slot is worse for a consumer than a slightly newer one, so the query returns the newer value instead.

That means a fast-path result can be one block ahead of the accounts and code rows in the same `get_contracts` call. Note the versioned path already has skew of its own: `get_contracts`, `get_account_balances` and `get_contract_slots` each resolve `Latest` independently, with no enclosing transaction. Worth deciding whether to accept the skew, wrap the reads in a repeatable-read transaction, or resolve the version once and pass the timestamp down.

The `valid_to > MAX_VERSION_TS` predicate is kept rather than dropped: the default partition is not guaranteed to hold only live rows. An archived row whose `valid_to` has no matching partition lands there (documented in `docs/for-solvers/self-hosted-evm-chain.md`), and `delete_contract` updates `valid_to` on rows that may currently sit in it.

## Not changed

`get_slots_delta` does not qualify. It selects rows by `valid_from` range with no `valid_to` predicate, and a slot changed inside the window and again after it has its in-window row archived, so restricting to the default partition would silently drop it.

## Tests

`test_get_slots_latest_matches_head_block` asserts the three ways of asking for the head — `None`, `BlockIdentifier::Latest`, and the head block by number — return identical slots, for a full read and a filtered one. It needs a database and has not been run in my environment (no Postgres available); `cargo check -p tycho-storage --tests` and `cargo clippy -p tycho-storage --lib` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)