### PR TITLE
feat(execution): Dispatcher-level per-hop fallback executors

### DIFF
--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -202,6 +202,22 @@ Returns either:
 
 Last swap's receiver is the final user/vault address.
 
+### Per-hop fallback executors
+
+Any hop may carry a fallback executor. The hop's executor slot holds `LibSwap.FALLBACK_MARKER` (`address(0)`, never an
+approved executor) followed by `uint16 primaryLength || primary || fallback`, where primary and fallback are each
+`executor (20 bytes) || protocolData`. Hops without a fallback are byte-identical to the plain layout.
+
+`Dispatcher._dispatchSwap` routes every hop: a plain hop goes straight to `_callSwapOnExecutor`; a fallback hop runs the
+primary through `trySwapOnExecutor` (an external self-call, `msg.sender == address(this)` only) wrapped in try/catch. A
+revert in the primary rolls back the whole sub-call — transfers, delta accounting, transient storage — and the fallback
+executor re-runs the full swap flow (its own `getTransferData`, transfer, delegatecall) on clean state. Primary and
+fallback may therefore be any protocol types; there are no compatibility constraints between them.
+
+Two invariants keep funds safe: sequential receiver resolution sends a fallback hop's input to the router (never
+pre-positioned at the primary pool, where a primary revert would strand them), and both legs run with
+`isSplitSwap = true` so the transfer-from-router path executes instead of the pre-positioning optimization.
+
 ## Rust Encoding Pipeline (`src/encoding/`)
 
 Encodes a `Solution` into EVM calldata through three trait layers:
