### PR TITLE
feat(indexer): EntityCache skeleton for the entity store (story 2)

### DIFF
--- a/crates/tycho-indexer/src/services/state/cache.rs
+++ b/crates/tycho-indexer/src/services/state/cache.rs
@@ -2,11 +2,15 @@
 //!
 //! Two entity families are cached:
 //!
-//! - **Accounts** (contract state), keyed by address. Several extractors can write the same account
-//!   at different block heights, so every cached value carries the block that last wrote it: a
-//!   newer block always wins, the same block twice is a no-op.
+//! - **Accounts** (contract state), keyed by address. Several extractors can write the same
+//!   account, so every cached value carries the time it was last written — the writing block's
+//!   timestamp, the same unit the database's `valid_from` versioning uses. A newer write always
+//!   wins; re-applying an equal-time change is a no-op because delta values are absolute.
 //! - **Component states** (protocol state), keyed by `(protocol system, component id)`. Exactly one
-//!   extractor writes each protocol system, in block order, so one height per entry is enough.
+//!   extractor writes each protocol system, in order, so one write time per entry is enough.
+//!
+//! Tags compare with "not older" (>=), never "strictly newer": consecutive blocks can share a
+//! timestamp on fast chains, and a strict comparison would silently drop the second block.
 //!
 //! The cache is written from exactly two places: the startup load, which runs before the
 //! extractors start, and the folds coming out of the block windows. It never reads the database,
@@ -24,6 +28,7 @@ use std::{
     sync::{RwLock, RwLockReadGuard},
 };
 
