### PR TITLE
fix(tycho-simulation): tolerate empty FeedMessages in stream decoder

### DIFF
--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -271,7 +271,12 @@ where
     }
 
     /// Decodes a `FeedMessage` into a `BlockUpdate` containing the updated states of protocol
-    /// components
+    /// components.
+    ///
+    /// A message with an empty `state_msgs` map (no synchronizer advanced this tick) decodes
+    /// into a status-only update: empty state maps, `sync_states` passed through, and the block
+    /// number of the last decoded message. Such a message before the first decoded block is an
+    /// error.
     pub async fn decode(&self, msg: &FeedMessage<H>) -> Result<Update, StreamDecodeError> {
         // stores all states updated in this tick/msg
         let mut updated_states = HashMap::new();
@@ -279,6 +284,26 @@ where
         let mut removed_pairs = HashMap::new();
         let mut contracts_map = HashMap::new();
         let mut msg_failed_components = HashSet::new();
+
+        // The BlockSynchronizer emits one FeedMessage per tick even when no synchronizer
+        // advanced (e.g. all delayed or stale during a websocket reconnect). Such a message
+        // carries only sync status. Emit a status-only update so consumers keep observing
+        // sync_states instead of failing on a transient stall.
+        if msg.state_msgs.is_empty() {
+            let current_block_number = self
+                .state
+                .read()
+                .await
+                .current_block_number;
+            if current_block_number == 0 {
+                return Err(StreamDecodeError::Fatal(
+                    "Received an empty FeedMessage before the first block".into(),
+                ));
+            }
+            debug!(current_block_number, "Empty FeedMessage; emitting status-only update");
+            return Ok(Update::new(current_block_number, HashMap::new(), HashMap::new())
+                .set_sync_states(msg.sync_states.clone()));
+        }
 
         let header = msg
             .state_msgs
@@ -1328,6 +1353,44 @@ mod tests {
         assert_eq!(res2.states.len(), 1);
         assert_eq!(res1.sync_states.len(), 1);
         assert_eq!(res2.sync_states.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_decode_empty_message_returns_status_only_update() {
+        let decoder = setup_decoder(true).await;
+
+        let msg = load_test_msg("uniswap_v2_snapshot");
+        let snapshot_update = decoder
+            .decode(&msg)
+            .await
+            .expect("decode failure");
+
+        let empty_msg =
+            FeedMessage { state_msgs: HashMap::new(), sync_states: msg.sync_states.clone() };
+        let update = decoder
+            .decode(&empty_msg)
+            .await
+            .expect("empty message should decode to a status-only update");
+
+        assert_eq!(update.block_number_or_timestamp, snapshot_update.block_number_or_timestamp);
+        assert!(!update.is_partial);
+        assert!(update.states.is_empty());
+        assert!(update.new_pairs.is_empty());
+        assert!(update.removed_pairs.is_empty());
+        assert_eq!(update.sync_states, msg.sync_states);
+    }
+
+    #[tokio::test]
+    async fn test_decode_empty_message_before_first_block_fails() {
+        let decoder = setup_decoder(true).await;
+
+        let empty_msg = FeedMessage { state_msgs: HashMap::new(), sync_states: HashMap::new() };
+        let res = decoder.decode(&empty_msg).await;
+
+        assert!(matches!(
+            res,
+            Err(StreamDecodeError::Fatal(ref m)) if m.contains("before the first block")
+        ));
     }
 
     #[tokio::test]

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -62,8 +62,14 @@ struct DecoderState {
     // again TODO: handle more gracefully inside tycho-client. We could fetch the snapshot and
     // try to decode it again.
     failed_components: HashSet<String>,
-    // The block number of the last confirmed block decoded via `decode()`.
+    // The block number of the last block decoded via `decode()`, confirmed or partial.
     current_block_number: u64,
+    // Whether the last block decoded via `decode()` was a partial (flashblock) header. Carried
+    // over onto status-only updates so `is_partial` reflects the real confirmation state.
+    current_block_is_partial: bool,
+    // Set while consecutive empty FeedMessages are being received. Lets the decoder log the
+    // start of a stall loudly and every repeat quietly, instead of spamming on every tick.
+    in_stall_episode: bool,
 }
 
 type DecodeFut =
@@ -275,8 +281,8 @@ where
     ///
     /// A message with an empty `state_msgs` map (no synchronizer advanced this tick) decodes
     /// into a status-only update: empty state maps, `sync_states` passed through, and the block
-    /// number of the last decoded message. Such a message before the first decoded block is an
-    /// error.
+    /// number and partial-block status carried over from the last decoded message. Such a
+    /// message before the first decoded block is an error.
     pub async fn decode(&self, msg: &FeedMessage<H>) -> Result<Update, StreamDecodeError> {
         // stores all states updated in this tick/msg
         let mut updated_states = HashMap::new();
@@ -290,18 +296,33 @@ where
         // carries only sync status. Emit a status-only update so consumers keep observing
         // sync_states instead of failing on a transient stall.
         if msg.state_msgs.is_empty() {
-            let current_block_number = self
-                .state
-                .read()
-                .await
-                .current_block_number;
-            if current_block_number == 0 {
-                return Err(StreamDecodeError::Fatal(
-                    "Received an empty FeedMessage before the first block".into(),
-                ));
+            let (current_block_number, current_block_is_partial, is_new_stall) = {
+                let mut state = self.state.write().await;
+                if state.current_block_number == 0 {
+                    return Err(StreamDecodeError::Fatal(
+                        "Received an empty FeedMessage before the first block".into(),
+                    ));
+                }
+                let is_new_stall = !state.in_stall_episode;
+                state.in_stall_episode = true;
+                (state.current_block_number, state.current_block_is_partial, is_new_stall)
+            };
+
+            if is_new_stall {
+                // Log the start of a stall loudly: until sync-status metrics land, this is the
+                // only in-band signal an operator has. Subsequent empty messages while the
+                // episode continues are logged at `debug!` — on a fast chain this line would
+                // otherwise repeat every block time for as long as the stall lasts.
+                warn!(
+                    current_block_number,
+                    sync_states = ?msg.sync_states,
+                    "All synchronizers stalled; emitting a status-only update"
+                );
+            } else {
+                debug!(current_block_number, "Empty FeedMessage; emitting status-only update");
             }
-            debug!(current_block_number, "Empty FeedMessage; emitting status-only update");
             return Ok(Update::new(current_block_number, HashMap::new(), HashMap::new())
+                .set_is_partial(current_block_is_partial)
                 .set_sync_states(msg.sync_states.clone()));
         }
 
@@ -959,6 +980,11 @@ where
         // Persist the newly added/updated states
         let mut state_guard = self.state.write().await;
 
+        if state_guard.in_stall_episode {
+            state_guard.in_stall_episode = false;
+            info!(block_number_or_timestamp, "Synchronizers recovered; resuming state updates");
+        }
+
         // Update failed components with any new ones
         state_guard
             .failed_components
@@ -983,6 +1009,7 @@ where
             .extend(updated_states.clone());
 
         state_guard.current_block_number = block_number_or_timestamp;
+        state_guard.current_block_is_partial = is_partial;
 
         // Add new components to persistent state
         for (id, component) in new_pairs.iter() {
@@ -1391,6 +1418,42 @@ mod tests {
             res,
             Err(StreamDecodeError::Fatal(ref m)) if m.contains("before the first block")
         ));
+    }
+
+    #[tokio::test]
+    async fn test_decode_empty_message_preserves_state_for_later_delta() {
+        let decoder = setup_decoder(true).await;
+
+        let snapshot_msg = load_test_msg("uniswap_v2_snapshot");
+        let snapshot_update = decoder
+            .decode(&snapshot_msg)
+            .await
+            .expect("snapshot decode failure");
+        assert_eq!(snapshot_update.states.len(), 1);
+
+        let empty_msg = FeedMessage {
+            state_msgs: HashMap::new(),
+            sync_states: snapshot_msg.sync_states.clone(),
+        };
+        // Two consecutive heartbeats: the first opens the stall episode, the second is the
+        // repeated case. Neither should disturb the state built from the snapshot.
+        decoder
+            .decode(&empty_msg)
+            .await
+            .expect("first heartbeat should decode to a status-only update");
+        decoder
+            .decode(&empty_msg)
+            .await
+            .expect("second heartbeat should decode to a status-only update");
+
+        let delta_msg = load_test_msg("uniswap_v2_delta");
+        let delta_update = decoder
+            .decode(&delta_msg)
+            .await
+            .expect("delta decode after heartbeats should still apply to the snapshot state");
+
+        assert_eq!(delta_update.states.len(), 1);
+        assert_eq!(delta_update.sync_states.len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

fynd crash loops from short extractor stalls showing `Fatal("Missing block!")` before dying

Over 2026-08-11/12 we lost fynd pods to stalls that were transient and recoverable:
• Robinhood — extractor stalls >3s on token metadata in the block hot path. 23 crashes in 24h.
• Arbitrum — an ingress-nginx reload closed all WebSockets. Both pods died 3.0s after the disconnect, while tycho-client was still reconnecting.
• Unichain/Polygon — a shared Substreams gRPC outage paused all extractors >3s.

## Root cause

The cause is in the Tycho stream decoder, not in fynd. When no extractor delivers a block within one block time (+ 3s timeout), `BlockSynchronizer` emits a `FeedMessage` with an empty `state_msgs` map. That is its status heartbeat — it carries `sync_states` so consumers can watch Delayed/Stale and recovery. `decode()` treated it as fatal, fynd propagated the `Err` with `?`, and the solver shut down. tycho-client already absorbs these stalls; the decoder killed
the consumer first.

## Fix

`decode()` now returns a status-only `Update` — empty state maps, `sync_states` passed through, block number and partial-block flag repeated from the last decoded block. An empty message before the first block stays an error.
Stall entry logs at `warn!` with `sync_states`, repeats at `debug!`, recovery at `info!`.

## Worth knowing

after this lands a stall no longer appears as a restart, it appears as aging data. Restart-based alerts will not catch it. 

## Follow-up

- raise `SolveError::MarketDataStale` in the fynd solve path
- expose per-protocol Stale/Delayed as metrics
- add staleness alerts.