### PR TITLE
fix: apply token cache write-through only after DB commit

### DIFF
--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -371,7 +371,14 @@ impl DBCacheWriteExecutor {
         let mut res =
             Err(PostgresError(StorageError::Unexpected("default response error".to_string())));
 
+        let token_cache = self.state_gateway.token_cache.clone();
+
         while retry_count < max_retries {
+            // Each attempt gets a fresh staging session; a failed attempt's
+            // leftovers are replaced by the next begin.
+            if let Some(cache) = &token_cache {
+                cache.begin_staging();
+            }
             res = conn
                 .build_transaction()
                 .repeatable_read()
@@ -419,6 +426,13 @@ impl DBCacheWriteExecutor {
                     }
                 }
                 _ => break,
+            }
+        }
+
+        if let Some(cache) = &token_cache {
+            match &res {
+                Ok(_) => cache.commit_staged(),
+                Err(_) => cache.discard_staged(),
             }
         }
 
@@ -1281,7 +1295,167 @@ mod test_serial_db {
     use tycho_common::models::ChangeType;
 
     use super::*;
-    use crate::postgres::{db_fixtures, db_fixtures::yesterday_one_am, testing::run_against_db};
+    use crate::postgres::{
+        db_fixtures,
+        db_fixtures::yesterday_one_am,
+        testing::run_against_db,
+        token_cache::{TokenCache, TokenQuery},
+    };
+
+    #[tokio::test]
+    async fn test_serial_db_write_rollback_discards_staged_cache_ops() {
+        run_against_db(|connection_pool| async move {
+            let mut connection = connection_pool
+                .get()
+                .await
+                .expect("Failed to get a connection from the pool");
+            let chain_id = db_fixtures::insert_chain(&mut connection, "ethereum").await;
+            db_fixtures::insert_token(
+                &mut connection,
+                chain_id,
+                "0000000000000000000000000000000000000000",
+                "ETH",
+                18,
+                Some(100),
+            )
+            .await;
+            let mut gateway: PostgresGateway =
+                PostgresGateway::from_connection(&mut connection).await;
+            gateway.token_cache = Some(Arc::new(
+                TokenCache::from_connection(&mut connection, &[Chain::Ethereum])
+                    .await
+                    .unwrap(),
+            ));
+            let cache = gateway.token_cache.clone().unwrap();
+
+            let (tx, rx) = mpsc::channel(10);
+            let write_executor = DBCacheWriteExecutor::new(
+                "ethereum".to_owned(),
+                Chain::Ethereum,
+                connection_pool.clone(),
+                gateway.clone(),
+                rx,
+            )
+            .await;
+            let handle = write_executor.run();
+
+            let token_address = Bytes::from("0xdAC17F958D2ee523a2206206994597C13D831ec7");
+            let token = models::token::Token::new(
+                &token_address,
+                "USDT",
+                6,
+                0,
+                &[Some(64), None],
+                Chain::Ethereum,
+                100,
+            );
+            // The token insert succeeds inside the transaction; the orphan
+            // transaction (its block is never written) then fails it, rolling
+            // everything back. Ops execute in message order.
+            let orphan_tx = get_sample_transaction(1);
+            let os_rx = send_write_message(
+                &tx,
+                get_sample_block(1),
+                vec![WriteOp::InsertTokens(vec![token]), WriteOp::UpsertTx(vec![orphan_tx])],
+            )
+            .await;
+            let result = os_rx
+                .await
+                .expect("Response from channel ok");
+            assert!(result.is_err(), "the write must fail on the orphan transaction");
+            handle.abort();
+
+            let cached = cache
+                .query_tokens(&TokenQuery {
+                    chain: Chain::Ethereum,
+                    addresses: Some(vec![token_address]),
+                    quality_range: QualityRange::None(),
+                    last_traded_ts_threshold: None,
+                    pagination: None,
+                })
+                .unwrap();
+            assert_eq!(
+                cached.total,
+                Some(0),
+                "a rolled-back token must not be visible in the cache"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_serial_db_write_commit_applies_staged_cache_ops() {
+        run_against_db(|connection_pool| async move {
+            let mut connection = connection_pool
+                .get()
+                .await
+                .expect("Failed to get a connection from the pool");
+            let chain_id = db_fixtures::insert_chain(&mut connection, "ethereum").await;
+            db_fixtures::insert_token(
+                &mut connection,
+                chain_id,
+                "0000000000000000000000000000000000000000",
+                "ETH",
+                18,
+                Some(100),
+            )
+            .await;
+            let mut gateway: PostgresGateway =
+                PostgresGateway::from_connection(&mut connection).await;
+            gateway.token_cache = Some(Arc::new(
+                TokenCache::from_connection(&mut connection, &[Chain::Ethereum])
+                    .await
+                    .unwrap(),
+            ));
+            let cache = gateway.token_cache.clone().unwrap();
+
+            let (tx, rx) = mpsc::channel(10);
+            let write_executor = DBCacheWriteExecutor::new(
+                "ethereum".to_owned(),
+                Chain::Ethereum,
+                connection_pool.clone(),
+                gateway.clone(),
+                rx,
+            )
+            .await;
+            let handle = write_executor.run();
+
+            let token_address = Bytes::from("0xdAC17F958D2ee523a2206206994597C13D831ec7");
+            let token = models::token::Token::new(
+                &token_address,
+                "USDT",
+                6,
+                0,
+                &[Some(64), None],
+                Chain::Ethereum,
+                100,
+            );
+            let block = get_sample_block(1);
+            let os_rx = send_write_message(
+                &tx,
+                block.clone(),
+                vec![WriteOp::UpsertBlock(vec![block.clone()]), WriteOp::InsertTokens(vec![token])],
+            )
+            .await;
+            os_rx
+                .await
+                .expect("Response from channel ok")
+                .expect("Transaction committed");
+            handle.abort();
+
+            let cached = cache
+                .query_tokens(&TokenQuery {
+                    chain: Chain::Ethereum,
+                    addresses: Some(vec![token_address]),
+                    quality_range: QualityRange::None(),
+                    last_traded_ts_threshold: None,
+                    pagination: None,
+                })
+                .unwrap();
+            assert_eq!(cached.total, Some(1), "a committed token must be visible in the cache");
+        })
+        .await;
+    }
 
     #[tokio::test]
     async fn test_write_and_flush() {

--- a/crates/tycho-storage/src/postgres/protocol.rs
+++ b/crates/tycho-storage/src/postgres/protocol.rs
@@ -1172,7 +1172,7 @@ impl PostgresGateway {
         .await?;
 
         if let Some(token_cache) = &self.token_cache {
-            token_cache.add_tokens(tokens);
+            token_cache.write_through_add_tokens(tokens);
         }
 
         Ok(())
@@ -1241,7 +1241,7 @@ impl PostgresGateway {
                 .filter(|t| address_to_db_id.contains_key(&t.address))
                 .cloned()
                 .collect();
-            token_cache.upsert_tokens(&updated);
+            token_cache.write_through_upsert_tokens(updated);
         }
 
         Ok(())
@@ -1423,7 +1423,13 @@ impl PostgresGateway {
                     *entry = (*entry).max(*transaction_ts);
                 }
             }
-            token_cache.update_last_traded(chain, latest_trade.into_iter());
+            token_cache.write_through_update_last_traded(
+                *chain,
+                latest_trade
+                    .into_iter()
+                    .map(|(token_address, ts)| (token_address.clone(), ts))
+                    .collect(),
+            );
         }
 
         Ok(())

--- a/crates/tycho-storage/src/postgres/token_cache.rs
+++ b/crates/tycho-storage/src/postgres/token_cache.rs
@@ -91,7 +91,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     ops::Bound,
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -319,6 +319,14 @@ impl ChainTokenStore {
     }
 }
 
+/// A cache mutation computed by a write-through site, buffered while the
+/// enclosing DB transaction is open and applied only if it commits.
+enum CacheOp {
+    AddTokens(Vec<Token>),
+    UpsertTokens(Vec<Token>),
+    UpdateLastTraded { chain: Chain, updates: Vec<(Address, NaiveDateTime)> },
+}
+
 /// The public face of the cache: one [`ChainTokenStore`] per chain plus the
 /// bookkeeping needed to keep them in sync with the database (see the module
 /// docs for the overall design).
@@ -330,6 +338,9 @@ pub struct TokenCache {
     /// Largest `token.modified_ts` this cache has seen; `refresh` polls for rows
     /// newer than this (minus a safety overlap).
     last_sync: RwLock<NaiveDateTime>,
+    /// Open staging session: `Some` buffers write-through mutations until
+    /// `commit_staged` / `discard_staged`; `None` means mutations apply at once.
+    staged: Mutex<Option<Vec<CacheOp>>>,
 }
 
 impl TokenCache {
@@ -389,7 +400,12 @@ impl TokenCache {
             stores.insert(chain, RwLock::new(store));
         }
 
-        Ok(Self { chains: stores, chain_ids, last_sync: RwLock::new(last_sync) })
+        Ok(Self {
+            chains: stores,
+            chain_ids,
+            last_sync: RwLock::new(last_sync),
+            staged: Mutex::new(None),
+        })
     }
 
     async fn load_chain(
@@ -462,6 +478,97 @@ impl TokenCache {
             .read()
             .expect("token cache lock poisoned");
         Ok(guard.query(query))
+    }
+
+    /// Opens a staging session, so write-through mutations are buffered instead
+    /// of applied. Any buffer left behind by an earlier session is replaced.
+    pub(crate) fn begin_staging(&self) {
+        let mut staged = self
+            .staged
+            .lock()
+            .expect("token cache staging lock poisoned");
+        if staged
+            .as_ref()
+            .is_some_and(|ops| !ops.is_empty())
+        {
+            warn!("Replacing a non-empty token cache staging buffer");
+        }
+        *staged = Some(Vec::new());
+    }
+
+    /// Applies the staged mutations in the order they were buffered and closes
+    /// the session. A no-op when no session is open.
+    pub(crate) fn commit_staged(&self) {
+        let ops = self
+            .staged
+            .lock()
+            .expect("token cache staging lock poisoned")
+            .take();
+        let Some(ops) = ops else {
+            return;
+        };
+        for op in ops {
+            self.apply(op);
+        }
+    }
+
+    /// Drops the staged mutations and closes the session, leaving the cache
+    /// exactly as it was before [`TokenCache::begin_staging`].
+    pub(crate) fn discard_staged(&self) {
+        *self
+            .staged
+            .lock()
+            .expect("token cache staging lock poisoned") = None;
+    }
+
+    /// Write-through entry for token inserts.
+    pub(crate) fn write_through_add_tokens(&self, tokens: &[Token]) {
+        self.stage_or_apply(CacheOp::AddTokens(tokens.to_vec()));
+    }
+
+    /// Write-through entry for token updates.
+    pub(crate) fn write_through_upsert_tokens(&self, tokens: Vec<Token>) {
+        self.stage_or_apply(CacheOp::UpsertTokens(tokens));
+    }
+
+    /// Write-through entry for balance-derived trade timestamps.
+    pub(crate) fn write_through_update_last_traded(
+        &self,
+        chain: Chain,
+        updates: Vec<(Address, NaiveDateTime)>,
+    ) {
+        self.stage_or_apply(CacheOp::UpdateLastTraded { chain, updates });
+    }
+
+    /// Buffers `op` while a staging session is open (the write executor's
+    /// transaction, which may still roll back), applies it at once otherwise
+    /// (the direct gateway autocommits, so its data is already durable).
+    fn stage_or_apply(&self, op: CacheOp) {
+        let mut staged = self
+            .staged
+            .lock()
+            .expect("token cache staging lock poisoned");
+        match staged.as_mut() {
+            Some(ops) => ops.push(op),
+            None => {
+                // The staging lock is never held while a store lock is taken.
+                drop(staged);
+                self.apply(op);
+            }
+        }
+    }
+
+    fn apply(&self, op: CacheOp) {
+        match op {
+            CacheOp::AddTokens(tokens) => self.add_tokens(&tokens),
+            CacheOp::UpsertTokens(tokens) => self.upsert_tokens(&tokens),
+            CacheOp::UpdateLastTraded { chain, updates } => self.update_last_traded(
+                &chain,
+                updates
+                    .iter()
+                    .map(|(address, ts)| (address, *ts)),
+            ),
+        }
     }
 
     /// Inserts tokens that are not yet cached; existing entries are left untouched,
@@ -615,6 +722,7 @@ impl TokenCache {
                 .collect(),
             chain_ids: HashMap::new(),
             last_sync: RwLock::new(NaiveDateTime::default()),
+            staged: Mutex::new(None),
         }
     }
 }
@@ -638,6 +746,8 @@ fn to_model_token(orm_token: &orm::Token, address: &Address, chain: Chain) -> To
 
 #[cfg(test)]
 mod test {
+    use std::slice;
+
     use chrono::DateTime;
 
     use super::*;
@@ -862,6 +972,75 @@ mod test {
         let cache = store_with_tokens(&[100]);
         let result = cache.query_tokens(&TokenQuery { chain: Chain::Base, ..base_query() });
         assert!(matches!(result, Err(StorageError::NotFound(_, _))));
+    }
+
+    fn total_traded_since(cache: &TokenCache, threshold: Option<NaiveDateTime>) -> Option<i64> {
+        cache
+            .query_tokens(&TokenQuery { last_traded_ts_threshold: threshold, ..base_query() })
+            .unwrap()
+            .total
+    }
+
+    #[test]
+    fn test_staging_buffers_until_commit() {
+        let cache = TokenCache::new_for_tests(&[Chain::Ethereum]);
+
+        cache.begin_staging();
+        cache.write_through_add_tokens(&[make_token(0, 100)]);
+        assert_eq!(total_traded_since(&cache, None), Some(0), "staged ops must not be visible");
+
+        cache.commit_staged();
+        assert_eq!(total_traded_since(&cache, None), Some(1), "committed ops must be visible");
+    }
+
+    #[test]
+    fn test_discard_drops_staged_ops() {
+        let cache = TokenCache::new_for_tests(&[Chain::Ethereum]);
+
+        cache.begin_staging();
+        cache.write_through_add_tokens(&[make_token(0, 100)]);
+        cache.discard_staged();
+        // A commit after discard must be a no-op, mirroring the executor's failure
+        // path followed by the next write's lifecycle.
+        cache.commit_staged();
+        assert_eq!(total_traded_since(&cache, None), Some(0), "discarded ops must never apply");
+    }
+
+    #[test]
+    fn test_retry_applies_staged_ops_exactly_once_and_in_order() {
+        let cache = TokenCache::new_for_tests(&[Chain::Ethereum]);
+        let token = make_token(0, 100);
+
+        // Attempt 1 fails and is discarded; attempt 2 stages the same data and
+        // commits — the deadlock-retry lifecycle in DBCacheWriteExecutor::write.
+        cache.begin_staging();
+        cache.write_through_add_tokens(slice::from_ref(&token));
+        cache.discard_staged();
+
+        cache.begin_staging();
+        cache.write_through_add_tokens(slice::from_ref(&token));
+        cache.write_through_update_last_traded(
+            Chain::Ethereum,
+            vec![(token.address.clone(), ts(2_000))],
+        );
+        cache.commit_staged();
+
+        assert_eq!(total_traded_since(&cache, None), Some(1));
+        // The traded filter only matches if UpdateLastTraded applied after
+        // AddTokens — ops must apply in push order.
+        assert_eq!(
+            total_traded_since(&cache, Some(ts(1_000))),
+            Some(1),
+            "ops must apply in push order"
+        );
+    }
+
+    #[test]
+    fn test_write_through_applies_immediately_without_session() {
+        let cache = TokenCache::new_for_tests(&[Chain::Ethereum]);
+        // No begin_staging: the DirectGateway topology. Mutations apply at once.
+        cache.write_through_add_tokens(&[make_token(0, 100)]);
+        assert_eq!(total_traded_since(&cache, None), Some(1));
     }
 }
 

--- a/crates/tycho-storage/src/postgres/token_cache.rs
+++ b/crates/tycho-storage/src/postgres/token_cache.rs
@@ -573,12 +573,12 @@ impl TokenCache {
 
     /// Inserts tokens that are not yet cached; existing entries are left untouched,
     /// mirroring the `ON CONFLICT DO NOTHING` insert semantics.
-    pub(crate) fn add_tokens(&self, tokens: &[Token]) {
+    fn add_tokens(&self, tokens: &[Token]) {
         self.write_tokens(tokens, false);
     }
 
     /// Inserts or overwrites tokens with the given values.
-    pub(crate) fn upsert_tokens(&self, tokens: &[Token]) {
+    fn upsert_tokens(&self, tokens: &[Token]) {
         self.write_tokens(tokens, true);
     }
 
@@ -604,7 +604,7 @@ impl TokenCache {
         }
     }
 
-    pub(crate) fn update_last_traded<'a>(
+    fn update_last_traded<'a>(
         &self,
         chain: &Chain,
         updates: impl Iterator<Item = (&'a Address, NaiveDateTime)>,

--- a/crates/tycho-storage/src/postgres/token_cache.rs
+++ b/crates/tycho-storage/src/postgres/token_cache.rs
@@ -68,11 +68,12 @@
 //! startup, and the gap grows with uptime. Only enable the cache in processes
 //! that write balances until the refresh also covers balance changes.
 //!
-//! Known limit: write-through runs while the enclosing DB transaction is still
-//! open, so on rollback the cache can run ahead of the database. This is
-//! harmless: only finalized block data reaches this path, so the cache still
-//! reflects on-chain state, and the database catches up when the write is
-//! retried or the extractor re-processes from its cursor.
+//! Write-through mutations computed inside the write executor's DB transaction
+//! are staged and applied only after the transaction commits, so a rollback —
+//! including one the process survives under in-process extractor restarts —
+//! never leaves the cache ahead of the database. Without an open staging
+//! session (the direct gateway's autocommitting calls, the delta refresh
+//! reading committed rows) mutations apply immediately.
 //!
 //! # Concurrency
 //!


### PR DESCRIPTION
## Problem

A write transaction that rolls back left the token cache ahead of the database. The cache then served phantom tokens that were never persisted, and `last_traded` timestamps advanced past any trade the database records. No refresh cycle removes either: the delta poll only ever inserts tokens and moves timestamps forward.

Found in review of #1302, not from a production incident. Today a write failure kills the process, so a restart reloads the cache and masks the divergence.

## Root cause

The three write-through sites in `protocol.rs` (`add_tokens`, `update_tokens`, `add_component_balances`) mutate the cache inline, while `DBCacheWriteExecutor::write` still holds the enclosing DB transaction open. The cache mutation is not part of that transaction, so a rollback undoes the SQL and keeps the cache mutation.

The extractor supervisor (#1026) removes the crash that hid this. Once the process survives a failed write, the divergence persists for the lifetime of the process.

## Fix

`TokenCache` gains a `CacheOp` staging buffer. The write-through sites now call `write_through_*` entry points, which buffer while a staging session is open and apply immediately otherwise. `DBCacheWriteExecutor::write` opens a session per transaction attempt and commits or discards the buffer based on the result, so a discarded retry cannot apply twice.

`add_tokens`, `upsert_tokens`, and `update_last_traded` are now private to `token_cache.rs`. The compiler rejects any future external call site that would bypass staging.

## Notes for reviewers

- Staged ops apply in push order on commit. `test_retry_applies_staged_ops_exactly_once_and_in_order` pins this.
- The refresh polls keep calling the direct methods on purpose: they read committed rows, so staging their results would be wrong.
- Without a staging session, mutations apply at once. This preserves `DirectGateway` semantics, guarded by `test_serial_db_cache_write_through`.

ENG-6331