### PR TITLE
feat: re-analyze recently traded quality-5 tokens

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -169,7 +169,7 @@ Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREAD
 |---|---|
 | `index` | Run all extractors from `extractors.yaml` + HTTP/WS server |
 | `run` | Run a single extractor (testing / debugging) |
-| `analyze-tokens` | Token quality analysis cron job; accepts `--settlement-contract <ADDRESS>` (default: CoW Swap settlement `0xc9f2e6ea1637E499406986ac50ddC92401ce1f58`) |
+| `analyze-tokens` | Token quality analysis cron job; accepts `--settlement-contract <ADDRESS>` (default: CoW Swap settlement `0xc9f2e6ea1637E499406986ac50ddC92401ce1f58`) and `--revive-traded-days <N>` (default 1: re-check quality-5 tokens traded within N days; Bad keeps 5) |
 | `rpc` | HTTP RPC server only (no extractors) |
 
 ### Feature flags

--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -169,7 +169,7 @@ Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREAD
 |---|---|
 | `index` | Run all extractors from `extractors.yaml` + HTTP/WS server |
 | `run` | Run a single extractor (testing / debugging) |
-| `analyze-tokens` | Token quality analysis cron job; accepts `--settlement-contract <ADDRESS>` (default: CoW Swap settlement `0xc9f2e6ea1637E499406986ac50ddC92401ce1f58`) and `--revive-traded-days <N>` (default 1: re-check quality-5 tokens traded within N days; Bad keeps 5) |
+| `analyze-tokens` | Token quality analysis cron job; accepts `--settlement-contract <ADDRESS>` (default: CoW Swap settlement `0xc9f2e6ea1637E499406986ac50ddC92401ce1f58`) and `--recovery-lookback-days <N>` (default 1: re-check quality-5 tokens traded within N days; Bad keeps 5) |
 | `rpc` | HTTP RPC server only (no extractors) |
 
 ### Feature flags

--- a/crates/tycho-indexer/src/cli.rs
+++ b/crates/tycho-indexer/src/cli.rs
@@ -294,6 +294,12 @@ pub struct AnalyzeTokenArgs {
     /// should be at least `concurrency * update_batch_size`.
     #[clap(long)]
     pub fetch_batch_size: usize,
+    /// Also re-analyze quality-5 tokens that traded within this many days. Quality 5 is
+    /// otherwise a dead end; this revives tokens whose behavior changed after listing
+    /// (e.g. launch transfer restrictions lifted). Set to 0 to disable; a large value
+    /// re-checks every quality-5 token with active liquidity (backfill).
+    #[clap(long, default_value_t = 1)]
+    pub revive_traded_days: u64,
 }
 
 #[cfg(test)]

