### PR TITLE
fix: create upcoming partitions in short transactions

### DIFF
--- a/crates/tycho-storage/migrations/2026-09-02_short_transaction_partition_creation/down.sql
+++ b/crates/tycho-storage/migrations/2026-09-02_short_transaction_partition_creation/down.sql
@@ -1,0 +1,11 @@
+-- Revert to partition creation inside run_maintenance: remove the short-transaction creation
+-- job and restore the @daily schedule from 2024-06-25_v0.7.2.
+
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE command LIKE '%create_upcoming_partitions%'
+   OR command LIKE '%run_maintenance_proc%';
+
+DROP PROCEDURE IF EXISTS create_upcoming_partitions(text, integer, interval);
+
+SELECT cron.schedule('@daily', $$CALL partman.run_maintenance_proc()$$);

--- a/crates/tycho-storage/migrations/2026-09-02_short_transaction_partition_creation/up.sql
+++ b/crates/tycho-storage/migrations/2026-09-02_short_transaction_partition_creation/up.sql
@@ -1,0 +1,141 @@
+-- Create upcoming partitions in short transactions
+--
+-- CREATE TABLE ... PARTITION OF takes an AccessExclusiveLock on the parent table, and
+-- pg_partman's run_maintenance() acquires it inside its per-table maintenance transaction,
+-- holding it until that transaction commits. Every query on the parent queues behind it for
+-- the full transaction, not for the creation itself: reader stalls of up to 18 seconds at
+-- midnight were measured (five extractor connections blocked in bind, all released at the
+-- maintenance commit).
+--
+-- create_upcoming_partitions() below creates each missing premake partition through
+-- partman.create_partition_time() in its own transaction, so the parent lock is held for
+-- milliseconds per partition. part_config stays the source of truth for what should exist
+-- (premake, partition_interval, which parents are managed), and partman's own
+-- calculate_time_partition_info() snaps each target time to the partition boundary.
+-- create_partition_time() returns false without taking the parent lock when the partition is
+-- already there, so a normal run does nothing until the day rolls over.
+--
+-- Lock handling matches drop_expired_partitions: a per-transaction lock_timeout so a blocked
+-- creation yields instead of stalling the readers queued behind it, retries with backoff,
+-- retry on any error because partman re-raises internal errors with a generic SQLSTATE, and a
+-- final RAISE so an exhausted run is visible in cron.job_run_details. The retry budget is
+-- smaller than the drop job's: this procedure makes up to premake+1 calls per parent rather
+-- than one, so the same budget would let a persistent failure run for many minutes.
+--
+-- run_maintenance_proc() stays scheduled as a safety net, moved to 01:00. With the premake
+-- partitions already created at 00:05 it has nothing to create and takes no parent lock; it
+-- only falls back to creating them (with the old stall) if create_upcoming_partitions()
+-- failed, which its own failed cron run also reports.
+
+CREATE OR REPLACE PROCEDURE create_upcoming_partitions(
+    p_lock_timeout text DEFAULT '2s',
+    p_max_attempts integer DEFAULT 3,
+    p_retry_delay interval DEFAULT '10 seconds'
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_parents text[];
+    v_premakes int[];
+    v_intervals interval[];
+    v_parent text;
+    v_target timestamptz;
+    v_offset integer;
+    v_created boolean;
+    v_attempt integer;
+    v_done boolean;
+    v_failed text[] := '{}';
+    i integer;
+BEGIN
+    -- Materialize the config before the loop: COMMIT is not allowed while a query cursor is
+    -- open. Covers every partman-managed parent, including ones added later.
+    SELECT array_agg(parent_table ORDER BY parent_table),
+           array_agg(premake ORDER BY parent_table),
+           array_agg(partition_interval::interval ORDER BY parent_table)
+    INTO v_parents, v_premakes, v_intervals
+    FROM partman.part_config
+    WHERE automatic_maintenance = 'on';
+
+    IF v_parents IS NULL THEN
+        RETURN;
+    END IF;
+
+    FOR i IN 1..array_length(v_parents, 1) LOOP
+        v_parent := v_parents[i];
+        -- Today plus the configured premake window. Offsets are snapped to the partition
+        -- boundary below; passing an unsnapped time makes partman build a range straddling
+        -- two partitions, which then fails as an overlap.
+        FOR v_offset IN 0..v_premakes[i] LOOP
+            SELECT base_timestamp INTO v_target
+            FROM partman.calculate_time_partition_info(
+                v_intervals[i],
+                clock_timestamp() + v_offset * v_intervals[i]
+            );
+
+            v_done := false;
+            v_attempt := 0;
+            WHILE NOT v_done AND v_attempt < p_max_attempts LOOP
+                v_attempt := v_attempt + 1;
+                BEGIN
+                    -- Applies to the current transaction only: if the parent lock is not
+                    -- granted within the timeout, yield instead of stalling the readers that
+                    -- queue behind the AccessExclusiveLock request.
+                    PERFORM set_config('lock_timeout', p_lock_timeout, true);
+                    SELECT partman.create_partition_time(
+                        p_parent_table := v_parent,
+                        p_partition_times := ARRAY[v_target]
+                    ) INTO v_created;
+                    IF v_created THEN
+                        RAISE NOTICE 'create_upcoming_partitions: created % partition for %',
+                            v_parent, v_target;
+                    END IF;
+                    v_done := true;
+                EXCEPTION
+                    WHEN OTHERS THEN
+                        RAISE NOTICE 'create_upcoming_partitions: % for % failed (attempt % of %): %',
+                            v_parent, v_target, v_attempt, p_max_attempts, SQLERRM;
+                END;
+                -- One transaction per partition: releases the parent lock (or nothing, after
+                -- a caught failure) before the backoff sleep or the next partition.
+                COMMIT;
+                IF NOT v_done AND v_attempt < p_max_attempts THEN
+                    PERFORM pg_sleep(extract(epoch FROM p_retry_delay));
+                END IF;
+            END LOOP;
+            IF NOT v_done THEN
+                -- The remaining offsets need the same parent lock, so skip this parent; the
+                -- 01:00 safety net or the next run picks them up.
+                v_failed := v_failed || v_parent;
+                EXIT;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    -- Completed creations are already committed; raising here only marks the run as failed
+    -- in cron.job_run_details so persistent errors are observable.
+    IF array_length(v_failed, 1) > 0 THEN
+        RAISE EXCEPTION 'create_upcoming_partitions: failed for % after % attempts each, remaining partitions retry next run',
+            v_failed, p_max_attempts;
+    END IF;
+END;
+$$;
+
+-- 00:05: right after the day rolls over, ahead of the 00:30 retention drops and the 01:00
+-- safety net.
+SELECT cron.schedule(
+    'create_upcoming_partitions',
+    '5 0 * * *',
+    'CALL create_upcoming_partitions();'
+);
+
+-- Move run_maintenance from midnight (@daily) to 01:00: demoted to a safety net that
+-- normally finds all premake partitions already created.
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE command LIKE '%run_maintenance_proc%';
+
+SELECT cron.schedule(
+    'run_maintenance_safety_net',
+    '0 1 * * *',
+    'CALL partman.run_maintenance_proc();'
+);


### PR DESCRIPTION
Follow-up to #1323, which moved retention out of `run_maintenance()`. This does the same for partition creation.

## Problem

`CREATE TABLE ... PARTITION OF` takes an `AccessExclusiveLock` on the parent, and `run_maintenance()` acquires it inside its per-table transaction, holding it until that transaction commits. Readers queue behind the lock request for the whole transaction, not for the creation itself.

Measured on dev-bsc at 00:00 (after #1323, so creation-only): five extractor connections blocked in `bind` on `component_balance` for 15.4-18.6s, all released together when maintenance committed. The same signature is present in prod: fynd-prod-base 9.3s, prod-base-2 2.7s on nights where maintenance succeeded.

The cost is the transaction length, not the DDL. On a local partitioned table, a reader arriving while a partition is created inside a 6s transaction blocks for 5017ms; the identical creation in its own transaction blocks it for 15ms.

## Change

New migration `2026-09-02_short_transaction_partition_creation`:

- Adds `create_upcoming_partitions(p_lock_timeout default '2s', p_max_attempts default 3, p_retry_delay default '10s')`, scheduled at 00:05. For each parent in `part_config` it walks offsets 0..premake, snaps each target time to the partition boundary with `partman.calculate_time_partition_info()`, and calls `partman.create_partition_time()` in its own transaction. `part_config` stays the source of truth for premake, interval and managed parents; already-existing partitions return false without taking the parent lock, so a normal run is a no-op (52ms locally).
- Lock handling mirrors `drop_expired_partitions`: per-transaction `lock_timeout` so a blocked creation yields instead of stalling queued readers, retries with backoff, retry on any error (partman re-raises internal errors with a generic SQLSTATE), and a final `RAISE` so an exhausted run shows up in `cron.job_run_details`. The retry budget is smaller than the drop job's because this makes up to premake+1 calls per parent rather than one.
- Moves `run_maintenance_proc()` from `@daily` to 01:00 as a safety net. With premake partitions already created it has nothing to create and takes no parent lock; it only falls back to creating them (with the old stall) if the 00:05 job failed.

Timestamps must be snapped before being passed to `create_partition_time()`: an unsnapped time makes partman build a range straddling two days, which then fails as an overlap. Verified both ways.

## Testing

Local PG16, pg_partman 5.1.0 (dev-bsc runs 5.2.4 with identical signatures for the three functions used), database built from migrations:

- no-op run when all partitions exist: 52ms
- gap fill across all three tables (middle premake day, newest day, first day) — all recreated
- contention (blocker holding `AccessShareLock` on the parent): the proc yields per attempt, retries, raises after the attempt budget, and a reader arriving during contention is blocked 19ms; after the blocker commits the next run restores the partition
- `diesel migration revert` + re-run
- `cargo test -p tycho-storage --lib`: 126 passed

Note for reviewers: partman derives its creation horizon from the newest data in the partition set (`ignore_default_data` is true, `infinite_time_partitions` false), while this procedure uses the wall clock. For a live database these agree; the clock-based version is also correct when an extractor is stalled and no rows have closed recently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)