### PR TITLE
fix: classify token analysis reverts as bad tokens

### DIFF
--- a/crates/tycho-ethereum/src/rpc/errors.rs
+++ b/crates/tycho-ethereum/src/rpc/errors.rs
@@ -90,11 +90,57 @@ impl RPCError {
             source: error,
         }))
     }
+
+    /// Returns true when the error is a JSON-RPC "execution reverted" response, i.e. the EVM
+    /// executed the call and reverted. Such failures are deterministic properties of the called
+    /// contract, not transport or provider issues.
+    pub fn is_execution_reverted(&self) -> bool {
+        let RPCError::RequestError(RequestError::Reqwest(e)) = self else {
+            return false;
+        };
+        let AlloyRpcError::ErrorResp(payload) = &e.source else {
+            return false;
+        };
+        // EIP-1474 reserves code 3 for eth_call reverts; some providers surface reverts
+        // under generic codes (e.g. -32000) with an "execution reverted" message instead.
+        payload.code == 3 ||
+            payload
+                .message
+                .to_lowercase()
+                .contains("execution reverted")
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::redact_url_paths;
+    use alloy::rpc::json_rpc::ErrorPayload;
+    use rstest::rstest;
+
+    use super::{redact_url_paths, AlloyRpcError, RPCError, TransportErrorKind};
+
+    #[rstest]
+    #[case::eip_1474_revert_code(3, "execution reverted", true)]
+    #[case::revert_under_generic_code(-32000, "execution reverted: something", true)]
+    #[case::header_not_found(-32000, "header not found", false)]
+    #[case::invalid_request(-32600, "invalid request", false)]
+    fn is_execution_reverted_classification(
+        #[case] code: i64,
+        #[case] message: &str,
+        #[case] expected: bool,
+    ) {
+        let payload = ErrorPayload { code, message: message.to_string().into(), data: None };
+        let err = RPCError::from_alloy(
+            "eth_call failed",
+            AlloyRpcError::<TransportErrorKind>::ErrorResp(payload),
+        );
+        assert_eq!(err.is_execution_reverted(), expected);
+    }
+
+    #[test]
+    fn is_execution_reverted_false_for_non_request_errors() {
+        assert!(!RPCError::SetupError("bad url".to_string()).is_execution_reverted());
+        assert!(!RPCError::UnknownError("boom".to_string()).is_execution_reverted());
+    }
 
     #[test]
     fn redacts_path_component() {

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -143,11 +143,24 @@ impl EthCallDetector {
             },
         );
 
-        let raw: AlloyBytes = self
+        let raw: AlloyBytes = match self
             .rpc
             .eth_call_with_state_overrides(tx, block_tag, overrides)
             .await
-            .map_err(|e| format!("eth_call with state overrides failed: {e}"))?;
+        {
+            Ok(raw) => raw,
+            // A revert is caused by the token itself (e.g. balanceOf reverting), not by the
+            // RPC: the injected Analyzer only propagates reverts raised by token calls.
+            // Report it as a Bad verdict so callers stop retrying the token indefinitely.
+            Err(e) if e.is_execution_reverted() => {
+                return Ok((
+                    TokenQuality::bad(format!("Token analysis simulation reverted: {e}")),
+                    None,
+                    None,
+                ))
+            }
+            Err(e) => return Err(format!("eth_call with state overrides failed: {e}")),
+        };
 
         let returns = analyzeCall::abi_decode_returns(raw.as_ref())
             .map_err(|e| format!("Failed to decode Analyzer return value: {e}"))?;
@@ -263,7 +276,7 @@ impl EthCallDetector {
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc};
+    use std::{collections::HashMap, str::FromStr, sync::Arc};
 
     use alloy::primitives::{address, Address};
     use tycho_common::models::token::{TokenOwnerStore, TokenQuality};
@@ -358,6 +371,41 @@ mod tests {
             let finder = TokenOwnerStore::new(TOKEN_HOLDERS.clone());
             EthCallDetector::new(&rpc, Arc::new(finder), COWSWAP_SETTLEMENT)
         }
+    }
+
+    #[tokio::test]
+    async fn detect_impl_maps_execution_revert_to_bad() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":0,"error":{"code":3,"message":"execution reverted","data":"0x"}}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let rpc = EthereumRpcClient::new(&server.url()).expect("mock rpc client");
+        let token = Bytes::from_str("e172e9b6cfbeeb5593bdce3f077356fdb33af904").unwrap();
+        let holder = Bytes::from_str("000000000004444c5dc75cb358380d2e3de08a90").unwrap();
+        let finder = TokenOwnerStore::new(HashMap::from([(
+            token.clone(),
+            (holder, U256::from(1_000_000_u64).to_bytes()),
+        )]));
+        let detector = EthCallDetector::new(&rpc, Arc::new(finder), COWSWAP_SETTLEMENT);
+
+        let (quality, gas, tax) = detector
+            .analyze(token, BlockTag::Latest)
+            .await
+            .expect("a reverting simulation must yield a Bad verdict, not an error");
+
+        assert!(matches!(quality, TokenQuality::Bad { .. }));
+        assert!(gas.is_none());
+        assert!(tax.is_none());
+        mock.assert_async().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The nightly `analyze-tokens` job retries the same broken tokens forever. On mainnet it warns ~300 times per run with `execution reverted`, finishes in seconds, and the retry backlog (quality 6–10) grew from 270 to 622 tokens over 30 days.

## Root cause

Some tokens revert when the analyzer calls them (for example on `balanceOf`). The detector reported this revert as an RPC error, and the job skips errors without lowering quality. So these tokens never leave the retry window.

## Fix

Treat an `execution reverted` response as a bad token instead of an error. The job then lowers the token's quality each night until it drops out of the retry window. Real transport and provider errors are still skipped without a quality change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)