@@ -232,6 +248,12 @@ group is PLE-encoded (`[len: u16][data]...`); Ekubo uses concatenation instead (
 **Swap grouping** (`evm/group_swaps.rs`): Consecutive swaps on the same groupable protocol (UniswapV4, BalancerV3,
 Ekubo) are batched into a single `SwapGroup` and executed via one delegatecall. The `SingleSwapStrategyEncoder` can also
 encode an entire multi-pool route as a single swap if all hops are on the same groupable protocol.
+
+**Fallback swaps**: `Swap::with_fallback_swap(Swap)` attaches a fallback executed by the router when the primary's
+executor reverts. The fallback must swap the same token pair, carry no split, and not nest another fallback. A
+fallback-carrying swap is never grouped. All three strategy encoders emit the fallback bundle
+(`FALLBACK_MARKER || uint16 primaryLength || primary || fallback`); `TychoExecutorEncoder` rejects fallback swaps
+(they need the TychoRouter's try/catch).
 
 ### SwapEncoder
 

--- a/crates/tycho-execution/contracts/lib/LibSwap.sol
+++ b/crates/tycho-execution/contracts/lib/LibSwap.sol
@@ -3,6 +3,14 @@ pragma solidity ^0.8.26;
 
 library LibSwap {
     /**
+     * @dev Sentinel value in a hop's executor slot marking that the hop
+     * carries a fallback bundle instead of a plain executor + protocol data
+     * pair. `address(0)` is never an approved executor, so the marker is
+     * unambiguous. Hops without a fallback keep the existing layout.
+     */
+    address internal constant FALLBACK_MARKER = address(0);
+
+    /**
      * @dev Returns arguments required to perform a single swap
      */
     function decodeSingleSwap(bytes calldata swap)
@@ -39,5 +47,30 @@ library LibSwap {
         split = uint24(bytes3(swap[2:5]));
         executor = address(uint160(bytes20(swap[5:25])));
         protocolData = swap[25:];
+    }
+
+    /**
+     * @dev Decodes a fallback bundle. `data` is the payload that follows the
+     * `FALLBACK_MARKER` executor slot:
+     * `uint16 primaryLength || primary || fallback`, where primary and
+     * fallback are each `executor (20 bytes) || protocolData` and
+     * primaryLength is the byte length of the primary pair.
+     */
+    function decodeFallbackSwap(bytes calldata data)
+        internal
+        pure
+        returns (
+            address executor,
+            bytes calldata protocolData,
+            address fallbackExecutor,
+            bytes calldata fallbackData
+        )
+    {
+        uint256 primaryLength = uint16(bytes2(data[0:2]));
+        executor = address(uint160(bytes20(data[2:22])));
+        protocolData = data[22:2 + primaryLength];
+        fallbackExecutor =
+            address(uint160(bytes20(data[2 + primaryLength:22 + primaryLength])));
+        fallbackData = data[22 + primaryLength:];
     }
 }

--- a/crates/tycho-execution/contracts/src/Dispatcher.sol
+++ b/crates/tycho-execution/contracts/src/Dispatcher.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.26;
 import {IExecutor} from "@interfaces/IExecutor.sol";
 import {ICallback} from "@interfaces/ICallback.sol";
 import {TransferManager} from "./TransferManager.sol";
+import {LibSwap} from "../lib/LibSwap.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
     SafeERC20
@@ -17,6 +18,7 @@ error Dispatcher__UnsupportedSingleHopCycle(address token);
 error Dispatcher__ExecutorAlreadyExists(address executor);
 error Dispatcher__SwapReverted(address executor);
 error Dispatcher__CallbackReverted(address executor);
+error Dispatcher__OnlySelf();
 
 /**
  * @title Dispatcher - Dispatch execution to external contracts
@@ -31,6 +33,7 @@ error Dispatcher__CallbackReverted(address executor);
  */
 contract Dispatcher is TransferManager {
     using SafeERC20 for IERC20;
+    using LibSwap for bytes;
 
     mapping(address => uint256) public executorsActivationTimestamp;
 
@@ -83,6 +86,75 @@ contract Dispatcher is TransferManager {
     function _removeExecutor(address target) internal {
         delete executorsActivationTimestamp[target];
         emit ExecutorRemoved(target);
+    }
+
+    /**
+     * @dev External self-call wrapper around `_callSwapOnExecutor` so a swap
+     * can run inside try/catch. A revert in the primary executor rolls back
+     * the whole sub-call — transfers, delta accounting, and transient
+     * storage writes — leaving clean state for the fallback executor.
+     * Only callable by the router itself; this is an internal mechanism,
+     * not a user-facing entry point, so it skips the reentrancy guard.
+     */
+    function trySwapOnExecutor(
+        address executor,
+        uint256 amount,
+        bytes calldata data,
+        bool isFirstSwap,
+        bool isSplitSwap,
+        address receiver
+    ) external returns (uint256) {
+        if (msg.sender != address(this)) {
+            revert Dispatcher__OnlySelf();
+        }
+        return _callSwapOnExecutor(
+            executor, amount, data, isFirstSwap, isSplitSwap, receiver
+        );
+    }
+
+    /**
+     * @dev Routes a hop to its executor. A hop whose executor slot holds
+     * `LibSwap.FALLBACK_MARKER` carries a fallback bundle: the primary
+     * executor runs in try/catch via `trySwapOnExecutor`, and on any revert
+     * the fallback executor re-runs the full swap flow on clean state.
+     *
+     * Fallback hops always pass `isSplitSwap = true`: their input tokens are
+     * always held by the router (receiver resolution never pre-positions
+     * them at the primary pool), so the transfer-from-router path must run
+     * instead of the sequential-swap pre-positioning optimization.
+     */
+    function _dispatchSwap(
+        address executor,
+        uint256 amount,
+        bytes calldata data,
+        bool isFirstSwap,
+        bool isSplitSwap,
+        address receiver
+    ) internal returns (uint256) {
+        if (executor != LibSwap.FALLBACK_MARKER) {
+            return _callSwapOnExecutor(
+                executor, amount, data, isFirstSwap, isSplitSwap, receiver
+            );
+        }
+
+        (
+            address primaryExecutor,
+            bytes calldata primaryData,
+            address fallbackExecutor,
+            bytes calldata fallbackData
+        ) = data.decodeFallbackSwap();
+
+        try this.trySwapOnExecutor(
+            primaryExecutor, amount, primaryData, isFirstSwap, true, receiver
+        ) returns (
+            uint256 amountOut
+        ) {
+            return amountOut;
+        } catch {}
+
+        return _callSwapOnExecutor(
+            fallbackExecutor, amount, fallbackData, isFirstSwap, true, receiver
+        );
     }
 
     /**

--- a/crates/tycho-execution/contracts/src/TychoRouterV3.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouterV3.sol
@@ -798,7 +798,7 @@ contract TychoRouterV3 is AccessControl, Dispatcher, EIP712 {
         {
             (address executor, bytes calldata protocolData) =
                 swap_.decodeSingleSwap();
-            actualAmountOut = _callSwapOnExecutor(
+            actualAmountOut = _dispatchSwap(
                 executor,
                 amountIn,
                 protocolData,
@@ -1069,7 +1069,7 @@ contract TychoRouterV3 is AccessControl, Dispatcher, EIP712 {
                 swapReceiver = receiver;
             }
 
-            uint256 currentAmountOut = _callSwapOnExecutor(
+            uint256 currentAmountOut = _dispatchSwap(
                 executor,
                 currentAmountIn,
                 protocolData,
@@ -1127,11 +1127,15 @@ contract TychoRouterV3 is AccessControl, Dispatcher, EIP712 {
                 (nextSwap,) = remainingSwaps.next();
                 (address nextExecutor, bytes calldata nextProtocolData) =
                     nextSwap.decodeSequentialSwap();
-                receiver =
-                    _callFundsExpectedAddress(nextExecutor, nextProtocolData);
+                // A fallback hop's input must stay at the router: if it were
+                // pre-positioned at the primary pool and the primary
+                // reverted, the tokens would be stranded there.
+                receiver = nextExecutor == LibSwap.FALLBACK_MARKER
+                    ? address(this)
+                    : _callFundsExpectedAddress(nextExecutor, nextProtocolData);
             }
 
-            calculatedAmount = _callSwapOnExecutor(
+            calculatedAmount = _dispatchSwap(
                 executor,
                 calculatedAmount,
                 protocolData,

--- a/crates/tycho-execution/contracts/test/LibSwap.t.sol
+++ b/crates/tycho-execution/contracts/test/LibSwap.t.sol
@@ -82,4 +82,38 @@ contract LibSwapTest is Test {
         assertEq(decodedExecutor, executor);
         assertEq(decodedProtocolData, protocolData);
     }
+
+    function testFallbackSwap() public view {
+        address executor = 0x1234567890123456789012345678901234567890;
+        bytes memory protocolData = abi.encodePacked(uint256(567));
+        address fallbackExecutor = 0xabCDEF1234567890ABcDEF1234567890aBCDeF12;
+        bytes memory fallbackData = abi.encodePacked(uint128(890));
+
+        bytes memory primary = abi.encodePacked(executor, protocolData);
+        bytes memory data = abi.encodePacked(
+            uint16(primary.length), primary, fallbackExecutor, fallbackData
+        );
+        this.assertFallbackSwap(
+            data, executor, protocolData, fallbackExecutor, fallbackData
+        );
+    }
+
+    function assertFallbackSwap(
+        bytes calldata data,
+        address executor,
+        bytes calldata protocolData,
+        address fallbackExecutor,
+        bytes calldata fallbackData
+    ) public pure {
+        (
+            address decodedExecutor,
+            bytes memory decodedProtocolData,
+            address decodedFallbackExecutor,
+            bytes memory decodedFallbackData
+        ) = data.decodeFallbackSwap();
+        assertEq(decodedExecutor, executor);
+        assertEq(decodedProtocolData, protocolData);
+        assertEq(decodedFallbackExecutor, fallbackExecutor);
+        assertEq(decodedFallbackData, fallbackData);
+    }
 }

--- a/crates/tycho-execution/contracts/test/TychoRouterFallbackSwap.t.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterFallbackSwap.t.sol
@@ -1,0 +1,362 @@
+pragma solidity ^0.8.26;
+
+import {TychoRouterV3, ClientFeeParams} from "@src/TychoRouterV3.sol";
+import {Dispatcher__OnlySelf} from "@src/Dispatcher.sol";
+import {LibSwap} from "../lib/LibSwap.sol";
+import "./TychoRouterTestSetup.sol";
+
+/// @dev Mock executor whose `swap` always reverts. Stands in for a primary
+/// executor hitting a protocol revert (e.g. a stale PropAMM quote).
+/// `getTransferData` decodes tokenIn/tokenOut from the first 40 bytes of
+/// `data` so the Dispatcher's single-hop-cycle check passes.
+contract AlwaysRevertingExecutor {
+    function getTransferData(bytes calldata data)
+        external
+        pure
+        returns (TransferManager.TransferType, address, address, address, bool)
+    {
+        address tokenIn = address(bytes20(data[0:20]));
+        address tokenOut = address(bytes20(data[20:40]));
+        return (
+            TransferManager.TransferType.None,
+            address(0),
+            tokenIn,
+            tokenOut,
+            false
+        );
+    }
+
+    function swap(uint256, bytes calldata, address) external payable {
+        revert("mock executor reverted");
+    }
+
+    function fundsExpectedAddress(bytes calldata)
+        external
+        view
+        returns (address)
+    {
+        return address(this);
+    }
+}
+
+contract TychoRouterFallbackSwapTest is TychoRouterTestSetup {
+    AlwaysRevertingExecutor revertingExecutor;
+
+    function setUp() public override {
+        super.setUp();
+        revertingExecutor = new AlwaysRevertingExecutor();
+        vm.warp(forkTimestamp - _SETUP_TIME_OFFSET_NEW_EXECUTOR);
+        address[] memory executors = new address[](1);
+        executors[0] = address(revertingExecutor);
+        vm.prank(EXECUTOR_SETTER);
+        tychoRouter.setExecutors(executors);
+        vm.warp(forkTimestamp);
+    }
+
+    /// @dev Encodes the payload that follows `LibSwap.FALLBACK_MARKER` in a
+    /// hop's executor slot: `uint16 primaryLength || primary || fallback`.
+    function encodeFallbackData(
+        address primaryExecutor,
+        bytes memory primaryData,
+        address fallbackExecutor,
+        bytes memory fallbackData
+    ) internal pure returns (bytes memory) {
+        bytes memory primary = abi.encodePacked(primaryExecutor, primaryData);
+        return abi.encodePacked(
+            uint16(primary.length), primary, fallbackExecutor, fallbackData
+        );
+    }
+
+    function testSingleSwapFallbackPrimaryReverts() public {
+        // Trade 1 WETH for DAI. The primary executor reverts, so the hop
+        // falls back to the Uniswap V2 executor.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes memory swap = encodeSingleSwap(
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                address(revertingExecutor),
+                abi.encodePacked(WETH_ADDR, DAI_ADDR),
+                address(usv2Executor),
+                encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR)
+            )
+        );
+
+        uint256 expectedAmountOut = 2018817438608734439722;
+        uint256 amountOut = tychoRouter.singleSwap(
+            amountIn,
+            WETH_ADDR,
+            DAI_ADDR,
+            expectedAmountOut,
+            expectedAmountOut * 9900 / 10000,
+            ALICE,
+            noClientFee(),
+            swap
+        );
+
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(DAI_ADDR).balanceOf(ALICE), expectedAmountOut);
+        assertEq(IERC20(WETH_ADDR).balanceOf(ALICE), 0);
+        vm.stopPrank();
+    }
+
+    function testSingleSwapFallbackPrimarySucceeds() public {
+        // The primary executor succeeds, so the fallback executor (which
+        // would revert if called) is never used.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes memory swap = encodeSingleSwap(
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                address(usv2Executor),
+                encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR),
+                address(revertingExecutor),
+                abi.encodePacked(WETH_ADDR, DAI_ADDR)
+            )
+        );
+
+        uint256 expectedAmountOut = 2018817438608734439722;
+        uint256 amountOut = tychoRouter.singleSwap(
+            amountIn,
+            WETH_ADDR,
+            DAI_ADDR,
+            expectedAmountOut,
+            expectedAmountOut * 9900 / 10000,
+            ALICE,
+            noClientFee(),
+            swap
+        );
+
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(DAI_ADDR).balanceOf(ALICE), expectedAmountOut);
+        vm.stopPrank();
+    }
+
+    function testSingleSwapFallbackBothRevert() public {
+        // Both the primary and the fallback executor revert. The fallback's
+        // revert bubbles up to the caller.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes memory swap = encodeSingleSwap(
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                address(revertingExecutor),
+                abi.encodePacked(WETH_ADDR, DAI_ADDR),
+                address(revertingExecutor),
+                abi.encodePacked(WETH_ADDR, DAI_ADDR)
+            )
+        );
+
+        vm.expectRevert(bytes("mock executor reverted"));
+        tychoRouter.singleSwap(
+            amountIn,
+            WETH_ADDR,
+            DAI_ADDR,
+            1000 ether,
+            1000 ether * 9900 / 10000,
+            ALICE,
+            noClientFee(),
+            swap
+        );
+        vm.stopPrank();
+    }
+
+    function testSingleSwapFallbackPrimaryUnapproved() public {
+        // The primary executor is not approved on the Dispatcher. Its
+        // validation revert is caught like any other primary failure and
+        // the fallback executes.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes memory swap = encodeSingleSwap(
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                makeAddr("unapprovedExecutor"),
+                abi.encodePacked(WETH_ADDR, DAI_ADDR),
+                address(usv2Executor),
+                encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR)
+            )
+        );
+
+        uint256 expectedAmountOut = 2018817438608734439722;
+        uint256 amountOut = tychoRouter.singleSwap(
+            amountIn,
+            WETH_ADDR,
+            DAI_ADDR,
+            expectedAmountOut,
+            expectedAmountOut * 9900 / 10000,
+            ALICE,
+            noClientFee(),
+            swap
+        );
+
+        assertEq(amountOut, expectedAmountOut);
+        vm.stopPrank();
+    }
+
+    function testSequentialSwapFallbackSecondHop() public {
+        // Trade 1 WETH for USDC through DAI. The second hop carries a
+        // fallback: its primary reverts, the Uniswap V2 executor completes
+        // it. The first hop's output stays at the router (never
+        // pre-positioned at the primary pool) and the fallback transfers it
+        // to the pool itself.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes[] memory swaps = new bytes[](2);
+        swaps[0] = encodeSequentialSwap(
+            address(usv2Executor),
+            encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR)
+        );
+        swaps[1] = encodeSequentialSwap(
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                address(revertingExecutor),
+                abi.encodePacked(DAI_ADDR, USDC_ADDR),
+                address(usv2Executor),
+                encodeUniswapV2Swap(DAI_USDC_POOL, DAI_ADDR, USDC_ADDR)
+            )
+        );
+
+        tychoRouter.sequentialSwap(
+            amountIn,
+            WETH_ADDR,
+            USDC_ADDR,
+            2000_000000, // expected amount out
+            2000_000000 * 9800 / 10000, // min amount out
+            ALICE,
+            noClientFee(),
+            pleEncode(swaps)
+        );
+
+        assertEq(IERC20(USDC_ADDR).balanceOf(ALICE), 2005810530);
+        assertEq(IERC20(WETH_ADDR).balanceOf(tychoRouterAddr), 0);
+        assertEq(IERC20(DAI_ADDR).balanceOf(tychoRouterAddr), 0);
+        vm.stopPrank();
+    }
+
+    function testSequentialSwapFallbackFirstHop() public {
+        // The first hop carries a fallback. The primary's revert rolls back
+        // any user-fund transfer, and the fallback re-pulls the input from
+        // the user's wallet.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes[] memory swaps = new bytes[](2);
+        swaps[0] = encodeSequentialSwap(
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                address(revertingExecutor),
+                abi.encodePacked(WETH_ADDR, DAI_ADDR),
+                address(usv2Executor),
+                encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR)
+            )
+        );
+        swaps[1] = encodeSequentialSwap(
+            address(usv2Executor),
+            encodeUniswapV2Swap(DAI_USDC_POOL, DAI_ADDR, USDC_ADDR)
+        );
+
+        tychoRouter.sequentialSwap(
+            amountIn,
+            WETH_ADDR,
+            USDC_ADDR,
+            2000_000000, // expected amount out
+            2000_000000 * 9800 / 10000, // min amount out
+            ALICE,
+            noClientFee(),
+            pleEncode(swaps)
+        );
+
+        assertEq(IERC20(USDC_ADDR).balanceOf(ALICE), 2005810530);
+        assertEq(IERC20(WETH_ADDR).balanceOf(ALICE), 0);
+        vm.stopPrank();
+    }
+
+    function testSplitSwapFallbackLastHop() public {
+        // Same route as _getSplitSwaps in TychoRouterSplitSwap.t.sol, with
+        // the DAI -> USDC hop wrapped in a fallback bundle whose primary
+        // reverts.
+        uint256 amountIn = 1 ether;
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes[] memory swaps = new bytes[](4);
+        // WETH -> WBTC (60%)
+        swaps[0] = encodeSplitSwap(
+            uint8(0),
+            uint8(1),
+            (0xffffff * 60) / 100,
+            address(usv2Executor),
+            encodeUniswapV2Swap(WETH_WBTC_POOL, WETH_ADDR, WBTC_ADDR)
+        );
+        // WBTC -> USDC
+        swaps[1] = encodeSplitSwap(
+            uint8(1),
+            uint8(3),
+            uint24(0),
+            address(usv2Executor),
+            encodeUniswapV2Swap(USDC_WBTC_POOL, WBTC_ADDR, USDC_ADDR)
+        );
+        // WETH -> DAI (remaining 40%)
+        swaps[2] = encodeSplitSwap(
+            uint8(0),
+            uint8(2),
+            uint24(0),
+            address(usv2Executor),
+            encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR)
+        );
+        // DAI -> USDC with fallback
+        swaps[3] = encodeSplitSwap(
+            uint8(2),
+            uint8(3),
+            uint24(0),
+            LibSwap.FALLBACK_MARKER,
+            encodeFallbackData(
+                address(revertingExecutor),
+                abi.encodePacked(DAI_ADDR, USDC_ADDR),
+                address(usv2Executor),
+                encodeUniswapV2Swap(DAI_USDC_POOL, DAI_ADDR, USDC_ADDR)
+            )
+        );
+
+        tychoRouter.splitSwap(
+            amountIn,
+            WETH_ADDR,
+            USDC_ADDR,
+            2000_000000, // expected amount out
+            2000_000000 * 9800 / 10000, // min amount out
+            4,
+            ALICE,
+            noClientFee(),
+            pleEncode(swaps)
+        );
+
+        assertEq(IERC20(USDC_ADDR).balanceOf(ALICE), 1989737355);
+        assertEq(IERC20(DAI_ADDR).balanceOf(tychoRouterAddr), 0);
+        vm.stopPrank();
+    }
+
+    function testTrySwapOnExecutorOnlySelf() public {
+        vm.expectRevert(abi.encodeWithSelector(Dispatcher__OnlySelf.selector));
+        tychoRouter.trySwapOnExecutor(
+            address(usv2Executor), 1 ether, hex"", true, false, ALICE
+        );
+    }
+}

--- a/crates/tycho-execution/src/encoding/evm/group_swaps.rs
+++ b/crates/tycho-execution/src/encoding/evm/group_swaps.rs
@@ -63,7 +63,20 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
             .as_ref()
             .is_none_or(|g| swap.token_out().address != g.token_in);
 
-        if current_swap_protocol == last_swap_protocol && groupable_protocol && no_split && no_cycle
+        // A swap with a fallback is its own router hop (the fallback bundle wraps exactly
+        // one executor call), so it can neither join a group nor be joined.
+        let no_fallback = swap.fallback_swap().is_none() &&
+            current_group.as_ref().is_none_or(|g| {
+                g.swaps
+                    .last()
+                    .is_none_or(|s| s.fallback_swap().is_none())
+            });
+
+        if current_swap_protocol == last_swap_protocol &&
+            groupable_protocol &&
+            no_split &&
+            no_cycle &&
+            no_fallback
         {
             // Second or later groupable pool in a sequence of groupable pools. Merge to the
             // current group.

--- a/crates/tycho-execution/src/encoding/evm/strategy_encoder/strategy_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/strategy_encoder/strategy_encoders.rs
@@ -8,7 +8,7 @@ use crate::encoding::{
     evm::{
         constants::NON_PLE_ENCODED_PROTOCOLS,
         gas_estimator::estimate_gas_usage,
-        group_swaps::group_swaps,
+        group_swaps::{group_swaps, SwapGroup},
         strategy_encoder::strategy_validators::{
             SequentialSwapValidator, SingleSwapValidator, SplitSwapValidator, SwapValidator,
         },
@@ -19,6 +19,94 @@ use crate::encoding::{
     strategy_encoder::StrategyEncoder,
     swap_encoder::SwapEncoder,
 };
+
+/// Marker placed in a hop's executor slot when the hop carries a fallback bundle. Must match
+/// `LibSwap.FALLBACK_MARKER` in the router contracts.
+const FALLBACK_MARKER: [u8; 20] = [0u8; 20];
+
+/// Encodes one router hop: `executor || protocolData` for a plain hop, or — when the hop
+/// carries a fallback — the bundle
+/// `FALLBACK_MARKER || uint16 primaryLength || primary || fallbackExecutor || fallbackData`,
+/// where primary is `executor || protocolData` and primaryLength is its byte length.
+fn encode_hop(
+    executor_address: &Bytes,
+    protocol_data: Vec<u8>,
+    fallback: Option<(Bytes, Vec<u8>)>,
+) -> Result<Vec<u8>, EncodingError> {
+    let mut primary = executor_address.to_vec();
+    primary.extend(protocol_data);
+    let Some((fallback_executor, fallback_data)) = fallback else {
+        return Ok(primary);
+    };
+    let primary_length = u16::try_from(primary.len()).map_err(|_| {
+        EncodingError::InvalidInput(format!(
+            "Primary swap data is {} bytes, exceeding the uint16 length prefix",
+            primary.len()
+        ))
+    })?;
+    let mut encoded = FALLBACK_MARKER.to_vec();
+    encoded.extend(primary_length.to_be_bytes());
+    encoded.extend(primary);
+    encoded.extend(fallback_executor.to_vec());
+    encoded.extend(fallback_data);
+    Ok(encoded)
+}
+
+/// Encodes a grouped swap's fallback swap, if any, as (executor address, protocol data).
+///
+/// The fallback must swap the same token pair as the primary, carry no split, and not nest
+/// another fallback.
+fn encode_fallback(
+    strategy: &dyn StrategyEncoder,
+    grouped_swap: &SwapGroup,
+    router_address: &Bytes,
+) -> Result<Option<(Bytes, Vec<u8>)>, EncodingError> {
+    let Some(fallback_swap) = grouped_swap
+        .swaps
+        .first()
+        .and_then(|swap| swap.fallback_swap())
+    else {
+        return Ok(None);
+    };
+    if grouped_swap.swaps.len() != 1 {
+        return Err(EncodingError::FatalError(
+            "A swap with a fallback must not be grouped with other swaps".to_string(),
+        ));
+    }
+    if fallback_swap.token_in().address != grouped_swap.token_in ||
+        fallback_swap.token_out().address != grouped_swap.token_out
+    {
+        return Err(EncodingError::InvalidInput(
+            "A fallback swap must swap the same token pair as its primary swap".to_string(),
+        ));
+    }
+    if fallback_swap.split() != 0.0 {
+        return Err(EncodingError::InvalidInput(
+            "A fallback swap must not have a split".to_string(),
+        ));
+    }
+    if fallback_swap.fallback_swap().is_some() {
+        return Err(EncodingError::InvalidInput(
+            "A fallback swap must not have a fallback itself".to_string(),
+        ));
+    }
+
+    let protocol = &fallback_swap
+        .component()
+        .protocol_system;
+    let swap_encoder = strategy
+        .get_swap_encoder(protocol)
+        .ok_or_else(|| {
+            EncodingError::InvalidInput(format!("Swap encoder not found for protocol: {protocol}"))
+        })?;
+    let encoding_context = EncodingContext {
+        router_address: Some(router_address.clone()),
+        group_token_in: grouped_swap.token_in.clone(),
+        group_token_out: grouped_swap.token_out.clone(),
+    };
+    let protocol_data = swap_encoder.encode_swap(fallback_swap, &encoding_context)?;
+    Ok(Some((swap_encoder.executor_address().clone(), protocol_data)))
+}
 
 /// Represents the encoder for a swap strategy which supports single swaps.
 ///
@@ -44,15 +132,6 @@ impl SingleSwapStrategyEncoder {
             router_address: router_address.clone(),
             single_swap_validator: SingleSwapValidator,
         })
-    }
-
-    /// Encodes information necessary for performing a single hop against a given executor for
-    /// a protocol.
-    fn encode_swap_header(&self, executor_address: Bytes, protocol_data: Vec<u8>) -> Vec<u8> {
-        let mut encoded = Vec::new();
-        encoded.extend(executor_address.to_vec());
-        encoded.extend(protocol_data);
-        encoded
     }
 }
 
@@ -130,8 +209,9 @@ impl StrategyEncoder for SingleSwapStrategyEncoder {
             }
         }
 
+        let fallback = encode_fallback(self, grouped_swap, &self.router_address)?;
         let swap_data =
-            self.encode_swap_header(swap_encoder.executor_address().clone(), initial_protocol_data);
+            encode_hop(swap_encoder.executor_address(), initial_protocol_data, fallback)?;
         let gas_usage = estimate_gas_usage(solution, Strategy::Single);
         Ok(EncodedSolution::new(
             swap_data,
@@ -175,15 +255,6 @@ impl SequentialSwapStrategyEncoder {
             router_address: router_address.clone(),
             sequential_swap_validator: SequentialSwapValidator,
         })
-    }
-
-    /// Encodes information necessary for performing a single hop against a given executor for
-    /// a protocol.
-    fn encode_swap_header(&self, executor_address: Bytes, protocol_data: Vec<u8>) -> Vec<u8> {
-        let mut encoded = Vec::new();
-        encoded.extend(executor_address.to_vec());
-        encoded.extend(protocol_data);
-        encoded
     }
 }
 
@@ -247,8 +318,9 @@ impl StrategyEncoder for SequentialSwapStrategyEncoder {
                 }
             }
 
-            let swap_data = self
-                .encode_swap_header(swap_encoder.executor_address().clone(), initial_protocol_data);
+            let fallback = encode_fallback(self, grouped_swap, &self.router_address)?;
+            let swap_data =
+                encode_hop(swap_encoder.executor_address(), initial_protocol_data, fallback)?;
             swaps.push(swap_data);
         }
 
@@ -298,21 +370,20 @@ impl SplitSwapStrategyEncoder {
     }
 
     /// Encodes information necessary for performing a single hop against a given executor for
-    /// a protocol as part of a split swap solution.
+    /// a protocol as part of a split swap solution. `hop_data` is the pre-encoded
+    /// executor + protocol data pair (or fallback bundle) produced by `encode_hop`.
     fn encode_swap_header(
         &self,
         token_in: U8,
         token_out: U8,
         split: U24,
-        executor_address: Bytes,
-        protocol_data: Vec<u8>,
+        hop_data: Vec<u8>,
     ) -> Vec<u8> {
         let mut encoded = Vec::new();
         encoded.push(token_in.to_be_bytes_vec()[0]);
         encoded.push(token_out.to_be_bytes_vec()[0]);
         encoded.extend_from_slice(&split.to_be_bytes_vec());
-        encoded.extend(executor_address.to_vec());
-        encoded.extend(protocol_data);
+        encoded.extend(hop_data);
         encoded
     }
 }
@@ -402,12 +473,14 @@ impl StrategyEncoder for SplitSwapStrategyEncoder {
                 }
             }
 
+            let fallback = encode_fallback(self, grouped_swap, &self.router_address)?;
+            let hop_data =
+                encode_hop(swap_encoder.executor_address(), initial_protocol_data, fallback)?;
             let swap_data = self.encode_swap_header(
                 get_token_position(&tokens, &grouped_swap.token_in)?,
                 get_token_position(&tokens, &grouped_swap.token_out)?,
                 percentage_to_uint24(grouped_swap.split),
-                swap_encoder.executor_address().clone(),
-                initial_protocol_data,
+                hop_data,
             );
             swaps.push(swap_data);
         }
@@ -527,6 +600,129 @@ mod tests {
             );
             assert_eq!(encoded_solution.interacting_with(), &router_address());
         }
+
+        #[test]
+        fn test_single_swap_strategy_encoder_with_fallback() {
+            // A single WETH -> DAI swap on a USV2 pool carrying a USV3 fallback for the
+            // same pair. The hop encodes as a fallback bundle behind the zero-address
+            // marker.
+            let weth = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+            let dai = Bytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap();
+
+            let fallback_swap = Swap::new(
+                ProtocolComponent {
+                    id: "0xC2e9F25Be6257c210d7Adf0D4Cd6E3E881ba25f8".to_string(),
+                    protocol_system: "uniswap_v3".to_string(),
+                    static_attributes: {
+                        let mut attrs = HashMap::new();
+                        attrs.insert(
+                            "fee".to_string(),
+                            Bytes::from(BigInt::from(3000).to_signed_bytes_be()),
+                        );
+                        attrs
+                    },
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(dai.clone()),
+                BigUint::ZERO,
+            );
+            let swap = Swap::new(
+                ProtocolComponent {
+                    id: "0xA478c2975Ab1Ea89e8196811F51A7B7Ade33eB11".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(dai.clone()),
+                BigUint::ZERO,
+            )
+            .with_fallback_swap(fallback_swap);
+
+            let swap_encoder_registry = get_swap_encoder_registry();
+            let encoder =
+                SingleSwapStrategyEncoder::new(swap_encoder_registry, router_address()).unwrap();
+            let expected_amount_out = BigUint::from_str("2018817438608734439720").unwrap();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                weth,
+                dai,
+                BigUint::from_str("1_000000000000000000").unwrap(),
+                expected_amount_out.clone(),
+                &expected_amount_out * BigUint::from(9800u64) / BigUint::from(10_000u64),
+                vec![swap],
+            );
+
+            let encoded_solution = encoder
+                .encode_strategy(&solution)
+                .unwrap();
+
+            let expected_swap = String::from(concat!(
+                "0000000000000000000000000000000000000000", // fallback marker
+                "0050",                                     // primary length (80 bytes)
+                // primary: USV2
+                "5615deb798bb3e4dfa0139dfa1b3d433cc23b72f", // executor address
+                "a478c2975ab1ea89e8196811f51a7b7ade33eb11", // component id (pool address)
+                "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // tokenIn (WETH)
+                "6b175474e89094c44da98b954eedeac495271d0f", // tokenOut (DAI)
+                // fallback: USV3
+                "2e234dae75c793f67a35089c9d99245e1c58470b", // executor address
+                "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // tokenIn (WETH)
+                "6b175474e89094c44da98b954eedeac495271d0f", // tokenOut (DAI)
+                "000bb8",                                   // pool fee
+                "c2e9f25be6257c210d7adf0d4cd6e3e881ba25f8", // component id
+                "00",                                       // zero2one
+            ));
+            assert_eq!(encode(encoded_solution.swaps()), expected_swap);
+        }
+
+        #[test]
+        fn test_single_swap_strategy_encoder_fallback_token_mismatch() {
+            // A fallback swapping a different token pair than its primary is rejected.
+            let weth = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+            let dai = Bytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap();
+            let usdc = Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+
+            let fallback_swap = Swap::new(
+                ProtocolComponent {
+                    id: "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(usdc.clone()),
+                BigUint::ZERO,
+            );
+            let swap = Swap::new(
+                ProtocolComponent {
+                    id: "0xA478c2975Ab1Ea89e8196811F51A7B7Ade33eB11".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(dai.clone()),
+                BigUint::ZERO,
+            )
+            .with_fallback_swap(fallback_swap);
+
+            let swap_encoder_registry = get_swap_encoder_registry();
+            let encoder =
+                SingleSwapStrategyEncoder::new(swap_encoder_registry, router_address()).unwrap();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                weth,
+                dai,
+                BigUint::from_str("1_000000000000000000").unwrap(),
+                BigUint::from_str("2018817438608734439720").unwrap(),
+                BigUint::from_str("1978441089836559750925").unwrap(),
+                vec![swap],
+            );
+
+            let result = encoder.encode_strategy(&solution);
+            assert!(matches!(result, Err(EncodingError::InvalidInput(_))));
+        }
     }
 
     mod sequential {
@@ -607,11 +803,206 @@ mod tests {
             );
             assert_eq!(encoded_solution.interacting_with(), &router_address());
         }
+
+        #[test]
+        fn test_sequential_swap_strategy_encoder_with_fallback() {
+            // WETH -> WBTC -> USDC on USV2 pools, where the second hop carries a USV3
+            // fallback for the same pair. Only the second hop encodes as a fallback
+            // bundle; the first hop keeps the plain layout.
+            let weth = weth();
+            let wbtc = Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap();
+            let usdc = Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+
+            let swap_weth_wbtc = Swap::new(
+                ProtocolComponent {
+                    id: "0xBb2b8038a1640196FbE3e38816F3e67Cba72D940".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(wbtc.clone()),
+                BigUint::ZERO,
+            );
+            let fallback_wbtc_usdc = Swap::new(
+                ProtocolComponent {
+                    id: "0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35".to_string(),
+                    protocol_system: "uniswap_v3".to_string(),
+                    static_attributes: {
+                        let mut attrs = HashMap::new();
+                        attrs.insert(
+                            "fee".to_string(),
+                            Bytes::from(BigInt::from(3000).to_signed_bytes_be()),
+                        );
+                        attrs
+                    },
+                    ..Default::default()
+                },
+                default_token(wbtc.clone()),
+                default_token(usdc.clone()),
+                BigUint::ZERO,
+            );
+            let swap_wbtc_usdc = Swap::new(
+                ProtocolComponent {
+                    id: "0x004375Dff511095CC5A197A54140a24eFEF3A416".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(wbtc.clone()),
+                default_token(usdc.clone()),
+                BigUint::ZERO,
+            )
+            .with_fallback_swap(fallback_wbtc_usdc);
+
+            let swap_encoder_registry = get_swap_encoder_registry();
+            let encoder =
+                SequentialSwapStrategyEncoder::new(swap_encoder_registry, router_address())
+                    .unwrap();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                weth,
+                usdc,
+                BigUint::from_str("1_000000000000000000").unwrap(),
+                BigUint::from_str("26173932").unwrap(),
+                BigUint::from_str("25650453").unwrap(),
+                vec![swap_weth_wbtc, swap_wbtc_usdc],
+            );
+
+            let encoded_solution = encoder
+                .encode_strategy(&solution)
+                .unwrap();
+
+            let expected = String::from(concat!(
+                // swap 1: WETH -> WBTC, plain hop
+                "0050",                                     // swap length (80 bytes)
+                "5615deb798bb3e4dfa0139dfa1b3d433cc23b72f", // executor address
+                "bb2b8038a1640196fbe3e38816f3e67cba72d940", // component id (pool address)
+                "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // tokenIn (WETH)
+                "2260fac5e5542a773aa44fbcfedf7c193bc2c599", // tokenOut (WBTC)
+                // swap 2: WBTC -> USDC, fallback bundle
+                "00ba",                                     // swap length (186 bytes)
+                "0000000000000000000000000000000000000000", // fallback marker
+                "0050",                                     // primary length (80 bytes)
+                "5615deb798bb3e4dfa0139dfa1b3d433cc23b72f", // executor address
+                "004375dff511095cc5a197a54140a24efef3a416", // component id (pool address)
+                "2260fac5e5542a773aa44fbcfedf7c193bc2c599", // tokenIn (WBTC)
+                "a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // tokenOut (USDC)
+                // fallback: USV3
+                "2e234dae75c793f67a35089c9d99245e1c58470b", // executor address
+                "2260fac5e5542a773aa44fbcfedf7c193bc2c599", // tokenIn (WBTC)
+                "a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // tokenOut (USDC)
+                "000bb8",                                   // pool fee
+                "99ac8ca7087fa4a2a1fb6357269965a2014abc35", // component id
+                "01",                                       // zero2one
+            ));
+
+            assert_eq!(encode(encoded_solution.swaps()), expected);
+        }
     }
 
     mod split {
         use super::*;
         use crate::encoding::models::{default_token, Swap};
+
+        #[test]
+        fn test_split_swap_strategy_encoder_with_fallback() {
+            // WETH -> DAI split over two USV2 pools (60/40), where the second hop
+            // carries a USV3 fallback for the same pair.
+            let weth = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+            let dai = Bytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap();
+
+            let swap_pool1 = Swap::new(
+                ProtocolComponent {
+                    id: "0xA478c2975Ab1Ea89e8196811F51A7B7Ade33eB11".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(dai.clone()),
+                BigUint::ZERO,
+            )
+            .with_split(0.6f64);
+            let fallback = Swap::new(
+                ProtocolComponent {
+                    id: "0xC2e9F25Be6257c210d7Adf0D4Cd6E3E881ba25f8".to_string(),
+                    protocol_system: "uniswap_v3".to_string(),
+                    static_attributes: {
+                        let mut attrs = HashMap::new();
+                        attrs.insert(
+                            "fee".to_string(),
+                            Bytes::from(BigInt::from(3000).to_signed_bytes_be()),
+                        );
+                        attrs
+                    },
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(dai.clone()),
+                BigUint::ZERO,
+            );
+            let swap_pool2 = Swap::new(
+                ProtocolComponent {
+                    id: "0xC3D03e4F041Fd4cD388c549Ee2A29a9E5075882f".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(weth.clone()),
+                default_token(dai.clone()),
+                BigUint::ZERO,
+            )
+            .with_fallback_swap(fallback);
+
+            let swap_encoder_registry = get_swap_encoder_registry();
+            let encoder =
+                SplitSwapStrategyEncoder::new(swap_encoder_registry, router_address()).unwrap();
+            let expected_amount_out = BigUint::from_str("2018817438608734439720").unwrap();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                weth,
+                dai,
+                BigUint::from_str("1_000000000000000000").unwrap(),
+                expected_amount_out.clone(),
+                &expected_amount_out * BigUint::from(9800u64) / BigUint::from(10_000u64),
+                vec![swap_pool1, swap_pool2],
+            );
+
+            let encoded_solution = encoder
+                .encode_strategy(&solution)
+                .unwrap();
+
+            let expected_swaps = [
+                // hop 1: plain USV2, 60%
+                "0055",                                     // ple encoded swaps (85 bytes)
+                "00",                                       // token in index
+                "01",                                       // token out index
+                "999999",                                   // split (60%)
+                "5615deb798bb3e4dfa0139dfa1b3d433cc23b72f", // executor address
+                "a478c2975ab1ea89e8196811f51a7b7ade33eb11", // component id (pool address)
+                "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // tokenIn (WETH)
+                "6b175474e89094c44da98b954eedeac495271d0f", // tokenOut (DAI)
+                // hop 2: fallback bundle, remaining 40%
+                "00bf",                                     // ple encoded swaps (191 bytes)
+                "00",                                       // token in index
+                "01",                                       // token out index
+                "000000",                                   // split (remainder)
+                "0000000000000000000000000000000000000000", // fallback marker
+                "0050",                                     // primary length (80 bytes)
+                "5615deb798bb3e4dfa0139dfa1b3d433cc23b72f", // executor address
+                "c3d03e4f041fd4cd388c549ee2a29a9e5075882f", // component id (pool address)
+                "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // tokenIn (WETH)
+                "6b175474e89094c44da98b954eedeac495271d0f", // tokenOut (DAI)
+                // fallback: USV3
+                "2e234dae75c793f67a35089c9d99245e1c58470b", // executor address
+                "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // tokenIn (WETH)
+                "6b175474e89094c44da98b954eedeac495271d0f", // tokenOut (DAI)
+                "000bb8",                                   // pool fee
+                "c2e9f25be6257c210d7adf0d4cd6e3e881ba25f8", // component id
+                "00",                                       // zero2one
+            ]
+            .join("");
+            assert_eq!(hex::encode(encoded_solution.swaps()), expected_swaps);
+        }
 
         #[test]
         fn test_split_input_cyclic_swap() {

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -171,6 +171,17 @@ impl TychoExecutorEncoder {
         &self,
         solution: &Solution,
     ) -> Result<EncodedSolution, EncodingError> {
+        if solution
+            .swaps()
+            .iter()
+            .any(|swap| swap.fallback_swap().is_some())
+        {
+            return Err(EncodingError::InvalidInput(
+                "Fallback swaps require the TychoRouter; they are not supported when calling \
+                 an executor directly"
+                    .to_string(),
+            ));
+        }
         let grouped_swaps = group_swaps(solution.swaps());
         let number_of_groups = grouped_swaps.len();
         if number_of_groups > 1 {

--- a/crates/tycho-execution/src/encoding/models.rs
+++ b/crates/tycho-execution/src/encoding/models.rs
@@ -240,6 +240,10 @@ pub struct Swap {
     estimated_amount_in: Option<BigUint>,
     /// Estimated gas usage for this swap by simulation
     estimated_gas: BigUint,
+    /// Optional fallback swap the router executes when this swap's executor reverts. Must swap
+    /// the same token pair. Only supported when encoding through the TychoRouter.
+    #[serde(default)]
+    fallback_swap: Option<Box<Swap>>,
 }
 
 impl Swap {
@@ -258,6 +262,7 @@ impl Swap {
             protocol_state: None,
             estimated_amount_in: None,
             estimated_gas,
+            fallback_swap: None,
         }
     }
 
@@ -282,6 +287,12 @@ impl Swap {
     /// Sets the estimated amount in for RFQ protocols
     pub fn with_estimated_amount_in(mut self, estimated_amount_in: BigUint) -> Self {
         self.estimated_amount_in = Some(estimated_amount_in);
+        self
+    }
+
+    /// Sets the fallback swap the router executes when this swap's executor reverts
+    pub fn with_fallback_swap(mut self, fallback_swap: Swap) -> Self {
+        self.fallback_swap = Some(Box::new(fallback_swap));
         self
     }
 
@@ -316,6 +327,10 @@ impl Swap {
     pub fn estimated_gas(&self) -> &BigUint {
         &self.estimated_gas
     }
+
+    pub fn fallback_swap(&self) -> Option<&Swap> {
+        self.fallback_swap.as_deref()
+    }
 }
 
 impl PartialEq for Swap {
@@ -326,7 +341,8 @@ impl PartialEq for Swap {
             self.split() == other.split() &&
             self.user_data() == other.user_data() &&
             self.estimated_amount_in() == other.estimated_amount_in() &&
-            self.estimated_gas() == other.estimated_gas()
+            self.estimated_gas() == other.estimated_gas() &&
+            self.fallback_swap() == other.fallback_swap()
     }
 }
 


### PR DESCRIPTION
Implements Option 2 from [PropAMMs - TychoRouter Executor](https://propeller-heads.atlassian.net/wiki/spaces/DEFI/pages/3622076420/PropAMMs+-+TychoRouter+Executor): a generic per-hop fallback in the Dispatcher. Any hop may name a fallback executor. If the primary executor reverts, the hop re-runs on the fallback with no protocol compatibility constraints between the two.

## Wire format

A hop with a fallback puts `LibSwap.FALLBACK_MARKER` (`address(0)`, never an approved executor) in its executor slot, followed by:

```
uint16 primaryLength || primary || fallback
primary  = executor (20 bytes) || protocolData
fallback = executor (20 bytes) || protocolData
```

Hops without a fallback are byte-identical to the current layout, for all three strategies.

## Solidity

- `LibSwap.decodeFallbackSwap` decodes the bundle.
- `Dispatcher.trySwapOnExecutor`: external self-call wrapper around `_callSwapOnExecutor`, callable only by the router itself (`Dispatcher__OnlySelf`). A revert inside it rolls back the primary's transfers, delta accounting, and transient storage.
- `Dispatcher._dispatchSwap`: routes every hop. Plain hops go straight to `_callSwapOnExecutor`; fallback hops run the primary in try/catch and, on any revert, re-run the full swap flow on the fallback executor.
- `_singleSwap`, `_sequentialSwap`, and `_splitSwap` call `_dispatchSwap`.

Two invariants keep funds safe:
- Sequential receiver resolution sends a fallback hop's input to the router, never to the primary pool. Tokens pre-positioned at a reverting primary pool would be stranded.
- Both legs run with `isSplitSwap = true`, so the transfer-from-router path executes instead of the sequential pre-positioning optimization.

## Rust encoding

- `Swap::with_fallback_swap(Swap)` attaches a fallback. It must swap the same token pair, carry no split, and not nest another fallback.
- `group_swaps` keeps fallback-carrying swaps in their own group.
- All three strategy encoders emit the fallback bundle. `TychoExecutorEncoder` rejects fallback swaps (they need the router's try/catch).

## Tests

- `TychoRouterFallbackSwap.t.sol` (8 fork tests): single/sequential/split hops where the primary reverts, primary succeeds, both revert (revert bubbles), primary unapproved, and `trySwapOnExecutor` auth.
- `LibSwap.t.sol`: bundle decode.
- Rust: bundle hex assertions for all three strategies, plus the token-pair mismatch error.
- All existing TychoRouter, Dispatcher, and encoding tests pass.

## Not in this PR

- The security model crate (`model/src/model/`) does not yet mirror `trySwapOnExecutor`/`_dispatchSwap`.
- No cross-language calldata integration test (`calldata.txt`) for fallback hops yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)