--- a/crates/tycho-indexer/src/cli.rs
+++ b/crates/tycho-indexer/src/cli.rs
@@ -295,11 +295,12 @@ pub struct AnalyzeTokenArgs {
     #[clap(long)]
     pub fetch_batch_size: usize,
     /// Also re-analyze quality-5 tokens that traded within this many days. Quality 5 is
-    /// otherwise a dead end; this revives tokens whose behavior changed after listing
-    /// (e.g. launch transfer restrictions lifted). Set to 0 to disable; a large value
-    /// re-checks every quality-5 token with active liquidity (backfill).
+    /// the analysis floor and is otherwise never revisited; a recently traded token gets
+    /// a recovery pass because its behavior may have changed after listing (e.g. launch
+    /// transfer restrictions lifted). Set to 0 to disable; a large value re-checks every
+    /// quality-5 token with active liquidity (backfill).
     #[clap(long, default_value_t = 1)]
-    pub revive_traded_days: u64,
+    pub recovery_lookback_days: u32,
 }
 
 #[cfg(test)]

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -27,13 +27,13 @@ pub async fn analyze_tokens(
     // Skip tokens that failed previously and ones we already analyzed successfully
     run_analysis_pass(&analyze_args, rpc, gw.clone(), QualityRange::new(6, 10), None, true).await?;
 
-    if analyze_args.revive_traded_days > 0 {
-        // Quality 5 is a dead end: the pass above never retries it. Re-check quality-5
-        // tokens that traded recently — their behavior may have changed since they were
-        // damned (e.g. launch transfer restrictions lifted). A Bad verdict keeps them
-        // at 5 instead of demoting further.
+    if analyze_args.recovery_lookback_days > 0 {
+        // Quality 5 is the analysis floor: the pass above never revisits it. Re-check
+        // floored tokens that traded recently — their behavior may have changed since
+        // analysis gave up (e.g. launch transfer restrictions lifted). A Bad verdict
+        // keeps them at 5 instead of demoting further.
         let traded_since = chrono::Utc::now().naive_utc() -
-            chrono::Duration::days(analyze_args.revive_traded_days as i64);
+            chrono::Duration::days(analyze_args.recovery_lookback_days as i64);
         run_analysis_pass(
             &analyze_args,
             rpc,
@@ -207,7 +207,7 @@ async fn analyze_batch(
 ///
 /// Good tokens go to 100 and fee tokens to 50. A Bad verdict lowers quality by one so the
 /// token eventually leaves the 6–10 retry window — except when `demote_on_bad` is false
-/// (revive pass): the token already sits at quality 5 and stays there.
+/// (recovery pass): the token already sits at quality 5 and stays there.
 fn apply_analysis(
     t: &mut Token,
     token_quality: TokenQuality,
@@ -266,8 +266,8 @@ mod test {
     #[rstest]
     #[case::good_promotes(TokenQuality::Good, 8, true, 100)]
     #[case::bad_demotes(TokenQuality::bad("transfer failed"), 8, true, 7)]
-    #[case::bad_keeps_quality_in_revive_pass(TokenQuality::bad("transfer failed"), 5, false, 5)]
-    #[case::good_promotes_in_revive_pass(TokenQuality::Good, 5, false, 100)]
+    #[case::bad_keeps_quality_in_recovery_pass(TokenQuality::bad("transfer failed"), 5, false, 5)]
+    #[case::good_promotes_in_recovery_pass(TokenQuality::Good, 5, false, 100)]
     fn test_apply_analysis_quality(
         #[case] verdict: TokenQuality,
         #[case] initial_quality: u32,
@@ -310,7 +310,7 @@ mod test {
             concurrency: 10,
             update_batch_size: 100,
             fetch_batch_size: 100,
-            revive_traded_days: 0,
+            recovery_lookback_days: 0,
         };
         let mut gw = testing::MockGateway::new();
         gw.expect_get_tokens()

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Instant};
 
+use chrono::NaiveDateTime;
 use futures03::{future::try_join_all, FutureExt};
 use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
@@ -7,7 +8,7 @@ use tycho_common::{
     models::{
         blockchain::BlockTag,
         protocol::QualityRange,
-        token::{Token, TokenOwnerStore, TokenQuality},
+        token::{Token, TokenOwnerStore, TokenQuality, TransferCost, TransferTax},
         Chain, PaginationParams,
     },
     storage::ProtocolGateway,
@@ -23,6 +24,38 @@ pub async fn analyze_tokens(
     rpc: &EthereumRpcClient,
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
 ) -> anyhow::Result<()> {
+    // Skip tokens that failed previously and ones we already analyzed successfully
+    run_analysis_pass(&analyze_args, rpc, gw.clone(), QualityRange::new(6, 10), None, true).await?;
+
+    if analyze_args.revive_traded_days > 0 {
+        // Quality 5 is a dead end: the pass above never retries it. Re-check quality-5
+        // tokens that traded recently — their behavior may have changed since they were
+        // damned (e.g. launch transfer restrictions lifted). A Bad verdict keeps them
+        // at 5 instead of demoting further.
+        let traded_since = chrono::Utc::now().naive_utc() -
+            chrono::Duration::days(analyze_args.revive_traded_days as i64);
+        run_analysis_pass(
+            &analyze_args,
+            rpc,
+            gw,
+            QualityRange::new(5, 5),
+            Some(traded_since),
+            false,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn run_analysis_pass(
+    analyze_args: &AnalyzeTokenArgs,
+    rpc: &EthereumRpcClient,
+    gw: Arc<dyn ProtocolGateway + Send + Sync>,
+    quality_range: QualityRange,
+    traded_since: Option<NaiveDateTime>,
+    demote_on_bad: bool,
+) -> anyhow::Result<()> {
     let mut tokens = Vec::new();
     let mut page = 0;
     let page_size = analyze_args.fetch_batch_size as i64;
@@ -33,9 +66,8 @@ pub async fn analyze_tokens(
             &(gw.get_tokens(
                 analyze_args.chain,
                 None,
-                // Skip tokens that failed previously and ones we already analyzed successfully
-                QualityRange::new(6, 10),
-                None,
+                quality_range.clone(),
+                traded_since,
                 Some(&pagination_params),
             )
             .await?
@@ -52,6 +84,7 @@ pub async fn analyze_tokens(
                     sem.clone(),
                     gw.clone(),
                     analyze_args.settlement_contract,
+                    demote_on_bad,
                 )
                 .boxed()
             })
@@ -59,7 +92,13 @@ pub async fn analyze_tokens(
 
         _ = try_join_all(tasks).await?;
         let duration = Instant::now().duration_since(start);
-        info!(processed = tokens.len(), page = page, duration = duration.as_secs(), "Progress");
+        info!(
+            processed = tokens.len(),
+            page = page,
+            duration = duration.as_secs(),
+            demote_on_bad,
+            "Progress"
+        );
 
         page += 1;
         if tokens.len() < (page_size as usize) {
@@ -77,6 +116,7 @@ async fn analyze_batch(
     sem: Arc<Semaphore>,
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
     settlement_contract: alloy::primitives::Address,
+    demote_on_bad: bool,
 ) -> anyhow::Result<()> {
     let _guard = sem.acquire().await?;
     let addresses = tokens
@@ -154,26 +194,7 @@ async fn analyze_batch(
             }
         };
 
-        match token_quality {
-            TokenQuality::Good => {
-                t.quality = 100;
-            }
-            TokenQuality::Bad { reason } => {
-                debug!(?t.address, ?reason, "Token quality detected as bad!");
-                // Remove 1 to the quality for each attempt. If it fails 5 times we won't try again.
-                t.quality -= 1;
-            }
-        }
-
-        // If it's a fee token, set quality to 50
-        if tax.is_some_and(|tax_value| tax_value > 0) {
-            t.quality = 50;
-        }
-
-        t.tax = tax.unwrap_or(0);
-        t.gas = gas
-            .map(|g| vec![Some(g)])
-            .unwrap_or_else(Vec::new);
+        apply_analysis(t, token_quality, gas, tax, demote_on_bad);
     }
 
     if !tokens.is_empty() {
@@ -182,9 +203,46 @@ async fn analyze_batch(
     Ok(())
 }
 
+/// Applies an analysis verdict to the token's quality, gas and tax fields.
+///
+/// Good tokens go to 100 and fee tokens to 50. A Bad verdict lowers quality by one so the
+/// token eventually leaves the 6–10 retry window — except when `demote_on_bad` is false
+/// (revive pass): the token already sits at quality 5 and stays there.
+fn apply_analysis(
+    t: &mut Token,
+    token_quality: TokenQuality,
+    gas: Option<TransferCost>,
+    tax: Option<TransferTax>,
+    demote_on_bad: bool,
+) {
+    match token_quality {
+        TokenQuality::Good => {
+            t.quality = 100;
+        }
+        TokenQuality::Bad { reason } => {
+            debug!(?t.address, ?reason, "Token quality detected as bad!");
+            // Remove 1 to the quality for each attempt. If it fails 5 times we won't try again.
+            if demote_on_bad {
+                t.quality -= 1;
+            }
+        }
+    }
+
+    // If it's a fee token, set quality to 50
+    if tax.is_some_and(|tax_value| tax_value > 0) {
+        t.quality = 50;
+    }
+
+    t.tax = tax.unwrap_or(0);
+    t.gas = gas
+        .map(|g| vec![Some(g)])
+        .unwrap_or_else(Vec::new);
+}
+
 #[cfg(test)]
 mod test {
     use chrono::NaiveDateTime;
+    use rstest::rstest;
     use tycho_common::{
         models::{protocol::ProtocolComponent, ChangeType},
         storage::WithTotal,
@@ -192,6 +250,50 @@ mod test {
 
     use super::*;
     use crate::testing;
+
+    fn test_token(quality: u32) -> Token {
+        Token::new(
+            &Bytes::from("0xe172e9b6cfbeeb5593bdce3f077356fdb33af904"),
+            "FOLD",
+            18,
+            0,
+            &[],
+            Chain::Ethereum,
+            quality,
+        )
+    }
+
+    #[rstest]
+    #[case::good_promotes(TokenQuality::Good, 8, true, 100)]
+    #[case::bad_demotes(TokenQuality::bad("transfer failed"), 8, true, 7)]
+    #[case::bad_keeps_quality_in_revive_pass(TokenQuality::bad("transfer failed"), 5, false, 5)]
+    #[case::good_promotes_in_revive_pass(TokenQuality::Good, 5, false, 100)]
+    fn test_apply_analysis_quality(
+        #[case] verdict: TokenQuality,
+        #[case] initial_quality: u32,
+        #[case] demote_on_bad: bool,
+        #[case] expected_quality: u32,
+    ) {
+        let mut t = test_token(initial_quality);
+
+        apply_analysis(&mut t, verdict, Some(30_000), Some(0), demote_on_bad);
+
+        assert_eq!(t.quality, expected_quality);
+        assert_eq!(t.gas, vec![Some(30_000)]);
+        assert_eq!(t.tax, 0);
+    }
+
+    #[rstest]
+    #[case::with_demotion(true)]
+    #[case::without_demotion(false)]
+    fn test_apply_analysis_fee_token_sets_50(#[case] demote_on_bad: bool) {
+        let mut t = test_token(5);
+
+        apply_analysis(&mut t, TokenQuality::Good, Some(30_000), Some(250), demote_on_bad);
+
+        assert_eq!(t.quality, 50);
+        assert_eq!(t.tax, 250);
+    }
 
     // requires a running ethereum node
     #[ignore = "require RPC connection"]
@@ -208,6 +310,7 @@ mod test {
             concurrency: 10,
             update_batch_size: 100,
             fetch_batch_size: 100,
+            revive_traded_days: 0,
         };
         let mut gw = testing::MockGateway::new();
         gw.expect_get_tokens()

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -416,6 +416,66 @@ mod test {
             .expect("analyze tokens failed");
     }
 
+    fn wiring_args(recovery_lookback_days: u32) -> AnalyzeTokenArgs {
+        AnalyzeTokenArgs {
+            chain: Chain::Ethereum,
+            settlement_contract: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+                .parse()
+                .unwrap(),
+            concurrency: 1,
+            update_batch_size: 10,
+            fetch_batch_size: 10,
+            recovery_lookback_days,
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_analyze_tokens_runs_recovery_pass_after_retry_pass() {
+        let rpc = EthereumRpcClient::new("http://localhost:1").expect("url parses");
+        let mut seq = Sequence::new();
+        let mut gw = testing::MockGateway::new();
+        gw.expect_get_tokens()
+            .withf(|_, _, quality, traded_since, _| {
+                quality.min == Some(6) && quality.max == Some(10) && traded_since.is_none()
+            })
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_get_tokens()
+            .withf(|_, _, quality, traded_since, _| {
+                quality.min == Some(5) && quality.max == Some(5) && traded_since.is_some()
+            })
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+
+        analyze_tokens(wiring_args(1), &rpc, Arc::new(gw))
+            .await
+            .expect("analyze tokens failed");
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_recovery_pass_disabled_at_zero() {
+        let rpc = EthereumRpcClient::new("http://localhost:1").expect("url parses");
+        let mut gw = testing::MockGateway::new();
+        gw.expect_get_tokens()
+            .withf(|_, _, quality, traded_since, _| {
+                quality.min == Some(6) && quality.max == Some(10) && traded_since.is_none()
+            })
+            .times(1)
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+
+        analyze_tokens(wiring_args(0), &rpc, Arc::new(gw))
+            .await
+            .expect("analyze tokens failed");
+    }
+
     fn outcome_test_gateway() -> testing::MockGateway {
         let mut gw = testing::MockGateway::new();
         gw.expect_get_token_owners()

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -25,7 +25,15 @@ pub async fn analyze_tokens(
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
 ) -> anyhow::Result<()> {
     // Skip tokens that failed previously and ones we already analyzed successfully
-    run_analysis_pass(&analyze_args, rpc, gw.clone(), QualityRange::new(6, 10), None, true).await?;
+    run_analysis_pass(
+        &analyze_args,
+        rpc,
+        gw.clone(),
+        QualityRange::new(6, 10),
+        None,
+        AnalysisPass::Retry,
+    )
+    .await?;
 
     if analyze_args.recovery_lookback_days > 0 {
         // Quality 5 is the analysis floor: the pass above never revisits it. Re-check
@@ -40,12 +48,21 @@ pub async fn analyze_tokens(
             gw,
             QualityRange::new(5, 5),
             Some(traded_since),
-            false,
+            AnalysisPass::Recovery,
         )
         .await?;
     }
 
     Ok(())
+}
+
+/// The retry pass demotes on a Bad verdict so tokens eventually leave the 6–10 retry
+/// window. The recovery pass re-checks floored (quality-5) tokens, which stay at the
+/// floor on Bad.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum AnalysisPass {
+    Retry,
+    Recovery,
 }
 
 async fn run_analysis_pass(
@@ -54,7 +71,7 @@ async fn run_analysis_pass(
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
     quality_range: QualityRange,
     traded_since: Option<NaiveDateTime>,
-    demote_on_bad: bool,
+    pass: AnalysisPass,
 ) -> anyhow::Result<()> {
     let mut tokens = Vec::new();
     let mut page = 0;
@@ -84,7 +101,7 @@ async fn run_analysis_pass(
                     sem.clone(),
                     gw.clone(),
                     analyze_args.settlement_contract,
-                    demote_on_bad,
+                    pass,
                 )
                 .boxed()
             })
@@ -96,7 +113,7 @@ async fn run_analysis_pass(
             processed = tokens.len(),
             page = page,
             duration = duration.as_secs(),
-            demote_on_bad,
+            ?pass,
             "Progress"
         );
 
@@ -116,7 +133,7 @@ async fn analyze_batch(
     sem: Arc<Semaphore>,
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
     settlement_contract: alloy::primitives::Address,
-    demote_on_bad: bool,
+    pass: AnalysisPass,
 ) -> anyhow::Result<()> {
     let _guard = sem.acquire().await?;
     let addresses = tokens
@@ -194,7 +211,7 @@ async fn analyze_batch(
             }
         };
 
-        apply_analysis(t, token_quality, gas, tax, demote_on_bad);
+        apply_analysis(t, token_quality, gas, tax, pass);
     }
 
     if !tokens.is_empty() {
@@ -205,15 +222,15 @@ async fn analyze_batch(
 
 /// Applies an analysis verdict to the token's quality, gas and tax fields.
 ///
-/// Good tokens go to 100 and fee tokens to 50. A Bad verdict lowers quality by one so the
-/// token eventually leaves the 6–10 retry window — except when `demote_on_bad` is false
-/// (recovery pass): the token already sits at quality 5 and stays there.
+/// Good tokens go to 100 and fee tokens to 50. A Bad verdict lowers quality by one in the
+/// retry pass so the token eventually leaves the 6–10 retry window; the recovery pass
+/// keeps quality-5 tokens at the floor.
 fn apply_analysis(
     t: &mut Token,
     token_quality: TokenQuality,
     gas: Option<TransferCost>,
     tax: Option<TransferTax>,
-    demote_on_bad: bool,
+    pass: AnalysisPass,
 ) {
     match token_quality {
         TokenQuality::Good => {
@@ -221,9 +238,11 @@ fn apply_analysis(
         }
         TokenQuality::Bad { reason } => {
             debug!(?t.address, ?reason, "Token quality detected as bad!");
-            // Remove 1 to the quality for each attempt. If it fails 5 times we won't try again.
-            if demote_on_bad {
-                t.quality -= 1;
+            match pass {
+                // Remove 1 per attempt; after 5 failures the token leaves the retry window.
+                AnalysisPass::Retry => t.quality -= 1,
+                // Already at the quality-5 floor.
+                AnalysisPass::Recovery => {}
             }
         }
     }
@@ -264,19 +283,24 @@ mod test {
     }
 
     #[rstest]
-    #[case::good_promotes(TokenQuality::Good, 8, true, 100)]
-    #[case::bad_demotes(TokenQuality::bad("transfer failed"), 8, true, 7)]
-    #[case::bad_keeps_quality_in_recovery_pass(TokenQuality::bad("transfer failed"), 5, false, 5)]
-    #[case::good_promotes_in_recovery_pass(TokenQuality::Good, 5, false, 100)]
+    #[case::good_promotes(TokenQuality::Good, 8, AnalysisPass::Retry, 100)]
+    #[case::bad_demotes(TokenQuality::bad("transfer failed"), 8, AnalysisPass::Retry, 7)]
+    #[case::bad_keeps_quality_in_recovery_pass(
+        TokenQuality::bad("transfer failed"),
+        5,
+        AnalysisPass::Recovery,
+        5
+    )]
+    #[case::good_promotes_in_recovery_pass(TokenQuality::Good, 5, AnalysisPass::Recovery, 100)]
     fn test_apply_analysis_quality(
         #[case] verdict: TokenQuality,
         #[case] initial_quality: u32,
-        #[case] demote_on_bad: bool,
+        #[case] pass: AnalysisPass,
         #[case] expected_quality: u32,
     ) {
         let mut t = test_token(initial_quality);
 
-        apply_analysis(&mut t, verdict, Some(30_000), Some(0), demote_on_bad);
+        apply_analysis(&mut t, verdict, Some(30_000), Some(0), pass);
 
         assert_eq!(t.quality, expected_quality);
         assert_eq!(t.gas, vec![Some(30_000)]);
@@ -284,12 +308,12 @@ mod test {
     }
 
     #[rstest]
-    #[case::with_demotion(true)]
-    #[case::without_demotion(false)]
-    fn test_apply_analysis_fee_token_sets_50(#[case] demote_on_bad: bool) {
+    #[case::retry_pass(AnalysisPass::Retry)]
+    #[case::recovery_pass(AnalysisPass::Recovery)]
+    fn test_apply_analysis_fee_token_sets_50(#[case] pass: AnalysisPass) {
         let mut t = test_token(5);
 
-        apply_analysis(&mut t, TokenQuality::Good, Some(30_000), Some(250), demote_on_bad);
+        apply_analysis(&mut t, TokenQuality::Good, Some(30_000), Some(250), pass);
 
         assert_eq!(t.quality, 50);
         assert_eq!(t.tax, 250);

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -308,12 +308,17 @@ mod test {
     }
 
     #[rstest]
-    #[case::retry_pass(AnalysisPass::Retry)]
-    #[case::recovery_pass(AnalysisPass::Recovery)]
-    fn test_apply_analysis_fee_token_sets_50(#[case] pass: AnalysisPass) {
+    #[case::good_in_retry_pass(TokenQuality::Good, AnalysisPass::Retry)]
+    #[case::good_in_recovery_pass(TokenQuality::Good, AnalysisPass::Recovery)]
+    #[case::bad_in_retry_pass(TokenQuality::bad("transfer failed"), AnalysisPass::Retry)]
+    #[case::bad_in_recovery_pass(TokenQuality::bad("transfer failed"), AnalysisPass::Recovery)]
+    fn test_apply_analysis_fee_token_sets_50(
+        #[case] verdict: TokenQuality,
+        #[case] pass: AnalysisPass,
+    ) {
         let mut t = test_token(5);
 
-        apply_analysis(&mut t, TokenQuality::Good, Some(30_000), Some(250), pass);
+        apply_analysis(&mut t, verdict, Some(30_000), Some(250), pass);
 
         assert_eq!(t.quality, 50);
         assert_eq!(t.tax, 250);

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -73,14 +73,15 @@ async fn run_analysis_pass(
     traded_since: Option<NaiveDateTime>,
     pass: AnalysisPass,
 ) -> anyhow::Result<()> {
+    // Fetch every matching token before analyzing: analysis promotes tokens out of the
+    // quality filter, which shifts OFFSET pages and would skip rows mid-run.
     let mut tokens = Vec::new();
     let mut page = 0;
     let page_size = analyze_args.fetch_batch_size as i64;
     loop {
-        let start = Instant::now();
         let pagination_params = PaginationParams::new(page, page_size);
-        tokens.clone_from(
-            &(gw.get_tokens(
+        let page_tokens = gw
+            .get_tokens(
                 analyze_args.chain,
                 None,
                 quality_range.clone(),
@@ -88,42 +89,63 @@ async fn run_analysis_pass(
                 Some(&pagination_params),
             )
             .await?
-            .entity),
-        );
-        let sem = Arc::new(Semaphore::new(analyze_args.concurrency));
-        let tasks = tokens
-            .chunks(analyze_args.update_batch_size)
-            .map(|chunk| {
-                analyze_batch(
-                    analyze_args.chain,
-                    rpc,
-                    chunk.to_vec(),
-                    sem.clone(),
-                    gw.clone(),
-                    analyze_args.settlement_contract,
-                    pass,
-                )
-                .boxed()
-            })
-            .collect::<Vec<_>>();
-
-        _ = try_join_all(tasks).await?;
-        let duration = Instant::now().duration_since(start);
-        info!(
-            processed = tokens.len(),
-            page = page,
-            duration = duration.as_secs(),
-            ?pass,
-            "Progress"
-        );
-
+            .entity;
+        let page_len = page_tokens.len();
+        tokens.extend(page_tokens);
         page += 1;
-        if tokens.len() < (page_size as usize) {
+        if page_len < (page_size as usize) {
             break;
         }
     }
+    info!(matched = tokens.len(), ?pass, "Starting analysis pass");
+
+    let start = Instant::now();
+    let sem = Arc::new(Semaphore::new(analyze_args.concurrency));
+    let tasks = tokens
+        .chunks(analyze_args.update_batch_size)
+        .map(|chunk| {
+            analyze_batch(
+                analyze_args.chain,
+                rpc,
+                chunk.to_vec(),
+                sem.clone(),
+                gw.clone(),
+                analyze_args.settlement_contract,
+                pass,
+            )
+            .boxed()
+        })
+        .collect::<Vec<_>>();
+
+    let outcomes = try_join_all(tasks).await?;
+    let mut totals = PassOutcome::default();
+    for outcome in outcomes {
+        totals.promoted += outcome.promoted;
+        totals.demoted += outcome.demoted;
+        totals.unchanged += outcome.unchanged;
+        totals.failed += outcome.failed;
+    }
+    let duration = Instant::now().duration_since(start);
+    info!(
+        ?pass,
+        analyzed = tokens.len(),
+        promoted = totals.promoted,
+        demoted = totals.demoted,
+        unchanged = totals.unchanged,
+        failed = totals.failed,
+        duration = duration.as_secs(),
+        "Analysis pass complete"
+    );
 
     Ok(())
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct PassOutcome {
+    promoted: usize,
+    demoted: usize,
+    unchanged: usize,
+    failed: usize,
 }
 
 async fn analyze_batch(
@@ -134,7 +156,7 @@ async fn analyze_batch(
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
     settlement_contract: alloy::primitives::Address,
     pass: AnalysisPass,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PassOutcome> {
     let _guard = sem.acquire().await?;
     let addresses = tokens
         .iter()
@@ -198,26 +220,36 @@ async fn analyze_batch(
         Arc::new(TokenOwnerStore::new(liquidity_token_owners)),
         settlement_contract,
     );
+    let mut outcome = PassOutcome::default();
     for t in tokens.iter_mut() {
         debug!(?t.address, "Analyzing token");
         let (token_quality, gas, tax) = match analyzer
             .analyze(t.address.clone(), BlockTag::Latest)
             .await
         {
-            Ok(t) => t,
+            Ok(res) => res,
             Err(error) => {
                 warn!(?error, "Token quality detection failed");
+                outcome.failed += 1;
                 continue;
             }
         };
 
+        let quality_before = t.quality;
         apply_analysis(t, token_quality, gas, tax, pass);
+        if t.quality > quality_before {
+            outcome.promoted += 1;
+        } else if t.quality < quality_before {
+            outcome.demoted += 1;
+        } else {
+            outcome.unchanged += 1;
+        }
     }
 
     if !tokens.is_empty() {
         gw.update_tokens(&tokens).await?;
     }
-    Ok(())
+    Ok(outcome)
 }
 
 /// Applies an analysis verdict to the token's quality, gas and tax fields.
@@ -261,6 +293,7 @@ fn apply_analysis(
 #[cfg(test)]
 mod test {
     use chrono::NaiveDateTime;
+    use mockall::Sequence;
     use rstest::rstest;
     use tycho_common::{
         models::{protocol::ProtocolComponent, ChangeType},
@@ -280,6 +313,10 @@ mod test {
             Chain::Ethereum,
             quality,
         )
+    }
+
+    fn test_token_at(address: &str, quality: u32) -> Token {
+        Token::new(&Bytes::from(address), "TEST", 18, 0, &[], Chain::Ethereum, quality)
     }
 
     #[rstest]
@@ -322,6 +359,113 @@ mod test {
 
         assert_eq!(t.quality, 50);
         assert_eq!(t.tax, 250);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_pass_fetches_all_pages_before_analyzing() {
+        let rpc = EthereumRpcClient::new("http://localhost:1").expect("url parses");
+        let args = AnalyzeTokenArgs {
+            chain: Chain::Ethereum,
+            settlement_contract: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+                .parse()
+                .unwrap(),
+            concurrency: 1,
+            update_batch_size: 2,
+            fetch_batch_size: 2,
+            recovery_lookback_days: 0,
+        };
+        let mut seq = Sequence::new();
+        let mut gw = testing::MockGateway::new();
+        gw.expect_get_tokens()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, _, _| {
+                Box::pin(async {
+                    Ok(WithTotal {
+                        entity: vec![
+                            test_token_at("0x0000000000000000000000000000000000000001", 8),
+                            test_token_at("0x0000000000000000000000000000000000000002", 8),
+                        ],
+                        total: Some(2),
+                    })
+                })
+            });
+        gw.expect_get_tokens()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(2) }) })
+            });
+        gw.expect_get_token_owners()
+            .returning(|_, _, _| Box::pin(async { Ok(HashMap::new()) }));
+        gw.expect_get_protocol_components()
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_get_protocol_states()
+            .returning(|_, _, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_update_tokens()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        analyze_tokens(args, &rpc, Arc::new(gw))
+            .await
+            .expect("analyze tokens failed");
+    }
+
+    fn outcome_test_gateway() -> testing::MockGateway {
+        let mut gw = testing::MockGateway::new();
+        gw.expect_get_token_owners()
+            .returning(|_, _, _| Box::pin(async { Ok(HashMap::new()) }));
+        gw.expect_get_protocol_components()
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_get_protocol_states()
+            .returning(|_, _, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_update_tokens()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(()) }));
+        gw
+    }
+
+    async fn run_outcome_batch(pass: AnalysisPass, initial_quality: u32) -> PassOutcome {
+        let rpc = EthereumRpcClient::new("http://localhost:1").expect("url parses");
+        let tokens = vec![
+            test_token_at("0x0000000000000000000000000000000000000001", initial_quality),
+            test_token_at("0x0000000000000000000000000000000000000002", initial_quality),
+        ];
+        analyze_batch(
+            Chain::Ethereum,
+            &rpc,
+            tokens,
+            Arc::new(Semaphore::new(1)),
+            Arc::new(outcome_test_gateway()),
+            "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+                .parse()
+                .unwrap(),
+            pass,
+        )
+        .await
+        .expect("analyze batch failed")
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_retry_pass_counts_demotions() {
+        // No owner in the store -> analyzer returns Bad without RPC -> retry pass demotes.
+        let outcome = run_outcome_batch(AnalysisPass::Retry, 8).await;
+        assert_eq!(outcome, PassOutcome { demoted: 2, ..Default::default() });
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_recovery_pass_counts_unchanged() {
+        let outcome = run_outcome_batch(AnalysisPass::Recovery, 5).await;
+        assert_eq!(outcome, PassOutcome { unchanged: 2, ..Default::default() });
     }
 
     // requires a running ethereum node

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -287,7 +287,7 @@ fn apply_analysis(
     t.tax = tax.unwrap_or(0);
     t.gas = gas
         .map(|g| vec![Some(g)])
-        .unwrap_or_else(Vec::new);
+        .unwrap_or_default();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Quality 5 is the analysis floor: the `analyze-tokens` job only retries tokens with quality 6–10, so a token that fails its first 5 nightly analyses is never checked again. On mainnet, a manual re-check of the quality-5 backlog recovered ~3,350 tokens.

## Root cause

Nothing re-analyzes quality-5 tokens. Token behavior can change after listing (launch restrictions lift, liquidity arrives), but the verdict from the token's first week is permanent.

## Fix

Add a second pass to `analyze-tokens`: fetch quality-5 tokens that traded within the last `--recovery-lookback-days` (default 1, i.e. since the previous nightly run) and re-analyze them. Good tokens promote to 100 and fee tokens to 50, as usual. A Bad verdict keeps quality at 5 instead of demoting — the token is already at the floor.

The trade filter reuses the existing `traded_n_days_ago` parameter of `get_tokens` (an EXISTS on current `component_balance` rows), so no storage changes are needed. Measured on prod mainnet: 307 quality-5 tokens traded within 24h (~1–2 min of eth_calls per run); the query itself takes well under a second.

## Notes for reviewers

- `--recovery-lookback-days 0` disables the pass. A large value re-checks every quality-5 token with active liquidity — usable as a one-time backfill per chain.
- Verdict application is extracted into `apply_analysis` with unit tests for the promote/demote/floor/fee cases.
- Re-tested honeypots stay at 5 at no extra risk: they are re-analyzed only while actively traded, ~300/night on mainnet.

## Extra

- Each pass now fetches all matching tokens before analyzing, so promotions cannot shift OFFSET pages mid-run. This also covers the backfill mode.
- Each pass logs a completion summary: promoted / demoted / unchanged / failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)