+use chrono::NaiveDateTime;
 use tycho_common::{
     models::{
         blockchain::BlockAggregatedChanges,
@@ -37,14 +42,14 @@ use tycho_common::{
 
 use super::window::FoldSink;
 
-/// A cached value together with the block number that last wrote it.
-type Tagged<T> = (T, u64);
+/// A cached value together with the time it was last written (the writing block's timestamp).
+type Tagged<T> = (T, NaiveDateTime);
 
 /// Cached state of one contract account.
 ///
-/// Every value carries the block that last wrote it, so writes from different extractors (which
-/// run at different block heights) can never regress a value: newer block wins, same block is a
-/// no-op.
+/// Every value carries the time it was last written, so writes from different extractors (which
+/// run at different points of the chain) can never regress a value: newer wins, equal-time
+/// re-application is a no-op.
 pub(crate) struct CachedAccount {
     chain: Chain,
     title: String,
@@ -61,24 +66,23 @@ pub(crate) struct CachedAccount {
 }
 
 impl CachedAccount {
-    /// Builds an entry from the startup snapshot. Every value arrives with the block **number**
-    /// that wrote it, which becomes its tag. (The rows version by timestamp, so the loader
-    /// recovers the block through each row's `modify_tx` — see the plan's snapshot-read task.)
+    /// Builds an entry from the startup snapshot. Each value's tag is its row's `valid_from`
+    /// timestamp, taken as-is — the cache versions by time exactly like the database does.
     #[allow(unused_variables)]
-    fn from_snapshot(filled: &Account, value_blocks: &HashMap<StoreKey, u64>) -> Self {
+    fn from_snapshot(filled: &Account, value_times: &HashMap<StoreKey, NaiveDateTime>) -> Self {
         todo!("build entry from snapshot")
     }
 
-    /// Builds an entry from a `Creation` delta folded at `block` — after startup, the only way a
-    /// new contract enters the cache. Creation deltas carry the whole initial tracked state.
+    /// Builds an entry from a `Creation` delta folded at time `at` — after startup, the only way
+    /// a new contract enters the cache. Creation deltas carry the whole initial tracked state.
     #[allow(unused_variables)]
-    fn from_creation(delta: &AccountDelta, block: u64) -> Self {
+    fn from_creation(delta: &AccountDelta, at: NaiveDateTime) -> Self {
         todo!("build entry from creation delta")
     }
 
-    /// Applies one folded delta; every changed value gets `block` as its tag.
+    /// Applies one folded delta; every changed value gets the block's timestamp as its tag.
     #[allow(unused_variables)]
-    fn fold(&mut self, delta: &AccountDelta, block: u64) {
+    fn fold(&mut self, delta: &AccountDelta, at: NaiveDateTime) {
         // Deleted slots become the zero value (as in `Account::apply_delta`). A delta that
         // carries code also refreshes `code_hash` — `Account::apply_delta` does not maintain
         // that field, so don't reuse it blindly.
@@ -96,29 +100,29 @@ impl CachedAccount {
 pub(crate) struct CachedComponentState {
     attributes: HashMap<AttrStoreKey, StoreVal>,
     balances: HashMap<Address, Balance>,
-    /// One height covers the whole entry: a single extractor writes each protocol system, in
-    /// block order.
-    height: u64,
+    /// One write time covers the whole entry: a single extractor writes each protocol system,
+    /// in order.
+    updated_at: NaiveDateTime,
 }
 
 impl CachedComponentState {
-    /// Builds an entry from the startup snapshot at the given height.
+    /// Builds an entry from the startup snapshot, tagged with its newest `valid_from`.
     #[allow(unused_variables)]
-    fn from_snapshot(state: &ProtocolComponentState, height: u64) -> Self {
+    fn from_snapshot(state: &ProtocolComponentState, at: NaiveDateTime) -> Self {
         todo!("build entry from snapshot")
     }
 
-    /// Applies one folded state delta for `block` when it is newer than the entry.
+    /// Applies one folded state delta when it is not older than the entry.
     #[allow(unused_variables)]
-    fn fold(&mut self, delta: &ProtocolComponentStateDelta, block: u64) {
-        // Skip when `block <= self.height` (replayed block). Deleted attributes are plain key
+    fn fold(&mut self, delta: &ProtocolComponentStateDelta, at: NaiveDateTime) {
+        // Skip when `at < self.updated_at` (replayed block). Deleted attributes are plain key
         // removals. Out-of-order folds from the single writer are a bug — debug-assert.
         todo!("apply folded state delta")
     }
 
-    /// Applies folded balance changes for `block`.
+    /// Applies folded balance changes.
     #[allow(unused_variables)]
-    fn fold_balances(&mut self, balances: &HashMap<Address, Balance>, block: u64) {
+    fn fold_balances(&mut self, balances: &HashMap<Address, Balance>, at: NaiveDateTime) {
         todo!("apply folded balances")
     }
 
@@ -187,12 +191,12 @@ impl FoldSink for EntityCache {
         // before their first attributes arrive:
         //
         // 1. `new_protocol_components` — create entries.
-        // 2. `state_deltas` — apply where newer than the entry height.
+        // 2. `state_deltas` — apply where not older than the entry.
         // 3. `component_balances` — apply.
         // 4. `deleted_protocol_components` — remove entries.
-        // 5. `account_deltas` — apply per value, tagged with this block; a `Creation` delta for an
-        //    unknown address creates the entry, any other change for an unknown address is skipped
-        //    (partial data must never create an entry).
+        // 5. `account_deltas` — apply per value, tagged with this block's timestamp; a `Creation`
+        //    delta for an unknown address creates the entry, any other change for an unknown
+        //    address is skipped (partial data must never create an entry).
         // 6. `account_balances` — apply.
         //
         // Not folded in phase 1: `new_tokens`, `component_tvl`, `dci_update` — DB-served.

--- a/crates/tycho-indexer/src/services/state/cache.rs
+++ b/crates/tycho-indexer/src/services/state/cache.rs
@@ -16,28 +16,28 @@
 //! - **Entries exist only complete.** An entry is created by a database fill or by a `Creation`
 //!   delta (both carry the entity's whole tracked state) — never by a partial update. Presence in
 //!   the cache is therefore proof that a hit is servable.
-//! - **Fills publish value-by-value.** A fill is a snapshot of the database at a stamped block; it
-//!   is published with set-if-newer per value and never replaces a whole entry, so a fold that
-//!   landed while the fill was in flight cannot be overwritten with older data.
+//! - **Fills publish value-by-value, with honest provenance, only reorg-safe state.** A fill is a
+//!   database snapshot; each published value carries the block that actually wrote it (the row's
+//!   `valid_from` for account values, the owning extractor's snapshot commit height for components)
+//!   and is applied only where newer than what the entry holds. A blanket "database head" stamp is
+//!   unsound: the head is chain-global while commits are per-extractor, so it can overstate
+//!   provenance and mask a concurrently folded newer value. Window top-up beyond the database base
+//!   decorates the response only — it is never published, because unfinalized values in the cache
+//!   would survive a revert that only purges the window.
 //!
 //! Locking: one mutex per entity, no whole-cache lock. The outer maps are only locked to look up
 //! or insert entry handles; folds and reads then lock the single entity they touch, so a fold on
 //! one account never blocks a read of another.
 //!
-//! Database fills are deliberately **not** deduplicated. Requests that miss the same entity
-//! concurrently may each query the database for it — accepted and measured rather than
-//! prevented, because three existing mechanisms already make duplicates rare and harmless:
+//! Database fills are deliberately **not** deduplicated. The reasoning is simple:
 //!
-//! - set-if-newer publication makes concurrent fills of one entity converge, so a duplicate costs a
-//!   redundant indexed point-read, never a wrong value;
-//! - identical request bodies are collapsed upstream by the HTTP response cache's in-flight
-//!   deduplication, which covers reconnecting clients snapshotting the same block;
-//! - the fill path's semaphore bounds total concurrent fill queries regardless.
+//! - duplicates are safe: publication is tag-guarded, so concurrent fills of one entity converge;
+//! - duplicates are rare: identical requests are already collapsed by the HTTP response cache, and
+//!   the fill semaphore bounds total fill concurrency.
 //!
-//! What remains is overlapping-but-not-identical requests (adjacent blocks, different page
-//! slicing). Their rate is observable via [`EntityCache::record_fill_start`]; per-entity
-//! single-flight (a guard map with waiter wake-up) can be reintroduced behind the same call
-//! sites if that metric ever shows the redundancy matters.
+//! The expectation is still checked: [`EntityCache::record_fill_start`] feeds
+//! `entity_cache_fill_duplicates`, and per-entity single-flight can be reintroduced behind the
+//! same call sites if the metric ever proves it wrong.
 
 // Not yet constructed by production code; wired into the pending-deltas facade and the fill path
 // in follow-ups.
@@ -95,11 +95,15 @@ pub(crate) struct CachedAccount {
 }
 
 impl CachedAccount {
-    /// Builds a complete entry from a database fill stamped at block `stamp`.
+    /// Builds a complete entry from a database fill.
     #[allow(unused_variables)]
     fn from_fill(filled: &Account, stamp: u64) -> Self {
-        // Every value starts tagged with `stamp`: the fill is a snapshot of the database at that
-        // block, no per-value provenance exists or is needed.
+        // Tags must be per-value provenance: the block that actually wrote each value (the row's
+        // `valid_from`, plumbed through the stamped gateway read). A single snapshot-level stamp
+        // would overstate provenance for values written earlier and let this entry mask another
+        // extractor's concurrently folded newer write to a shared account (see the module doc);
+        // `stamp` is only the fallback tag for values whose provenance the gateway cannot supply,
+        // and must then be a per-writer commit height, never the chain-global head.
         todo!("build entry from filled account")
     }
 
@@ -125,9 +129,9 @@ impl CachedAccount {
     /// Publishes a database fill stamped at block `stamp`, value by value.
     #[allow(unused_variables)]
     fn set_if_newer(&mut self, filled: &Account, stamp: u64) {
-        // Per slot / field: write only when `stamp` is greater than the stored tag. Never clear
-        // values absent from the fill — an absent slot means "not tracked by this query", not
-        // "deleted".
+        // Per slot / field: write only when the incoming value's own provenance tag (its row's
+        // `valid_from`) is greater than the stored tag. Never clear values absent from the fill —
+        // an absent slot means "not tracked by this query", not "deleted".
         todo!("tag-compared publication")
     }
 
@@ -171,7 +175,9 @@ impl CachedComponentState {
     #[allow(unused_variables)]
     fn set_if_newer(&mut self, filled: &ProtocolComponentState, stamp: u64) {
         // Single-height entries publish atomically: apply the whole fill iff
-        // `stamp > self.height`.
+        // `stamp > self.height`, where `stamp` is the owning extractor's committed height read in
+        // the same database snapshot as the fill (not the chain-global head — see the module
+        // doc). Only the reorg-safe base is ever published; window top-up stays response-local.
         todo!("height-compared publication")
     }
 

--- a/crates/tycho-indexer/src/services/state/cache.rs
+++ b/crates/tycho-indexer/src/services/state/cache.rs
@@ -1,51 +1,27 @@
-//! Long-lived in-memory entity state, fed by window folds and database fills.
+//! Long-lived in-memory entity state.
 //!
 //! Two entity families are cached:
 //!
-//! - **Accounts** (contract state), keyed by address. Shared: several extractors can fold into the
-//!   same account at different block heights, so every cached value carries the block that last
-//!   wrote it (per-slot / per-field tags).
-//! - **Component states** (protocol state), keyed by `(protocol system, component id)`. Each
-//!   protocol system has exactly one extractor and its folds are monotonic, so one height per entry
-//!   is enough: a write applies only when its block is higher than the stored height.
+//! - **Accounts** (contract state), keyed by address. Several extractors can write the same account
+//!   at different block heights, so every cached value carries the block that last wrote it: a
+//!   newer block always wins, the same block twice is a no-op.
+//! - **Component states** (protocol state), keyed by `(protocol system, component id)`. Exactly one
+//!   extractor writes each protocol system, in block order, so one height per entry is enough.
 //!
-//! Invariants the cache upholds:
+//! The cache is written from exactly two places: the startup load, which runs before the
+//! extractors start, and the folds coming out of the block windows. It never reads the database,
+//! and it never evicts — an entity missing from the cache does not exist.
 //!
-//! - **Highest block wins.** Delta values are absolute, so re-applying an already-applied block is
-//!   a no-op and out-of-order writers can never regress a value.
-//! - **Entries exist only complete.** An entry is created by a database fill or by a `Creation`
-//!   delta (both carry the entity's whole tracked state) — never by a partial update. Presence in
-//!   the cache is therefore proof that a hit is servable.
-//! - **Fills publish value-by-value, with honest provenance, only reorg-safe state.** A fill is a
-//!   database snapshot; each published value carries the block that actually wrote it (the row's
-//!   `valid_from` for account values, the owning extractor's snapshot commit height for components)
-//!   and is applied only where newer than what the entry holds. A blanket "database head" stamp is
-//!   unsound: the head is chain-global while commits are per-extractor, so it can overstate
-//!   provenance and mask a concurrently folded newer value. Window top-up beyond the database base
-//!   decorates the response only — it is never published, because unfinalized values in the cache
-//!   would survive a revert that only purges the window.
-//!
-//! Locking: one mutex per entity, no whole-cache lock. The outer maps are only locked to look up
-//! or insert entry handles; folds and reads then lock the single entity they touch, so a fold on
-//! one account never blocks a read of another.
-//!
-//! Database fills are deliberately **not** deduplicated. The reasoning is simple:
-//!
-//! - duplicates are safe: publication is tag-guarded, so concurrent fills of one entity converge;
-//! - duplicates are rare: identical requests are already collapsed by the HTTP response cache, and
-//!   the fill semaphore bounds total fill concurrency.
-//!
-//! The expectation is still checked: [`EntityCache::record_fill_start`] feeds
-//! `entity_cache_fill_duplicates`, and per-entity single-flight can be reintroduced behind the
-//! same call sites if the metric ever proves it wrong.
+//! Reads and folds take turns behind one read-write lock: a fold takes the write side and
+//! applies one whole block atomically, reads take the read side. Folds are expected to take well
+//! under a millisecond, so blocking is acceptable and a reader never observes half a block.
 
-// Not yet constructed by production code; wired into the pending-deltas facade and the fill path
-// in follow-ups.
+// Not yet constructed by production code; wired into the loader and the pump in follow-ups.
 #![allow(dead_code)]
 
 use std::{
-    collections::{HashMap, HashSet},
-    sync::{Arc, Mutex, RwLock},
+    collections::HashMap,
+    sync::{RwLock, RwLockReadGuard},
 };
 
 use tycho_common::{
@@ -64,18 +40,11 @@ use super::window::FoldSink;
 /// A cached value together with the block number that last wrote it.
 type Tagged<T> = (T, u64);
 
-/// Handle to one cached entry; hold the lock for the shortest possible span.
-type EntryHandle<T> = Arc<Mutex<T>>;
-
-/// Entry handles by key. The outer lock guards map membership only; entry state is behind the
-/// per-entry mutex.
-type EntryMap<K, T> = RwLock<HashMap<K, EntryHandle<T>>>;
-
 /// Cached state of one contract account.
 ///
-/// Every mutable value is tagged with its writing block (see the module doc); `set_if_newer`
-/// compares tags so fills and folds can interleave in any order and converge to the
-/// highest-block value per field.
+/// Every value carries the block that last wrote it, so writes from different extractors (which
+/// run at different block heights) can never regress a value: newer block wins, same block is a
+/// no-op.
 pub(crate) struct CachedAccount {
     chain: Chain,
     title: String,
@@ -83,63 +52,41 @@ pub(crate) struct CachedAccount {
     native_balance: Tagged<Balance>,
     token_balances: HashMap<Address, Tagged<AccountBalance>>,
     code: Tagged<Code>,
-    /// Maintained alongside `code`: recomputed when a fold carries code, taken verbatim from
-    /// fills. The database path and the delta path are known to disagree on this field today;
-    /// matching the delta path here is intentional.
+    /// Kept in sync when a fold carries code.
     code_hash: CodeHash,
-    /// Transaction references come from fills only — folded deltas do not carry them, matching
-    /// the delta-patched reads served today.
+    /// Transaction references come from the startup load only — folds don't carry them.
     balance_modify_tx: TxHash,
     code_modify_tx: TxHash,
     creation_tx: Option<TxHash>,
 }
 
 impl CachedAccount {
-    /// Builds a complete entry from a database fill.
+    /// Builds an entry from the startup snapshot. Every value arrives with the block that wrote
+    /// it (the row's `valid_from`), which becomes its tag.
     #[allow(unused_variables)]
-    fn from_fill(filled: &Account, stamp: u64) -> Self {
-        // Tags must be per-value provenance: the block that actually wrote each value (the row's
-        // `valid_from`, plumbed through the stamped gateway read). A single snapshot-level stamp
-        // would overstate provenance for values written earlier and let this entry mask another
-        // extractor's concurrently folded newer write to a shared account (see the module doc);
-        // `stamp` is only the fallback tag for values whose provenance the gateway cannot supply,
-        // and must then be a per-writer commit height, never the chain-global head.
-        todo!("build entry from filled account")
+    fn from_snapshot(filled: &Account, value_blocks: &HashMap<StoreKey, u64>) -> Self {
+        todo!("build entry from snapshot")
     }
 
-    /// Builds a complete entry from a `Creation` delta folded at block `block`.
+    /// Builds an entry from a `Creation` delta folded at `block` — after startup, the only way a
+    /// new contract enters the cache. Creation deltas carry the whole initial tracked state.
     #[allow(unused_variables)]
     fn from_creation(delta: &AccountDelta, block: u64) -> Self {
-        // Creation deltas carry the account's whole initial tracked state (the equivalent of
-        // `AccountDelta::into_account_without_tx`); transaction references stay empty until a
-        // fill provides them.
         todo!("build entry from creation delta")
     }
 
-    /// Applies one folded delta for block `block` to this entry.
+    /// Applies one folded delta; every changed value gets `block` as its tag.
     #[allow(unused_variables)]
     fn fold(&mut self, delta: &AccountDelta, block: u64) {
-        // - Each slot in the delta gets its value (deleted slots become the zero value, as in
-        //   `Account::apply_delta`) and `block` as its tag.
-        // - Balance and code update likewise when present; code updates recompute `code_hash`.
-        // - Tags make re-application of an already-folded block a no-op.
+        // Deleted slots become the zero value (as in `Account::apply_delta`). A delta that
+        // carries code also refreshes `code_hash` — `Account::apply_delta` does not maintain
+        // that field, so don't reuse it blindly.
         todo!("apply folded delta")
     }
 
-    /// Publishes a database fill stamped at block `stamp`, value by value.
-    #[allow(unused_variables)]
-    fn set_if_newer(&mut self, filled: &Account, stamp: u64) {
-        // Per slot / field: write only when the incoming value's own provenance tag (its row's
-        // `valid_from`) is greater than the stored tag. Never clear values absent from the fill —
-        // an absent slot means "not tracked by this query", not "deleted".
-        todo!("tag-compared publication")
-    }
-
-    /// Materializes the cached base state as an [`Account`] for response assembly.
+    /// Materializes the cached state as an [`Account`] for response assembly.
     #[allow(unused_variables)]
     fn materialize(&self, address: &Address) -> Account {
-        // Tags are dropped here; callers that patch window deltas on top must read the tags via
-        // the entry handle instead (the patching read path lands with the routing layer).
         todo!("assemble account")
     }
 }
@@ -148,154 +95,83 @@ impl CachedAccount {
 pub(crate) struct CachedComponentState {
     attributes: HashMap<AttrStoreKey, StoreVal>,
     balances: HashMap<Address, Balance>,
-    /// Block height of the whole entry. One extractor writes each protocol system and its folds
-    /// are monotonic, so a single height replaces per-value tags; writes apply only when their
-    /// block exceeds it.
+    /// One height covers the whole entry: a single extractor writes each protocol system, in
+    /// block order.
     height: u64,
 }
 
 impl CachedComponentState {
-    /// Applies one folded state delta for block `block`.
+    /// Builds an entry from the startup snapshot at the given height.
+    #[allow(unused_variables)]
+    fn from_snapshot(state: &ProtocolComponentState, height: u64) -> Self {
+        todo!("build entry from snapshot")
+    }
+
+    /// Applies one folded state delta for `block` when it is newer than the entry.
     #[allow(unused_variables)]
     fn fold(&mut self, delta: &ProtocolComponentStateDelta, block: u64) {
-        // Skip when `block <= self.height` (re-applied block); debug-assert on `<` — an
-        // out-of-order fold from the single writer is a bug, not a race. Otherwise extend
-        // `attributes` with `updated_attributes`, remove `deleted_attributes` keys (plain
-        // removal, no tombstones), set `height = block`.
+        // Skip when `block <= self.height` (replayed block). Deleted attributes are plain key
+        // removals. Out-of-order folds from the single writer are a bug — debug-assert.
         todo!("apply folded state delta")
     }
 
-    /// Applies folded balance changes for block `block`.
+    /// Applies folded balance changes for `block`.
     #[allow(unused_variables)]
     fn fold_balances(&mut self, balances: &HashMap<Address, Balance>, block: u64) {
         todo!("apply folded balances")
     }
 
-    /// Publishes a database fill stamped at block `stamp` when it is newer than the entry.
-    #[allow(unused_variables)]
-    fn set_if_newer(&mut self, filled: &ProtocolComponentState, stamp: u64) {
-        // Single-height entries publish atomically: apply the whole fill iff
-        // `stamp > self.height`, where `stamp` is the owning extractor's committed height read in
-        // the same database snapshot as the fill (not the chain-global head — see the module
-        // doc). Only the reorg-safe base is ever published; window top-up stays response-local.
-        todo!("height-compared publication")
-    }
-
-    /// Materializes the cached base state for response assembly.
+    /// Materializes the cached state for response assembly.
     #[allow(unused_variables)]
     fn materialize(&self, component_id: &str) -> ProtocolComponentState {
         todo!("assemble component state")
     }
 }
 
-/// Identifies one cacheable entity; used to track in-flight fills for the duplicate metric.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum EntityKey {
-    Account(Address),
-    Component(String, ComponentId),
-}
-
-/// Memory bounds for the cache.
-pub(crate) struct CacheLimits {
-    /// Byte cap for cached entries. Least-recently-used whole entities are evicted above it;
-    /// eviction is safe because entries are complete and re-fillable.
-    pub(crate) max_bytes: u64,
-}
-
-/// The long-lived entity store. See the module doc for the data model and invariants.
+/// The long-lived entity store. See the module doc for the data model and locking.
 pub(crate) struct EntityCache {
-    accounts: EntryMap<Address, CachedAccount>,
-    components: EntryMap<(String, ComponentId), CachedComponentState>,
-    /// Keys with a database fill currently in flight. Observability only: fills are not
-    /// deduplicated (see the module doc), this set just counts concurrent duplicates.
-    in_flight_fills: Mutex<HashSet<EntityKey>>,
-    limits: CacheLimits,
+    /// Folds take the write side and apply one whole block atomically; reads take the read
+    /// side. Folds are fast, so waiting is fine and a reader never sees half a block.
+    state: RwLock<CacheState>,
+}
+
+/// The maps behind the lock.
+pub(crate) struct CacheState {
+    pub(crate) accounts: HashMap<Address, CachedAccount>,
+    pub(crate) components: HashMap<(String, ComponentId), CachedComponentState>,
+    // Memory accounting (running byte total, reconciled periodically) attaches here.
 }
 
 impl EntityCache {
-    pub(crate) fn new(limits: CacheLimits) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            accounts: RwLock::new(HashMap::new()),
-            components: RwLock::new(HashMap::new()),
-            in_flight_fills: Mutex::new(HashSet::new()),
-            limits,
+            state: RwLock::new(CacheState { accounts: HashMap::new(), components: HashMap::new() }),
         }
     }
 
-    /// Returns the entry handle for `address`, if cached.
-    ///
-    /// Presence means the entry is complete and servable. Callers lock the returned handle for
-    /// the shortest possible span — a held entry lock delays folds of that entity.
-    #[allow(unused_variables)]
-    pub(crate) fn account(&self, address: &Address) -> Option<EntryHandle<CachedAccount>> {
-        // Clone the `Arc` under the outer read guard, drop the guard before the caller locks the
-        // entry, record the access for eviction ordering.
-        todo!("account lookup")
+    /// Read access for response assembly. Folds wait until the guard is dropped — hold it only
+    /// long enough to copy out what the response needs.
+    pub(crate) fn read(&self) -> RwLockReadGuard<'_, CacheState> {
+        self.state
+            .read()
+            .expect("entity cache lock poisoned")
     }
 
-    /// Returns the entry handle for `(system, component_id)`, if cached.
+    /// Startup load only: runs before the extractors start, so nothing else is writing.
     #[allow(unused_variables)]
-    pub(crate) fn component(
+    pub(crate) fn insert_loaded_account(&self, address: Address, entry: CachedAccount) {
+        todo!("insert loaded account")
+    }
+
+    /// Startup load only.
+    #[allow(unused_variables)]
+    pub(crate) fn insert_loaded_component(
         &self,
-        system: &str,
-        component_id: &str,
-    ) -> Option<EntryHandle<CachedComponentState>> {
-        todo!("component lookup")
-    }
-
-    /// Publishes a filled account stamped at block `stamp`.
-    ///
-    /// Creates the entry when absent (fills are complete by construction); otherwise defers to
-    /// [`CachedAccount::set_if_newer`] so concurrent folds are never regressed.
-    #[allow(unused_variables)]
-    pub(crate) fn set_account_if_newer(&self, address: Address, filled: &Account, stamp: u64) {
-        todo!("publish account fill")
-    }
-
-    /// Publishes a filled component state stamped at block `stamp`.
-    #[allow(unused_variables)]
-    pub(crate) fn set_component_if_newer(
-        &self,
-        system: &str,
-        filled: &ProtocolComponentState,
-        stamp: u64,
+        system: String,
+        component_id: ComponentId,
+        entry: CachedComponentState,
     ) {
-        todo!("publish component fill")
-    }
-
-    /// Records the start of a database fill for `keys`, returning how many of them already have
-    /// a fill in flight from a concurrent caller.
-    ///
-    /// Observability only: nothing waits on this set and duplicate fills are allowed (see the
-    /// module doc). The return value feeds the `entity_cache_fill_duplicates` counter — the
-    /// signal that decides whether per-entity single-flight is ever worth reintroducing.
-    #[allow(unused_variables)]
-    pub(crate) fn record_fill_start(&self, keys: &[EntityKey]) -> usize {
-        // Insert every key into `in_flight_fills`; count the ones that were already present.
-        todo!("track in-flight fill keys")
-    }
-
-    /// Records the end of a database fill for `keys` (success or failure).
-    ///
-    /// Callers release from a drop guard so error paths unwind the set too. Because the set is
-    /// a plain membership set, a key filled concurrently by two callers is released by the first
-    /// to finish — the tail of the second fill goes uncounted. A leaked or early-released key
-    /// only skews the duplicate metric; it can never block serving.
-    #[allow(unused_variables)]
-    pub(crate) fn record_fill_end(&self, keys: &[EntityKey]) {
-        todo!("release in-flight fill keys")
-    }
-
-    /// Evicts least-recently-used entities until the cache fits `limits.max_bytes`.
-    #[allow(unused_variables)]
-    pub(crate) fn evict_to_cap(&self) {
-        // - Size accounting: running byte total maintained on insert/update/remove, reconciled
-        //   periodically against a full recomputation (the reporting task owns the cadence).
-        // - Order: reads and fill publications count as use; folds do not — a folded-but-never-
-        //   read entity is a fine eviction candidate.
-        // - Evict whole entities only; count evictions for the sustained-eviction alert. Evicting
-        //   an entity mid-fill is safe: the fill republishes a complete entry.
-        todo!("lru eviction")
+        todo!("insert loaded component")
     }
 }
 
@@ -306,30 +182,22 @@ impl FoldSink for EntityCache {
         extractor: &str,
         block: &BlockAggregatedChanges,
     ) -> Result<(), StorageError> {
-        // Component families first, so entries created by this block exist before the same
-        // block's deltas and balances land on them:
+        // Under the write lock, apply the whole block in an order where new components exist
+        // before their first attributes arrive:
         //
-        // 1. `new_protocol_components` — create `(extractor, component id)` entries. New entries
-        //    start empty with a height below this block so steps 2 and 3 fill their initial state.
-        // 2. `state_deltas` — `CachedComponentState::fold` on existing entries; unknown component
-        //    ids are skipped (partial data never creates entries).
-        // 3. `component_balances` — `CachedComponentState::fold_balances`.
+        // 1. `new_protocol_components` — create entries.
+        // 2. `state_deltas` — apply where newer than the entry height.
+        // 3. `component_balances` — apply.
         // 4. `deleted_protocol_components` — remove entries.
+        // 5. `account_deltas` — apply per value, tagged with this block; a `Creation` delta for an
+        //    unknown address creates the entry, any other change for an unknown address is skipped
+        //    (partial data must never create an entry).
+        // 6. `account_balances` — apply.
         //
-        // Then accounts:
+        // Not folded in phase 1: `new_tokens`, `component_tvl`, `dci_update` — DB-served.
         //
-        // 5. `account_deltas` — `CachedAccount::fold` on existing entries; unknown addresses create
-        //    an entry via `CachedAccount::from_creation` only for `Creation` deltas and are skipped
-        //    otherwise.
-        // 6. `account_balances` — token balances, tagged with this block.
-        //
-        // Not folded here: `new_tokens`, `component_tvl`, `dci_update` — those entities stay
-        // database-served.
-        //
-        // Errors: per the [`FoldSink`] contract an error means the block was not fully applied
-        // and the window keeps it buffered. Apply per entity family and fail before mutating on
-        // malformed input (e.g. an id mismatch), so a re-fold of the same block converges via
-        // the tag/height no-op rule.
+        // An error means the block was not applied: the window keeps it and the process stops.
+        // Fail before mutating, so a replay of the same block converges.
         todo!("fold one block")
     }
 }

--- a/crates/tycho-indexer/src/services/state/cache.rs
+++ b/crates/tycho-indexer/src/services/state/cache.rs
@@ -61,8 +61,9 @@ pub(crate) struct CachedAccount {
 }
 
 impl CachedAccount {
-    /// Builds an entry from the startup snapshot. Every value arrives with the block that wrote
-    /// it (the row's `valid_from`), which becomes its tag.
+    /// Builds an entry from the startup snapshot. Every value arrives with the block **number**
+    /// that wrote it, which becomes its tag. (The rows version by timestamp, so the loader
+    /// recovers the block through each row's `modify_tx` — see the plan's snapshot-read task.)
     #[allow(unused_variables)]
     fn from_snapshot(filled: &Account, value_blocks: &HashMap<StoreKey, u64>) -> Self {
         todo!("build entry from snapshot")

--- a/crates/tycho-indexer/src/services/state/cache.rs
+++ b/crates/tycho-indexer/src/services/state/cache.rs
@@ -1,0 +1,336 @@
+//! Long-lived in-memory entity state, fed by window folds and database fills.
+//!
+//! Two entity families are cached:
+//!
+//! - **Accounts** (contract state), keyed by address. Shared: several extractors can fold into the
+//!   same account at different block heights, so every cached value carries the block that last
+//!   wrote it (per-slot / per-field tags).
+//! - **Component states** (protocol state), keyed by `(protocol system, component id)`. Each
+//!   protocol system has exactly one extractor and its folds are monotonic, so one height per entry
+//!   is enough: a write applies only when its block is higher than the stored height.
+//!
+//! Invariants the cache upholds:
+//!
+//! - **Highest block wins.** Delta values are absolute, so re-applying an already-applied block is
+//!   a no-op and out-of-order writers can never regress a value.
+//! - **Entries exist only complete.** An entry is created by a database fill or by a `Creation`
+//!   delta (both carry the entity's whole tracked state) — never by a partial update. Presence in
+//!   the cache is therefore proof that a hit is servable.
+//! - **Fills publish value-by-value.** A fill is a snapshot of the database at a stamped block; it
+//!   is published with set-if-newer per value and never replaces a whole entry, so a fold that
+//!   landed while the fill was in flight cannot be overwritten with older data.
+//!
+//! Locking: one mutex per entity, no whole-cache lock. The outer maps are only locked to look up
+//! or insert entry handles; folds and reads then lock the single entity they touch, so a fold on
+//! one account never blocks a read of another. Fill deduplication (single-flight) is keyed
+//! per entity: concurrent requesters of the same missing entity produce one database read.
+
+// Not yet constructed by production code; wired into the pending-deltas facade and the fill path
+// in follow-ups.
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, RwLock, Weak},
+};
+
+use tokio::sync::Notify;
+use tycho_common::{
+    models::{
+        blockchain::BlockAggregatedChanges,
+        contract::{Account, AccountBalance, AccountDelta},
+        protocol::{ProtocolComponentState, ProtocolComponentStateDelta},
+        Address, AttrStoreKey, Balance, Chain, Code, CodeHash, ComponentId, StoreKey, StoreVal,
+        TxHash,
+    },
+    storage::StorageError,
+};
+
+use super::window::FoldSink;
+
+/// A cached value together with the block number that last wrote it.
+type Tagged<T> = (T, u64);
+
+/// Handle to one cached entry; hold the lock for the shortest possible span.
+type EntryHandle<T> = Arc<Mutex<T>>;
+
+/// Entry handles by key. The outer lock guards map membership only; entry state is behind the
+/// per-entry mutex.
+type EntryMap<K, T> = RwLock<HashMap<K, EntryHandle<T>>>;
+
+/// Cached state of one contract account.
+///
+/// Every mutable value is tagged with its writing block (see the module doc); `set_if_newer`
+/// compares tags so fills and folds can interleave in any order and converge to the
+/// highest-block value per field.
+pub(crate) struct CachedAccount {
+    chain: Chain,
+    title: String,
+    slots: HashMap<StoreKey, Tagged<StoreVal>>,
+    native_balance: Tagged<Balance>,
+    token_balances: HashMap<Address, Tagged<AccountBalance>>,
+    code: Tagged<Code>,
+    /// Maintained alongside `code`: recomputed when a fold carries code, taken verbatim from
+    /// fills. The database path and the delta path are known to disagree on this field today;
+    /// matching the delta path here is intentional.
+    code_hash: CodeHash,
+    /// Transaction references come from fills only — folded deltas do not carry them, matching
+    /// the delta-patched reads served today.
+    balance_modify_tx: TxHash,
+    code_modify_tx: TxHash,
+    creation_tx: Option<TxHash>,
+}
+
+impl CachedAccount {
+    /// Builds a complete entry from a database fill stamped at block `stamp`.
+    #[allow(unused_variables)]
+    fn from_fill(filled: &Account, stamp: u64) -> Self {
+        // Every value starts tagged with `stamp`: the fill is a snapshot of the database at that
+        // block, no per-value provenance exists or is needed.
+        todo!("build entry from filled account")
+    }
+
+    /// Builds a complete entry from a `Creation` delta folded at block `block`.
+    #[allow(unused_variables)]
+    fn from_creation(delta: &AccountDelta, block: u64) -> Self {
+        // Creation deltas carry the account's whole initial tracked state (the equivalent of
+        // `AccountDelta::into_account_without_tx`); transaction references stay empty until a
+        // fill provides them.
+        todo!("build entry from creation delta")
+    }
+
+    /// Applies one folded delta for block `block` to this entry.
+    #[allow(unused_variables)]
+    fn fold(&mut self, delta: &AccountDelta, block: u64) {
+        // - Each slot in the delta gets its value (deleted slots become the zero value, as in
+        //   `Account::apply_delta`) and `block` as its tag.
+        // - Balance and code update likewise when present; code updates recompute `code_hash`.
+        // - Tags make re-application of an already-folded block a no-op.
+        todo!("apply folded delta")
+    }
+
+    /// Publishes a database fill stamped at block `stamp`, value by value.
+    #[allow(unused_variables)]
+    fn set_if_newer(&mut self, filled: &Account, stamp: u64) {
+        // Per slot / field: write only when `stamp` is greater than the stored tag. Never clear
+        // values absent from the fill — an absent slot means "not tracked by this query", not
+        // "deleted".
+        todo!("tag-compared publication")
+    }
+
+    /// Materializes the cached base state as an [`Account`] for response assembly.
+    #[allow(unused_variables)]
+    fn materialize(&self, address: &Address) -> Account {
+        // Tags are dropped here; callers that patch window deltas on top must read the tags via
+        // the entry handle instead (the patching read path lands with the routing layer).
+        todo!("assemble account")
+    }
+}
+
+/// Cached state of one protocol component.
+pub(crate) struct CachedComponentState {
+    attributes: HashMap<AttrStoreKey, StoreVal>,
+    balances: HashMap<Address, Balance>,
+    /// Block height of the whole entry. One extractor writes each protocol system and its folds
+    /// are monotonic, so a single height replaces per-value tags; writes apply only when their
+    /// block exceeds it.
+    height: u64,
+}
+
+impl CachedComponentState {
+    /// Applies one folded state delta for block `block`.
+    #[allow(unused_variables)]
+    fn fold(&mut self, delta: &ProtocolComponentStateDelta, block: u64) {
+        // Skip when `block <= self.height` (re-applied block); debug-assert on `<` — an
+        // out-of-order fold from the single writer is a bug, not a race. Otherwise extend
+        // `attributes` with `updated_attributes`, remove `deleted_attributes` keys (plain
+        // removal, no tombstones), set `height = block`.
+        todo!("apply folded state delta")
+    }
+
+    /// Applies folded balance changes for block `block`.
+    #[allow(unused_variables)]
+    fn fold_balances(&mut self, balances: &HashMap<Address, Balance>, block: u64) {
+        todo!("apply folded balances")
+    }
+
+    /// Publishes a database fill stamped at block `stamp` when it is newer than the entry.
+    #[allow(unused_variables)]
+    fn set_if_newer(&mut self, filled: &ProtocolComponentState, stamp: u64) {
+        // Single-height entries publish atomically: apply the whole fill iff
+        // `stamp > self.height`.
+        todo!("height-compared publication")
+    }
+
+    /// Materializes the cached base state for response assembly.
+    #[allow(unused_variables)]
+    fn materialize(&self, component_id: &str) -> ProtocolComponentState {
+        todo!("assemble component state")
+    }
+}
+
+/// Identifies one cacheable entity, used to key single-flight fills.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum EntityKey {
+    Account(Address),
+    Component(String, ComponentId),
+}
+
+/// Memory bounds for the cache.
+pub(crate) struct CacheLimits {
+    /// Byte cap for cached entries. Least-recently-used whole entities are evicted above it;
+    /// eviction is safe because entries are complete and re-fillable.
+    pub(crate) max_bytes: u64,
+}
+
+/// The long-lived entity store. See the module doc for the data model and invariants.
+pub(crate) struct EntityCache {
+    accounts: EntryMap<Address, CachedAccount>,
+    components: EntryMap<(String, ComponentId), CachedComponentState>,
+    /// In-flight database fills, one guard per entity (single-flight). Owners insert on claim
+    /// and remove-and-notify on release; waiters await the notify, then re-read the cache.
+    /// `Arc` so [`FillTicket`]s can release without borrowing the cache.
+    fills: Arc<Mutex<HashMap<EntityKey, Arc<Notify>>>>,
+    limits: CacheLimits,
+}
+
+impl EntityCache {
+    pub(crate) fn new(limits: CacheLimits) -> Self {
+        Self {
+            accounts: RwLock::new(HashMap::new()),
+            components: RwLock::new(HashMap::new()),
+            fills: Arc::new(Mutex::new(HashMap::new())),
+            limits,
+        }
+    }
+
+    /// Returns the entry handle for `address`, if cached.
+    ///
+    /// Presence means the entry is complete and servable. Callers lock the returned handle for
+    /// the shortest possible span — a held entry lock delays folds of that entity.
+    #[allow(unused_variables)]
+    pub(crate) fn account(&self, address: &Address) -> Option<EntryHandle<CachedAccount>> {
+        // Clone the `Arc` under the outer read guard, drop the guard before the caller locks the
+        // entry, record the access for eviction ordering.
+        todo!("account lookup")
+    }
+
+    /// Returns the entry handle for `(system, component_id)`, if cached.
+    #[allow(unused_variables)]
+    pub(crate) fn component(
+        &self,
+        system: &str,
+        component_id: &str,
+    ) -> Option<EntryHandle<CachedComponentState>> {
+        todo!("component lookup")
+    }
+
+    /// Publishes a filled account stamped at block `stamp`.
+    ///
+    /// Creates the entry when absent (fills are complete by construction); otherwise defers to
+    /// [`CachedAccount::set_if_newer`] so concurrent folds are never regressed.
+    #[allow(unused_variables)]
+    pub(crate) fn set_account_if_newer(&self, address: Address, filled: &Account, stamp: u64) {
+        todo!("publish account fill")
+    }
+
+    /// Publishes a filled component state stamped at block `stamp`.
+    #[allow(unused_variables)]
+    pub(crate) fn set_component_if_newer(
+        &self,
+        system: &str,
+        filled: &ProtocolComponentState,
+        stamp: u64,
+    ) {
+        todo!("publish component fill")
+    }
+
+    /// Claims fill ownership for a set of missing entities.
+    ///
+    /// Splits `misses` into keys this caller now owns (it must run the database fill and then
+    /// drop the ticket) and fills already in flight elsewhere (await them, then re-read the
+    /// cache). Guarantees at most one in-flight fill per entity regardless of request fan-in.
+    #[allow(unused_variables)]
+    pub(crate) fn claim_fills(&self, misses: Vec<EntityKey>) -> FillClaims {
+        // Under the `fills` lock, partition: absent key -> insert a fresh `Notify`, caller owns
+        // it; present key -> clone the existing `Notify` for awaiting. Ownership is released by
+        // `FillTicket::drop`, which covers error and panic paths of the fill.
+        todo!("partition owned vs pending")
+    }
+
+    /// Evicts least-recently-used entities until the cache fits `limits.max_bytes`.
+    #[allow(unused_variables)]
+    pub(crate) fn evict_to_cap(&self) {
+        // - Size accounting: running byte total maintained on insert/update/remove, reconciled
+        //   periodically against a full recomputation (the reporting task owns the cadence).
+        // - Order: reads and fill publications count as use; folds do not — a folded-but-never-
+        //   read entity is a fine eviction candidate.
+        // - Evict whole entities only, skip entities with an in-flight fill, count evictions for
+        //   the sustained-eviction alert.
+        todo!("lru eviction")
+    }
+}
+
+impl FoldSink for EntityCache {
+    #[allow(unused_variables)]
+    fn apply_folded(
+        &self,
+        extractor: &str,
+        block: &BlockAggregatedChanges,
+    ) -> Result<(), StorageError> {
+        // Component families first, so entries created by this block exist before the same
+        // block's deltas and balances land on them:
+        //
+        // 1. `new_protocol_components` — create `(extractor, component id)` entries. New entries
+        //    start empty with a height below this block so steps 2 and 3 fill their initial state.
+        // 2. `state_deltas` — `CachedComponentState::fold` on existing entries; unknown component
+        //    ids are skipped (partial data never creates entries).
+        // 3. `component_balances` — `CachedComponentState::fold_balances`.
+        // 4. `deleted_protocol_components` — remove entries.
+        //
+        // Then accounts:
+        //
+        // 5. `account_deltas` — `CachedAccount::fold` on existing entries; unknown addresses create
+        //    an entry via `CachedAccount::from_creation` only for `Creation` deltas and are skipped
+        //    otherwise.
+        // 6. `account_balances` — token balances, tagged with this block.
+        //
+        // Not folded here: `new_tokens`, `component_tvl`, `dci_update` — those entities stay
+        // database-served.
+        //
+        // Errors: per the [`FoldSink`] contract an error means the block was not fully applied
+        // and the window keeps it buffered. Apply per entity family and fail before mutating on
+        // malformed input (e.g. an id mismatch), so a re-fold of the same block converges via
+        // the tag/height no-op rule.
+        todo!("fold one block")
+    }
+}
+
+/// Release-on-drop ownership of in-flight fills (see [`EntityCache::claim_fills`]).
+pub(crate) struct FillClaims {
+    /// Keys this caller must fill.
+    pub(crate) owned: FillTicket,
+    /// Fills owned by other callers; await these, then re-read the cache.
+    pub(crate) pending: Vec<Arc<Notify>>,
+}
+
+/// Owned fill keys; dropping releases them and wakes all waiters.
+pub(crate) struct FillTicket {
+    keys: Vec<EntityKey>,
+    /// Weak so a ticket outliving the cache degrades to a no-op release.
+    fills: Weak<Mutex<HashMap<EntityKey, Arc<Notify>>>>,
+}
+
+impl FillTicket {
+    pub(crate) fn keys(&self) -> &[EntityKey] {
+        &self.keys
+    }
+}
+
+impl Drop for FillTicket {
+    fn drop(&mut self) {
+        // Remove each key from the fill map and `notify_waiters` on its guard. Runs on success,
+        // error, and panic paths alike; waiters re-read the cache and re-claim on a miss, so a
+        // failed fill degrades to a retry, never a hang.
+    }
+}

--- a/crates/tycho-indexer/src/services/state/cache.rs
+++ b/crates/tycho-indexer/src/services/state/cache.rs
@@ -22,19 +22,32 @@
 //!
 //! Locking: one mutex per entity, no whole-cache lock. The outer maps are only locked to look up
 //! or insert entry handles; folds and reads then lock the single entity they touch, so a fold on
-//! one account never blocks a read of another. Fill deduplication (single-flight) is keyed
-//! per entity: concurrent requesters of the same missing entity produce one database read.
+//! one account never blocks a read of another.
+//!
+//! Database fills are deliberately **not** deduplicated. Requests that miss the same entity
+//! concurrently may each query the database for it — accepted and measured rather than
+//! prevented, because three existing mechanisms already make duplicates rare and harmless:
+//!
+//! - set-if-newer publication makes concurrent fills of one entity converge, so a duplicate costs a
+//!   redundant indexed point-read, never a wrong value;
+//! - identical request bodies are collapsed upstream by the HTTP response cache's in-flight
+//!   deduplication, which covers reconnecting clients snapshotting the same block;
+//! - the fill path's semaphore bounds total concurrent fill queries regardless.
+//!
+//! What remains is overlapping-but-not-identical requests (adjacent blocks, different page
+//! slicing). Their rate is observable via [`EntityCache::record_fill_start`]; per-entity
+//! single-flight (a guard map with waiter wake-up) can be reintroduced behind the same call
+//! sites if that metric ever shows the redundancy matters.
 
 // Not yet constructed by production code; wired into the pending-deltas facade and the fill path
 // in follow-ups.
 #![allow(dead_code)]
 
 use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex, RwLock, Weak},
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex, RwLock},
 };
 
-use tokio::sync::Notify;
 use tycho_common::{
     models::{
         blockchain::BlockAggregatedChanges,
@@ -169,7 +182,7 @@ impl CachedComponentState {
     }
 }
 
-/// Identifies one cacheable entity, used to key single-flight fills.
+/// Identifies one cacheable entity; used to track in-flight fills for the duplicate metric.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum EntityKey {
     Account(Address),
@@ -187,10 +200,9 @@ pub(crate) struct CacheLimits {
 pub(crate) struct EntityCache {
     accounts: EntryMap<Address, CachedAccount>,
     components: EntryMap<(String, ComponentId), CachedComponentState>,
-    /// In-flight database fills, one guard per entity (single-flight). Owners insert on claim
-    /// and remove-and-notify on release; waiters await the notify, then re-read the cache.
-    /// `Arc` so [`FillTicket`]s can release without borrowing the cache.
-    fills: Arc<Mutex<HashMap<EntityKey, Arc<Notify>>>>,
+    /// Keys with a database fill currently in flight. Observability only: fills are not
+    /// deduplicated (see the module doc), this set just counts concurrent duplicates.
+    in_flight_fills: Mutex<HashSet<EntityKey>>,
     limits: CacheLimits,
 }
 
@@ -199,7 +211,7 @@ impl EntityCache {
         Self {
             accounts: RwLock::new(HashMap::new()),
             components: RwLock::new(HashMap::new()),
-            fills: Arc::new(Mutex::new(HashMap::new())),
+            in_flight_fills: Mutex::new(HashSet::new()),
             limits,
         }
     }
@@ -245,17 +257,27 @@ impl EntityCache {
         todo!("publish component fill")
     }
 
-    /// Claims fill ownership for a set of missing entities.
+    /// Records the start of a database fill for `keys`, returning how many of them already have
+    /// a fill in flight from a concurrent caller.
     ///
-    /// Splits `misses` into keys this caller now owns (it must run the database fill and then
-    /// drop the ticket) and fills already in flight elsewhere (await them, then re-read the
-    /// cache). Guarantees at most one in-flight fill per entity regardless of request fan-in.
+    /// Observability only: nothing waits on this set and duplicate fills are allowed (see the
+    /// module doc). The return value feeds the `entity_cache_fill_duplicates` counter — the
+    /// signal that decides whether per-entity single-flight is ever worth reintroducing.
     #[allow(unused_variables)]
-    pub(crate) fn claim_fills(&self, misses: Vec<EntityKey>) -> FillClaims {
-        // Under the `fills` lock, partition: absent key -> insert a fresh `Notify`, caller owns
-        // it; present key -> clone the existing `Notify` for awaiting. Ownership is released by
-        // `FillTicket::drop`, which covers error and panic paths of the fill.
-        todo!("partition owned vs pending")
+    pub(crate) fn record_fill_start(&self, keys: &[EntityKey]) -> usize {
+        // Insert every key into `in_flight_fills`; count the ones that were already present.
+        todo!("track in-flight fill keys")
+    }
+
+    /// Records the end of a database fill for `keys` (success or failure).
+    ///
+    /// Callers release from a drop guard so error paths unwind the set too. Because the set is
+    /// a plain membership set, a key filled concurrently by two callers is released by the first
+    /// to finish — the tail of the second fill goes uncounted. A leaked or early-released key
+    /// only skews the duplicate metric; it can never block serving.
+    #[allow(unused_variables)]
+    pub(crate) fn record_fill_end(&self, keys: &[EntityKey]) {
+        todo!("release in-flight fill keys")
     }
 
     /// Evicts least-recently-used entities until the cache fits `limits.max_bytes`.
@@ -265,8 +287,8 @@ impl EntityCache {
         //   periodically against a full recomputation (the reporting task owns the cadence).
         // - Order: reads and fill publications count as use; folds do not — a folded-but-never-
         //   read entity is a fine eviction candidate.
-        // - Evict whole entities only, skip entities with an in-flight fill, count evictions for
-        //   the sustained-eviction alert.
+        // - Evict whole entities only; count evictions for the sustained-eviction alert. Evicting
+        //   an entity mid-fill is safe: the fill republishes a complete entry.
         todo!("lru eviction")
     }
 }
@@ -303,34 +325,5 @@ impl FoldSink for EntityCache {
         // malformed input (e.g. an id mismatch), so a re-fold of the same block converges via
         // the tag/height no-op rule.
         todo!("fold one block")
-    }
-}
-
-/// Release-on-drop ownership of in-flight fills (see [`EntityCache::claim_fills`]).
-pub(crate) struct FillClaims {
-    /// Keys this caller must fill.
-    pub(crate) owned: FillTicket,
-    /// Fills owned by other callers; await these, then re-read the cache.
-    pub(crate) pending: Vec<Arc<Notify>>,
-}
-
-/// Owned fill keys; dropping releases them and wakes all waiters.
-pub(crate) struct FillTicket {
-    keys: Vec<EntityKey>,
-    /// Weak so a ticket outliving the cache degrades to a no-op release.
-    fills: Weak<Mutex<HashMap<EntityKey, Arc<Notify>>>>,
-}
-
-impl FillTicket {
-    pub(crate) fn keys(&self) -> &[EntityKey] {
-        &self.keys
-    }
-}
-
-impl Drop for FillTicket {
-    fn drop(&mut self) {
-        // Remove each key from the fill map and `notify_waiters` on its guard. Runs on success,
-        // error, and panic paths alike; waiters re-read the cache and re-claim on a miss, so a
-        // failed fill degrades to a retry, never a hang.
     }
 }

--- a/crates/tycho-indexer/src/services/state/mod.rs
+++ b/crates/tycho-indexer/src/services/state/mod.rs
@@ -6,6 +6,64 @@
 //!
 //! This module currently contains the block window ([`window`]) and the entity store ([`cache`])
 //! it folds into. The database fill path and the request routing layer build on top of them.
+//!
+//! # Synchronization model
+//!
+//! Shared state: one [`window::DeltaWindow`] per extractor behind a mutex, and the
+//! [`cache::EntityCache`] with one lock per entry, written only by folds and fills. The
+//! correctness bar for every response: each returned value equals the entity's true value at the
+//! requested version `V`.
+//!
+//! ## Reads vs folds
+//!
+//! A read captures, under the window lock, its patch — every delta in `(floor − 1, V]` for its
+//! keys — strictly **before** reading any entry. Folding and eviction are atomic under the same
+//! lock, so patch and entry bases always connect: a fold that lands in between only moves values
+//! the patch already covers, and tag-guarded application (`delta block > tag`) makes the overlap
+//! a no-op.
+//!
+//! **Read guard:** if any required value's tag (or entry height) exceeds `V` — a batched fold or
+//! a concurrent fill advanced the entity past an older `V` — the request cannot be served from
+//! the cache (it keeps no history) and routes to the fallback. That fallback must be the
+//! latest-plus-window-patch read, not a plain versioned query: during commit lag the database
+//! also has no rows for `(committed, V]`. The window-depth margin over the maximum served
+//! version age makes this guard a rare tripwire, not a working path; it is counted when it
+//! fires.
+//!
+//! ## Folds vs fills
+//!
+//! Folds apply only blocks at or below the db-committed watermark, and the watermark must be a
+//! lagging observation of **acknowledged database flushes** — never ahead of what a concurrent
+//! database read returns. Then every folded block's effects are contained in any fill's base, so
+//! a fold that skipped an absent entity mid-fill loses nothing once the fill's entry lands. Two
+//! further requirements close the remaining races:
+//!
+//! - **Honest provenance** (see the cache module doc): filled values are tagged with the block that
+//!   actually wrote them, never a chain-global head stamp, so a fill can never mask a concurrently
+//!   folded newer value on a shared account.
+//! - **Publication validated against eviction:** between a fill's database snapshot and its
+//!   publication, eviction may fold blocks the snapshot missed and drop them from the window. Entry
+//!   insertion therefore happens in a critical section with the involved window lock(s),
+//!   re-checking that no involved extractor's floor has passed its snapshot commit height;
+//!   otherwise the fill is discarded and the request falls back.
+//!
+//! ## Reads vs fills
+//!
+//! Entries appear in the maps only complete — a fill builds the whole entry before inserting the
+//! handle — so a hit is never partial, and per-value tag guards make concurrent (including
+//! duplicate) publications converge. Fills publish only the reorg-safe database base: the window
+//! top-up that completes a response to `V` is applied to a response-local copy and never
+//! published, so a revert — which purges only unfolded window blocks — can never leave an
+//! orphaned unfinalized value in the cache that equal-height canonical folds would then silently
+//! skip. A reader whose `V` predates a concurrently published newer value is caught by the read
+//! guard.
+//!
+//! ## Deletions
+//!
+//! Attribute and component deletions fold as guarded removals. Folding and eviction are atomic,
+//! so every folded deletion lies below the window floor, and version resolution routes every `V`
+//! below the floor to the versioned database fallback — a cache-path read can never observe an
+//! entity as missing at a `V` that precedes its deletion.
 
 pub(crate) mod cache;
 pub(crate) mod window;

--- a/crates/tycho-indexer/src/services/state/mod.rs
+++ b/crates/tycho-indexer/src/services/state/mod.rs
@@ -4,7 +4,8 @@
 //! `⊕` applies deltas on top of a base and the highest block wins for each value. The database is
 //! read only for entities the cache has never seen.
 //!
-//! This module currently contains the block window ([`window`]). The entity cache, the database
-//! fill path, and the request routing layer build on top of it.
+//! This module currently contains the block window ([`window`]) and the entity store ([`cache`])
+//! it folds into. The database fill path and the request routing layer build on top of them.
 
+pub(crate) mod cache;
 pub(crate) mod window;

--- a/crates/tycho-indexer/src/services/state/mod.rs
+++ b/crates/tycho-indexer/src/services/state/mod.rs
@@ -7,63 +7,21 @@
 //! This module currently contains the block window ([`window`]) and the entity store ([`cache`])
 //! it folds into. The database fill path and the request routing layer build on top of them.
 //!
-//! # Synchronization model
+//! # Synchronization
 //!
-//! Shared state: one [`window::DeltaWindow`] per extractor behind a mutex, and the
-//! [`cache::EntityCache`] with one lock per entry, written only by folds and fills. The
-//! correctness bar for every response: each returned value equals the entity's true value at the
-//! requested version `V`.
+//! The cache is written by the startup load — which runs before anything else — and then only
+//! by folds. Reads and folds are sequential: a fold takes the write side of one lock and applies
+//! a whole block atomically, reads take the read side. Folds are fast, so waiting is fine, and a
+//! read never sees half a block.
 //!
-//! ## Reads vs folds
+//! A read collects the window patch for its keys first, then reads the entries, and applies only
+//! the patch changes that are newer than each value's tag. If an entry has already moved past
+//! the requested version (folding is batched), that request is served the way uncommitted
+//! versions are served today — latest from the DB plus the buffered window changes — because the
+//! cache keeps no history.
 //!
-//! A read captures, under the window lock, its patch — every delta in `(floor − 1, V]` for its
-//! keys — strictly **before** reading any entry. Folding and eviction are atomic under the same
-//! lock, so patch and entry bases always connect: a fold that lands in between only moves values
-//! the patch already covers, and tag-guarded application (`delta block > tag`) makes the overlap
-//! a no-op.
-//!
-//! **Read guard:** if any required value's tag (or entry height) exceeds `V` — a batched fold or
-//! a concurrent fill advanced the entity past an older `V` — the request cannot be served from
-//! the cache (it keeps no history) and routes to the fallback. That fallback must be the
-//! latest-plus-window-patch read, not a plain versioned query: during commit lag the database
-//! also has no rows for `(committed, V]`. The window-depth margin over the maximum served
-//! version age makes this guard a rare tripwire, not a working path; it is counted when it
-//! fires.
-//!
-//! ## Folds vs fills
-//!
-//! Folds apply only blocks at or below the db-committed watermark, and the watermark must be a
-//! lagging observation of **acknowledged database flushes** — never ahead of what a concurrent
-//! database read returns. Then every folded block's effects are contained in any fill's base, so
-//! a fold that skipped an absent entity mid-fill loses nothing once the fill's entry lands. Two
-//! further requirements close the remaining races:
-//!
-//! - **Honest provenance** (see the cache module doc): filled values are tagged with the block that
-//!   actually wrote them, never a chain-global head stamp, so a fill can never mask a concurrently
-//!   folded newer value on a shared account.
-//! - **Publication validated against eviction:** between a fill's database snapshot and its
-//!   publication, eviction may fold blocks the snapshot missed and drop them from the window. Entry
-//!   insertion therefore happens in a critical section with the involved window lock(s),
-//!   re-checking that no involved extractor's floor has passed its snapshot commit height;
-//!   otherwise the fill is discarded and the request falls back.
-//!
-//! ## Reads vs fills
-//!
-//! Entries appear in the maps only complete — a fill builds the whole entry before inserting the
-//! handle — so a hit is never partial, and per-value tag guards make concurrent (including
-//! duplicate) publications converge. Fills publish only the reorg-safe database base: the window
-//! top-up that completes a response to `V` is applied to a response-local copy and never
-//! published, so a revert — which purges only unfolded window blocks — can never leave an
-//! orphaned unfinalized value in the cache that equal-height canonical folds would then silently
-//! skip. A reader whose `V` predates a concurrently published newer value is caught by the read
-//! guard.
-//!
-//! ## Deletions
-//!
-//! Attribute and component deletions fold as guarded removals. Folding and eviction are atomic,
-//! so every folded deletion lies below the window floor, and version resolution routes every `V`
-//! below the floor to the versioned database fallback — a cache-path read can never observe an
-//! entity as missing at a `V` that precedes its deletion.
+//! Versions below the window go to the versioned DB path. Deletions folded into the cache are
+//! always below the window floor by then, so a below-window read never misses them.
 
 pub(crate) mod cache;
 pub(crate) mod window;


### PR DESCRIPTION
## What

Skeleton for the entity store (story 2 of the entity-cache plan): interfaces and contracts only — method bodies are `todo!()` with the intended behavior in doc comments. Plan: https://github.com/zizou0x/files/pull/3 · Design doc: https://propellerswap.slack.com/archives/C0B787HG10T/p1786093064886909

## Base

Based on `main`. The `DeltaWindow` and its `FoldSink` trait are already in `main`, so this diff shows only the store skeleton. `EntityCache` implements `FoldSink::fold`.

## Layout

`services/state/cache.rs`:

- `CachedAccount` — every value carries the timestamp of the block that last wrote it, the same unit the database's `valid_from` versioning uses, so writes from different extractors can never regress a value. `code_hash` maintained on code folds; tx references come from the startup load.
- `CachedComponentState` — one write time per entry (a single extractor writes each protocol system, in block order).
- `EntityCache` — one read-write lock: folds take the write side and apply a whole block atomically, reads take the read side (folds are expected to be fast). Written only by the startup load (before extractors run) and by folds; never reads the DB, never evicts.
- Snapshot constructors take each value's write time from the loaded rows (`valid_from`).

`services/state/mod.rs` — short synchronization notes (sequential reads/folds, patch-before-entry reads, read guard, below-window fallback).

Not in this PR: implementations, the startup loader, wiring into the pump/handlers, tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
