### PR TITLE
chore(execution): verify contracts on Blockscout chains

### DIFF
--- a/crates/tycho-execution/contracts/hardhat.config.js
+++ b/crates/tycho-execution/contracts/hardhat.config.js
@@ -4,22 +4,6 @@ require("@nomicfoundation/hardhat-verify");
 require("@nomiclabs/hardhat-ethers");
 require("@nomicfoundation/hardhat-foundry");
 
-// Chains whose explorer is Blockscout rather than an Etherscan instance.
-const BLOCKSCOUT_NETWORKS = ["robinhood"];
-
-// hardhat-verify sends every string apiKey to the Etherscan v2 API, which does
-// not index Blockscout-only chains. An object keyed by network name keeps
-// verification on the customChains apiURL instead. Blockscout accepts any value
-// here; a Pro key from dev.blockscout.com raises the request rate limit.
-function explorerApiKey() {
-    const flag = process.argv.indexOf("--network");
-    const network = flag === -1 ? process.env.HARDHAT_NETWORK : process.argv[flag + 1];
-    if (BLOCKSCOUT_NETWORKS.includes(network)) {
-        return {[network]: process.env.BLOCKCHAIN_EXPLORER_API_KEY || "empty"};
-    }
-    return process.env.BLOCKCHAIN_EXPLORER_API_KEY;
-}
-
 module.exports = {
     solidity: {
         compilers: [
@@ -105,8 +89,10 @@ module.exports = {
         privateVerification: false,
     },
 
+    // Etherscan-family explorers only. Blockscout chains verify through their
+    // native v2 API in scripts/utils.js, which hardhat-verify never sees.
     etherscan: {
-        apiKey: explorerApiKey(),
+        apiKey: process.env.BLOCKCHAIN_EXPLORER_API_KEY,
         customChains: [
             {
                 network: "unichain",
@@ -122,14 +108,6 @@ module.exports = {
                 urls: {
                     apiURL: "https://api.routescan.io/v2/network/mainnet/evm/9745/etherscan/api",
                     browserURL: "https://plasmascan.to/"
-                }
-            },
-            {
-                network: "robinhood",
-                chainId: 4663,
-                urls: {
-                    apiURL: "https://robinhoodchain.blockscout.com/api",
-                    browserURL: "https://robinhoodchain.blockscout.com/"
                 }
             }
         ]

--- a/crates/tycho-execution/contracts/scripts/README.md
+++ b/crates/tycho-execution/contracts/scripts/README.md
@@ -27,10 +27,10 @@ from being stored in the shell history.
    export BLOCKCHAIN_EXPLORER_API_KEY=<blockchain-explorer-api-key>
    ```
 
-On chains whose explorer is Blockscout (`robinhood`), verification needs no key — set
-`BLOCKCHAIN_EXPLORER_API_KEY=empty`. Anonymous requests are rate limited; if verification returns
-`Too many requests`, use a free Pro key from [dev.blockscout.com](https://dev.blockscout.com) (starts with `proapi_`)
-as the value instead.
+On Robinhood Chain (`robinhood`), leave `BLOCKCHAIN_EXPLORER_API_KEY` unset.
+
+If verification reports that Blockscout has not indexed the contract, re-run the deploy script
+later. Re-running skips a deployment that already exists.
 
 ## Deploy Tycho Router
 

--- a/crates/tycho-execution/contracts/scripts/deploy-executors.js
+++ b/crates/tycho-execution/contracts/scripts/deploy-executors.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const {ethers} = require("hardhat");
 const hre = require("hardhat");
+const {verifyOnExplorer} = require("./utils");
 
 // Constructor args for each executor live in the shared config.
 // See config/executor_deployments.json.
@@ -122,6 +123,8 @@ async function main() {
         }
         const {contract: contractName, args} = deployment;
         const Executor = await ethers.getContractFactory(contractName);
+        // The Blockscout verification path needs the fully qualified name.
+        const {sourceName} = await hre.artifacts.readArtifact(contractName);
 
         // Get bytecode with constructor arguments
         const deployTx = Executor.getDeployTransaction(...args);
@@ -136,13 +139,23 @@ async function main() {
         const computedAddress = ethers.utils.getCreate2Address(create2FactoryAddress, salt, bytecodeHash);
         console.log(`${contractName} (${protocol}) will be deployed to: ${computedAddress}`);
 
-        const deploymentData = ethers.utils.concat([salt, bytecode]);
-        const tx = await deployer.sendTransaction({
-            to: create2FactoryAddress,
-            data: deploymentData,
-        });
-        await tx.wait();
-        console.log(`${contractName} deployed to: ${computedAddress}`);
+        // The address is derived from the bytecode and the constructor
+        // arguments, so an existing contract there is this exact build.
+        // Skipping the deployment makes the script re-runnable, which matters
+        // when verification has to be retried.
+        const deployed =
+            (await ethers.provider.getCode(computedAddress)) !== "0x";
+        if (deployed) {
+            console.log(`${contractName} already deployed, skipping deployment`);
+        } else {
+            const deploymentData = ethers.utils.concat([salt, bytecode]);
+            const tx = await deployer.sendTransaction({
+                to: create2FactoryAddress,
+                data: deploymentData,
+            });
+            await tx.wait();
+            console.log(`${contractName} deployed to: ${computedAddress}`);
+        }
 
         // Verify on Tenderly
         try {
@@ -155,13 +168,18 @@ async function main() {
             console.error("Error during contract verification:", error);
         }
 
-        console.log("Waiting for 1 minute before verifying the contract...");
-        await new Promise(resolve => setTimeout(resolve, 60000));
-        // Verify on Etherscan
+        if (!deployed) {
+            console.log("Waiting for 1 minute before verifying the contract...");
+            await new Promise(resolve => setTimeout(resolve, 60000));
+        }
+
+        // Verify on the block explorer
         try {
-            await hre.run("verify:verify", {
+            await verifyOnExplorer({
+                network,
                 address: computedAddress,
-                constructorArguments: args,
+                contractFqn: `${sourceName}:${contractName}`,
+                constructorArgs: args,
             });
             console.log(`${contractName} verified successfully on blockchain explorer!`);
         } catch (error) {

--- a/crates/tycho-execution/contracts/scripts/deploy-fee-calculator.js
+++ b/crates/tycho-execution/contracts/scripts/deploy-fee-calculator.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const {ethers} = require("hardhat");
 const hre = require("hardhat");
-const {resolveRolesNetwork} = require("./utils");
+const {resolveRolesNetwork, verifyOnExplorer} = require("./utils");
 
 async function main() {
     const network = hre.network.name;
@@ -41,14 +41,23 @@ async function main() {
     );
     console.log(`FeeCalculator will be deployed to: ${computedAddress}`);
 
-    const deploymentData = ethers.utils.concat([salt, bytecode]);
-    const tx = await deployer.sendTransaction({
-        to: create2FactoryAddress,
-        data: deploymentData,
-        gasLimit: 3_000_000,
-    });
-    await tx.wait();
-    console.log(`FeeCalculator deployed to: ${computedAddress}`);
+    // The address is derived from the bytecode, so an existing contract there is
+    // this exact build. Skipping the deployment makes the script re-runnable,
+    // which matters when verification has to be retried.
+    const deployed =
+        (await ethers.provider.getCode(computedAddress)) !== "0x";
+    if (deployed) {
+        console.log("FeeCalculator already deployed, skipping deployment");
+    } else {
+        const deploymentData = ethers.utils.concat([salt, bytecode]);
+        const tx = await deployer.sendTransaction({
+            to: create2FactoryAddress,
+            data: deploymentData,
+            gasLimit: 3_000_000,
+        });
+        await tx.wait();
+        console.log(`FeeCalculator deployed to: ${computedAddress}`);
+    }
 
     // Verify on Tenderly
     try {
@@ -61,16 +70,20 @@ async function main() {
         console.error("Error during contract verification:", error);
     }
 
-    console.log(
-        "Waiting for 1 minute before verifying the contract..."
-    );
-    await new Promise(resolve => setTimeout(resolve, 60000));
+    if (!deployed) {
+        console.log(
+            "Waiting for 1 minute before verifying the contract..."
+        );
+        await new Promise(resolve => setTimeout(resolve, 60000));
+    }
 
-    // Verify on Etherscan
+    // Verify on the block explorer
     try {
-        await hre.run("verify:verify", {
+        await verifyOnExplorer({
+            network,
             address: computedAddress,
-            constructorArguments: [routerFeeSetter],
+            contractFqn: "src/FeeCalculator.sol:FeeCalculator",
+            constructorArgs: [routerFeeSetter],
         });
         console.log(
             "FeeCalculator verified successfully on blockchain explorer!"

--- a/crates/tycho-execution/contracts/scripts/deploy-router.js
+++ b/crates/tycho-execution/contracts/scripts/deploy-router.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const {ethers} = require("hardhat");
 const hre = require("hardhat");
-const {resolveRolesNetwork} = require("./utils");
+const {resolveRolesNetwork, verifyOnExplorer} = require("./utils");
 
 async function main() {
     const network = hre.network.name;
@@ -52,13 +52,23 @@ async function main() {
     const computedAddress = ethers.utils.getCreate2Address(create2FactoryAddress, salt, bytecodeHash);
     console.log(`TychoRouterV3 will be deployed to: ${computedAddress}`);
 
-    const deploymentData = ethers.utils.concat([salt, bytecode]);
-    const tx = await deployer.sendTransaction({
-        to: create2FactoryAddress,
-        data: deploymentData,
-    });
-    await tx.wait();
-    console.log(`TychoRouterV3 deployed to: ${computedAddress}`);
+    // The address is derived from the bytecode and the constructor arguments, so
+    // an existing contract there is this exact build. Skipping the deployment
+    // makes the script re-runnable, which matters when verification has to be
+    // retried.
+    const deployed =
+        (await ethers.provider.getCode(computedAddress)) !== "0x";
+    if (deployed) {
+        console.log("TychoRouterV3 already deployed, skipping deployment");
+    } else {
+        const deploymentData = ethers.utils.concat([salt, bytecode]);
+        const tx = await deployer.sendTransaction({
+            to: create2FactoryAddress,
+            data: deploymentData,
+        });
+        await tx.wait();
+        console.log(`TychoRouterV3 deployed to: ${computedAddress}`);
+    }
 
     // Verify on Tenderly
     try {
@@ -72,14 +82,18 @@ async function main() {
         console.error("Error during contract verification:", error);
     }
 
-    console.log("Waiting for 1 minute before verifying the contract...");
-    await new Promise(resolve => setTimeout(resolve, 60000));
+    if (!deployed) {
+        console.log("Waiting for 1 minute before verifying the contract...");
+        await new Promise(resolve => setTimeout(resolve, 60000));
+    }
 
-    // Verify on Etherscan
+    // Verify on the block explorer
     try {
-        await hre.run("verify:verify", {
+        await verifyOnExplorer({
+            network,
             address: computedAddress,
-            constructorArguments: [
+            contractFqn: "src/TychoRouterV3.sol:TychoRouterV3",
+            constructorArgs: [
                 permit2,
                 feeCalculator,
                 unpauser,

--- a/crates/tycho-execution/contracts/scripts/utils.js
+++ b/crates/tycho-execution/contracts/scripts/utils.js
@@ -91,8 +91,12 @@ function getHardhatStandardJsonInput(contractsDir, contractFqn) {
 /**
  * Blockscout's verification endpoints answer HTTP 500 for any address it does
  * not hold as a contract, so check the two reasons that happens up front.
+ *
+ * @returns {boolean} whether Blockscout already holds the contract as verified.
+ *     Submitting again for such an address is rejected, and deploy scripts are
+ *     meant to be re-runnable.
  */
-async function assertVerifiable(config, address) {
+async function checkVerifiable(config, address) {
     if ((await ethers.provider.getCode(address)) === "0x") {
         throw new Error(
             `No contract deployed at ${address}. The address is derived from ` +
@@ -114,8 +118,18 @@ async function assertVerifiable(config, address) {
             "contract creation shows up."
         );
     }
+
+    return ok && body.is_verified === true;
 }
 
+/**
+ * Wait for the submitted verification to land.
+ *
+ * `is_verified` is the only signal available: Blockscout's v2 smart-contract
+ * response carries no verification status field, and it pushes the outcome of a
+ * submission over a websocket rather than over HTTP. A rejected verification is
+ * therefore indistinguishable from a slow queue, and surfaces as this timeout.
+ */
 async function pollBlockscoutVerification(config, address) {
     const url = `${config.apiBase}/smart-contracts/${address}`;
 
@@ -124,14 +138,13 @@ async function pollBlockscoutVerification(config, address) {
         if (ok && body.is_verified) {
             return;
         }
-        if (ok && body.verification_status === "failed") {
-            throw new Error(
-                "Blockscout verification failed: " + JSON.stringify(body)
-            );
-        }
         await new Promise(resolve => setTimeout(resolve, 5000));
     }
-    throw new Error("Timed out waiting for Blockscout verification");
+    throw new Error(
+        "Timed out waiting for Blockscout verification. It reports the reason " +
+        "for a rejected submission only in its UI: see " +
+        `${config.browserUrl}address/${address}#code`
+    );
 }
 
 /**
@@ -145,15 +158,18 @@ async function verifyOnBlockscout({network, address, contractFqn, constructorArg
         throw new Error(`No Blockscout config for network "${network}"`);
     }
 
+    console.log(`Verifying on Blockscout (chain ${config.chainId})...`);
+    if (await checkVerifiable(config, address)) {
+        console.log(`Already verified: ${config.browserUrl}address/${address}#code`);
+        return;
+    }
+
     const contractsDir = path.resolve(__dirname, "..");
     const constructorArgsHex = encodeConstructorArgs(
         contractsDir,
         contractFqn,
         constructorArgs
     );
-
-    console.log(`Verifying on Blockscout (chain ${config.chainId})...`);
-    await assertVerifiable(config, address);
 
     const {standardJson, compilerVersion} = getHardhatStandardJsonInput(
         contractsDir,

--- a/crates/tycho-execution/contracts/scripts/utils.js
+++ b/crates/tycho-execution/contracts/scripts/utils.js
@@ -1,8 +1,223 @@
 const {ethers} = require("hardhat");
+const hre = require("hardhat");
 const Safe = require('@safe-global/protocol-kit').default;
 const {EthersAdapter} = require('@safe-global/protocol-kit');
 const {default: SafeApiKit} = require("@safe-global/api-kit");
+const fs = require("fs");
+const path = require("path");
 const roles = require("./roles.json");
+
+// Chains whose explorer is a Blockscout instance rather than an Etherscan one.
+// Verification goes through Blockscout's native v2 API because hardhat-verify
+// and forge verify-contract cannot set a browser User-Agent, and the instance
+// sits behind Cloudflare (see USER_AGENT). No API key is required.
+const BLOCKSCOUT_NETWORKS = {
+    robinhood: {
+        chainId: 4663,
+        apiBase: "https://robinhoodchain.blockscout.com/api/v2",
+        browserUrl: "https://robinhoodchain.blockscout.com/",
+    },
+};
+
+// Cloudflare answers 403 to requests carrying a curl or node User-Agent.
+const USER_AGENT =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+async function blockscoutGet(url) {
+    const res = await fetch(url, {
+        headers: {"user-agent": USER_AGENT, accept: "application/json"},
+    });
+    // Cloudflare answers with an HTML challenge page rather than JSON.
+    const text = await res.text();
+    try {
+        return {ok: res.ok, body: JSON.parse(text)};
+    } catch {
+        return {ok: false, body: null};
+    }
+}
+
+function artifactPath(contractsDir, contractFqn, extension) {
+    const [sourceName, contractName] = contractFqn.split(":");
+    return path.join(
+        contractsDir,
+        "artifacts",
+        sourceName,
+        `${contractName}${extension}`
+    );
+}
+
+/** ABI-encode constructor arguments using the artifact's own input types. */
+function encodeConstructorArgs(contractsDir, contractFqn, constructorArgs) {
+    const artifact = JSON.parse(
+        fs.readFileSync(artifactPath(contractsDir, contractFqn, ".json"), "utf8")
+    );
+    const constructor = artifact.abi.find(
+        (entry) => entry.type === "constructor"
+    );
+    const types = (constructor?.inputs || []).map((input) => input.type);
+    return ethers.utils.defaultAbiCoder
+        .encode(types, constructorArgs)
+        .replace(/^0x/, "");
+}
+
+/**
+ * Load the exact standard JSON input that produced the deployed artifact.
+ *
+ * The contract's .dbg.json names its build-info file, so this always matches
+ * the compile the deployment bytecode came from. Do not search build-info by
+ * contract name: `IFeeCalculator.sol` and `FeeCalculator.sol` both match a
+ * suffix test, and stale build-info files from earlier compiles linger.
+ */
+function getHardhatStandardJsonInput(contractsDir, contractFqn) {
+    const dbgPath = artifactPath(contractsDir, contractFqn, ".dbg.json");
+    if (!fs.existsSync(dbgPath)) {
+        throw new Error(
+            `No Hardhat artifact at ${dbgPath}. ` +
+            "Run `npx hardhat compile` first."
+        );
+    }
+
+    const {buildInfo} = JSON.parse(fs.readFileSync(dbgPath, "utf8"));
+    const buildInfoPath = path.resolve(path.dirname(dbgPath), buildInfo);
+    const info = JSON.parse(fs.readFileSync(buildInfoPath, "utf8"));
+
+    return {
+        standardJson: JSON.stringify(info.input),
+        compilerVersion: `v${info.solcLongVersion}`,
+    };
+}
+
+/**
+ * Blockscout's verification endpoints answer HTTP 500 for any address it does
+ * not hold as a contract, so check the two reasons that happens up front.
+ */
+async function assertVerifiable(config, address) {
+    if ((await ethers.provider.getCode(address)) === "0x") {
+        throw new Error(
+            `No contract deployed at ${address}. The address is derived from ` +
+            "the current artifact bytecode, so a recompile since deployment " +
+            "moves it. Check out the deployed commit and recompile."
+        );
+    }
+
+    const {ok, body} = await blockscoutGet(
+        `${config.apiBase}/addresses/${address}`
+    );
+    if (ok && body.is_contract === false) {
+        throw new Error(
+            `Blockscout has not indexed ${address} as a contract yet, and it ` +
+            "rejects verification for unknown addresses. CREATE2 deployments " +
+            "reach Blockscout through internal transactions, which this " +
+            "instance indexes behind the chain head. Check " +
+            `${config.browserUrl}address/${address} and retry once the ` +
+            "contract creation shows up."
+        );
+    }
+}
+
+async function pollBlockscoutVerification(config, address) {
+    const url = `${config.apiBase}/smart-contracts/${address}`;
+
+    for (let attempt = 0; attempt < 30; attempt++) {
+        const {ok, body} = await blockscoutGet(url);
+        if (ok && body.is_verified) {
+            return;
+        }
+        if (ok && body.verification_status === "failed") {
+            throw new Error(
+                "Blockscout verification failed: " + JSON.stringify(body)
+            );
+        }
+        await new Promise(resolve => setTimeout(resolve, 5000));
+    }
+    throw new Error("Timed out waiting for Blockscout verification");
+}
+
+/**
+ * Verify on a Blockscout instance via its native v2 standard-input API.
+ * Compiler settings come from the artifact's own build-info, so they match the
+ * deployment by construction.
+ */
+async function verifyOnBlockscout({network, address, contractFqn, constructorArgs}) {
+    const config = BLOCKSCOUT_NETWORKS[network];
+    if (!config) {
+        throw new Error(`No Blockscout config for network "${network}"`);
+    }
+
+    const contractsDir = path.resolve(__dirname, "..");
+    const constructorArgsHex = encodeConstructorArgs(
+        contractsDir,
+        contractFqn,
+        constructorArgs
+    );
+
+    console.log(`Verifying on Blockscout (chain ${config.chainId})...`);
+    await assertVerifiable(config, address);
+
+    const {standardJson, compilerVersion} = getHardhatStandardJsonInput(
+        contractsDir,
+        contractFqn
+    );
+
+    const form = new FormData();
+    form.append("compiler_version", compilerVersion);
+    form.append("contract_name", contractFqn.split(":")[1]);
+    form.append(
+        "files[0]",
+        new Blob([standardJson], {type: "application/json"}),
+        "standard-input.json"
+    );
+    form.append("autodetect_constructor_args", "false");
+    form.append("constructor_args", constructorArgsHex);
+    form.append("license_type", "none");
+
+    const verifyUrl =
+        `${config.apiBase}/smart-contracts/${address}` +
+        "/verification/via/standard-input";
+    const res = await fetch(verifyUrl, {
+        method: "POST",
+        headers: {"user-agent": USER_AGENT, accept: "application/json"},
+        body: form,
+    });
+    const body = await res.text();
+    if (!res.ok) {
+        throw new Error(
+            `HTTP ${res.status} from ${verifyUrl}: ${body.slice(0, 500)}`
+        );
+    }
+
+    console.log(`Verification submitted: ${body.trim()}`);
+    await pollBlockscoutVerification(config, address);
+    console.log(`Verified: ${config.browserUrl}address/${address}#code`);
+}
+
+/**
+ * Verify on whichever explorer the network uses: Blockscout's native v2 API for
+ * Blockscout chains, hardhat-verify's Etherscan flow everywhere else.
+ *
+ * @param {string} network Hardhat network name
+ * @param {string} address Deployed contract address
+ * @param {string} contractFqn Source path and contract name, `src/X.sol:X`.
+ *     Used by the Blockscout path; hardhat-verify detects it from the bytecode.
+ * @param {Array} constructorArgs Constructor arguments, in declaration order
+ */
+async function verifyOnExplorer({network, address, contractFqn, constructorArgs}) {
+    if (BLOCKSCOUT_NETWORKS[network]) {
+        await verifyOnBlockscout({
+            network,
+            address,
+            contractFqn,
+            constructorArgs,
+        });
+        return;
+    }
+
+    await hre.run("verify:verify", {
+        address,
+        constructorArguments: constructorArgs,
+    });
+}
 
 const txServiceUrls = {
     ethereum: "https://safe-transaction-mainnet.safe.global",
@@ -75,5 +290,6 @@ async function proposeTransaction(safeAddress, txData, signer, methodName) {
 
 module.exports = {
     proposeOrSendTransaction,
-    resolveRolesNetwork
+    resolveRolesNetwork,
+    verifyOnExplorer,
 }


### PR DESCRIPTION
Verification on Robinhood Chain went through hardhat-verify, which cannot set a browser `User-Agent` — Cloudflare answers 403 to everything else.

  Blockscout chains now verify through the explorer's native v2 standard-input API, with a browser `User-Agent` and no API key:

  - Standard JSON input comes from the contract's own `.dbg.json` build-info reference, not a filename-suffix scan over build-info (which also matched `IFeeCalculator.sol` and stale compiles).
  - Constructor arguments encode from the artifact ABI, so one path serves the router's six arguments and the fee calculator's one.
  - Blockscout returns HTTP 500 for an address it has not indexed as a contract; a pre-flight check reports that separately from missing bytecode.
  - Both deploy scripts skip a CREATE2 deployment that already exists, so retrying verification is just a re-run.
