### PR TITLE
feat(simulation): gate pending indexers on a state capability

### DIFF
--- a/crates/tycho-common/src/simulation/protocol_sim.rs
+++ b/crates/tycho-common/src/simulation/protocol_sim.rs
@@ -376,6 +376,23 @@ pub trait ProtocolSim: fmt::Debug + Send + Sync + 'static {
         balances: &Balances,
     ) -> Result<(), TransitionError>;
 
+    /// Whether [`delta_transition`](Self::delta_transition) can bring this state to the block
+    /// `delta` describes, and quote it afterwards, without reading anything beyond its own
+    /// arguments.
+    ///
+    /// `false` means the transition or a quote taken after it falls back to a source the caller
+    /// does not supply — for EVM protocols, contract storage held in a database that only the
+    /// confirmed indexing pipeline updates. Applying `delta` to such a state layers new
+    /// attributes over stale storage and reports no error, so callers that transition a state
+    /// outside that pipeline must refuse it instead.
+    ///
+    /// Defaults to `false`. Return `true` once both the transition and the quote path are known
+    /// to depend on the arguments alone.
+    #[allow(unused)]
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        false
+    }
+
     /// Calculates the swap volume required to achieve the provided goal when trading against this
     /// pool.
     ///
@@ -507,6 +524,10 @@ where
     ) -> Result<(), TransitionError> {
         self.delta_transition(TransitionParams::new(delta, tokens, balances))
             .map(|_| ())
+    }
+
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        <T as SwapQuoter>::transitions_from_delta_alone(self, delta)
     }
 
     fn query_pool_swap(&self, params: &QueryPoolSwapParams) -> Result<PoolSwap, SimulationError> {

--- a/crates/tycho-common/src/simulation/swap.rs
+++ b/crates/tycho-common/src/simulation/swap.rs
@@ -984,6 +984,23 @@ pub trait SwapQuoter: fmt::Debug + Send + Sync + 'static {
     fn delta_transition(&mut self, params: TransitionParams)
         -> Result<Transition, TransitionError>;
 
+    /// Whether [`delta_transition`](Self::delta_transition) can bring this state to the block
+    /// `delta` describes, and quote it afterwards, without reading anything beyond its own
+    /// arguments.
+    ///
+    /// `false` means the transition or a quote taken after it falls back to a source the caller
+    /// does not supply — for EVM protocols, contract storage held in a database that only the
+    /// confirmed indexing pipeline updates. Applying `delta` to such a state layers new
+    /// attributes over stale storage and reports no error, so callers that transition a state
+    /// outside that pipeline must refuse it instead.
+    ///
+    /// Defaults to `false`. Return `true` once both the transition and the quote path are known
+    /// to depend on the arguments alone.
+    #[allow(unused)]
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        false
+    }
+
     /// Clones the protocol state as a trait object.
     ///
     /// This method enables cloning when the pool is used as a boxed trait object,

--- a/crates/tycho-simulation/CLAUDE.md
+++ b/crates/tycho-simulation/CLAUDE.md
@@ -83,6 +83,15 @@ state. Fluid and Curve close that gap the same way:
 Reading under the pending block's own number and timestamp matters: anything with on-chain time
 math (Fluid's expanding limits, Curve's ramping `A()`) is wrong under the parent block's clock.
 
+`ProtocolSim::transitions_from_delta_alone(delta)` is how a state reports which side of that
+branch it lands on, and `apply_deltas_ephemeral` fails the whole update when a delta targets a
+state that reports `false`. It defaults to `false`, so a new protocol is refused from the pending
+path until its author has checked that both the transition and the quote depend on the delta
+alone. Native states return `true`; Fluid and Curve return `true` only when their attribute is
+present; `EVMPoolState`, ERC4626, Balancer V3 and VM-backed V4 hook handlers keep the default.
+The property is per state and per delta, not per protocol name — `uniswap_v4` and
+`uniswap_v4_hooks` decode into the same type and differ only in whether a hook is attached.
+
 ## Features
 
 | Feature | Default | Contents |

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1059,9 +1059,8 @@ where
     /// `DecoderState`. Calling this method twice with the same input produces identical results.
     ///
     /// Every state is rebuilt from `state_deltas` alone; nothing here writes to the VM database.
-    /// A protocol decoding into the generic VM adapter therefore cannot take part: it re-reads
-    /// pool state from that database, so its storage-derived values stay at the confirmed block —
-    /// even though the delta's balance and block-environment attributes do get applied.
+    /// A state that reports `transitions_from_delta_alone() == false` for its delta therefore
+    /// cannot take part, and this method fails rather than quote it against confirmed data.
     ///
     /// # Parameters
     /// * `pending_deltas` — map from extractor name to the `BlockAggregatedChanges` produced by the
@@ -1070,6 +1069,10 @@ where
     ///   returned [`Update`]; its `block_number` and `block_timestamp` are injected into each state
     ///   delta so that protocols relying on block context (e.g. aerodrome slipstreams, etherfi)
     ///   receive correct values.
+    ///
+    /// # Errors
+    /// Returns [`StreamDecodeError::Fatal`] if any delta targets a pool whose state cannot be
+    /// transitioned from that delta alone. Pools with no decoded state yet are skipped.
     pub async fn apply_deltas_ephemeral(
         &self,
         pending_deltas: &HashMap<String, BlockAggregatedChanges>,
@@ -1083,7 +1086,7 @@ where
 
         let mut updated_states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
 
-        for deltas in pending_deltas.values() {
+        for (extractor, deltas) in pending_deltas {
             let all_balances = Balances {
                 component_balances: deltas
                     .component_balances
@@ -1104,6 +1107,19 @@ where
                     ProtocolStateDelta::from(state_delta.clone()),
                     current_block.clone(),
                 );
+
+                let reads_beyond_delta = updated_states
+                    .get(id)
+                    .or_else(|| state_guard.states.get(id))
+                    .is_some_and(|state| !state.transitions_from_delta_alone(&dto_delta));
+                if reads_beyond_delta {
+                    return Err(StreamDecodeError::Fatal(format!(
+                        "extractor '{extractor}': pool {id} cannot be transitioned from this \
+                         delta alone, so it would quote confirmed state. Have its indexer supply \
+                         the attributes the state needs, or stop registering one for it."
+                    )));
+                }
+
                 if let Err(e) = Self::apply_update(
                     id,
                     dto_delta,
@@ -1805,5 +1821,88 @@ mod tests {
         assert!(!decoder.admits("x", &component_with_id("b")));
         assert!(decoder.admits("x", &component_with_id("c")));
         assert!(decoder.admits("y", &component_with_id("a")));
+    }
+
+    const EPHEMERAL_POOL: &str = "0x0000000000000000000000000000000000000bad1";
+
+    fn reserve_deltas() -> HashMap<String, BlockAggregatedChanges> {
+        use tycho_common::models::protocol::ProtocolComponentStateDelta;
+
+        let attributes = HashMap::from([
+            ("reserve0".to_string(), Bytes::from(1_000_u64.to_be_bytes().to_vec())),
+            ("reserve1".to_string(), Bytes::from(2_000_u64.to_be_bytes().to_vec())),
+        ]);
+        HashMap::from([(
+            "uniswap_v2".to_string(),
+            BlockAggregatedChanges {
+                state_deltas: HashMap::from([(
+                    EPHEMERAL_POOL.to_string(),
+                    ProtocolComponentStateDelta::new(EPHEMERAL_POOL, attributes, HashSet::new()),
+                )]),
+                ..Default::default()
+            },
+        )])
+    }
+
+    async fn decoder_holding(state: Box<dyn ProtocolSim>) -> TychoStreamDecoder<BlockHeader> {
+        let decoder = setup_decoder(true).await;
+        decoder
+            .state
+            .write()
+            .await
+            .states
+            .insert(EPHEMERAL_POOL.to_string(), state);
+        decoder
+    }
+
+    #[tokio::test]
+    async fn test_apply_deltas_ephemeral_transitions_a_state_that_needs_only_the_delta() {
+        let decoder =
+            decoder_holding(Box::new(UniswapV2State::new(U256::from(1), U256::from(1)))).await;
+
+        let update = decoder
+            .apply_deltas_ephemeral(&reserve_deltas(), BlockHeader::default())
+            .await
+            .expect("a state carrying its reserves in the delta must transition");
+
+        let state = update
+            .states
+            .get(EPHEMERAL_POOL)
+            .expect("the pool must appear in the ephemeral update")
+            .as_any()
+            .downcast_ref::<UniswapV2State>()
+            .expect("the pool keeps its type");
+        assert_eq!(state, &UniswapV2State::new(U256::from(1_000), U256::from(2_000)));
+    }
+
+    /// A state that reads past its delta would quote the confirmed block while reporting the
+    /// pending one. `MockProtocolSim` does not override the capability, so it takes the
+    /// conservative default and must be refused.
+    #[tokio::test]
+    async fn test_apply_deltas_ephemeral_refuses_a_state_that_reads_past_the_delta() {
+        let decoder = decoder_holding(Box::new(MockProtocolSim::new())).await;
+
+        let error = decoder
+            .apply_deltas_ephemeral(&reserve_deltas(), BlockHeader::default())
+            .await
+            .expect_err("a state that reads past the delta must be refused");
+
+        let message = error.to_string();
+        assert!(message.contains(EPHEMERAL_POOL), "{message}");
+        assert!(message.contains("uniswap_v2"), "{message}");
+    }
+
+    /// Pools the decoder has no state for yet are not the caller's mistake — they are skipped,
+    /// as on the confirmed path.
+    #[tokio::test]
+    async fn test_apply_deltas_ephemeral_skips_pools_with_no_state() {
+        let decoder = setup_decoder(true).await;
+
+        let update = decoder
+            .apply_deltas_ephemeral(&reserve_deltas(), BlockHeader::default())
+            .await
+            .expect("an unknown pool must not fail the update");
+
+        assert!(update.states.is_empty());
     }
 }

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1825,15 +1825,14 @@ mod tests {
 
     const EPHEMERAL_POOL: &str = "0x0000000000000000000000000000000000000bad1";
 
-    fn reserve_deltas() -> HashMap<String, BlockAggregatedChanges> {
+    fn pending_deltas(
+        extractor: &str,
+        attributes: HashMap<String, Bytes>,
+    ) -> HashMap<String, BlockAggregatedChanges> {
         use tycho_common::models::protocol::ProtocolComponentStateDelta;
 
-        let attributes = HashMap::from([
-            ("reserve0".to_string(), Bytes::from(1_000_u64.to_be_bytes().to_vec())),
-            ("reserve1".to_string(), Bytes::from(2_000_u64.to_be_bytes().to_vec())),
-        ]);
         HashMap::from([(
-            "uniswap_v2".to_string(),
+            extractor.to_string(),
             BlockAggregatedChanges {
                 state_deltas: HashMap::from([(
                     EPHEMERAL_POOL.to_string(),
@@ -1842,6 +1841,16 @@ mod tests {
                 ..Default::default()
             },
         )])
+    }
+
+    fn reserve_deltas() -> HashMap<String, BlockAggregatedChanges> {
+        pending_deltas(
+            "uniswap_v2",
+            HashMap::from([
+                ("reserve0".to_string(), Bytes::from(1_000_u64.to_be_bytes().to_vec())),
+                ("reserve1".to_string(), Bytes::from(2_000_u64.to_be_bytes().to_vec())),
+            ]),
+        )
     }
 
     async fn decoder_holding(state: Box<dyn ProtocolSim>) -> TychoStreamDecoder<BlockHeader> {
@@ -1904,5 +1913,65 @@ mod tests {
             .expect("an unknown pool must not fail the update");
 
         assert!(update.states.is_empty());
+    }
+
+    /// An Angstrom hook reads only the delta: `delta_transition` copies three attributes off it
+    /// and the swap maths is pure Rust. A V4 pool carrying one transitions on the pending path.
+    #[tokio::test]
+    async fn test_apply_deltas_ephemeral_angstrom_hooked_v4_pool() {
+        use alloy::primitives::aliases::U24;
+
+        use crate::evm::protocol::{
+            uniswap_v4::{
+                hooks::angstrom::hook_handler::{AngstromFees, AngstromHookHandler},
+                state::{UniswapV4Fees, UniswapV4State},
+            },
+            utils::uniswap::tick_list::TickInfo,
+        };
+
+        let mut pool = UniswapV4State::new(
+            1_000_000_000_000_000_000,
+            U256::from_str("79228162514264337593543950336").unwrap(),
+            UniswapV4Fees { zero_for_one: 100, one_for_zero: 100, lp_fee: 100 },
+            0,
+            60,
+            vec![
+                TickInfo::new(-600, 500_000_000_000_000_000).unwrap(),
+                TickInfo::new(600, -500_000_000_000_000_000).unwrap(),
+            ],
+        )
+        .unwrap();
+        pool.set_hook_handler(Box::new(AngstromHookHandler::new(
+            Address::ZERO,
+            Address::ZERO,
+            AngstromFees { unlock: U24::from(338), protocol_unlock: U24::from(112) },
+            false,
+        )));
+        let deltas = pending_deltas(
+            "uniswap_v4_hooks",
+            HashMap::from([(
+                "liquidity".to_string(),
+                Bytes::from(
+                    2_000_000_000_000_000_000_u128
+                        .to_be_bytes()
+                        .to_vec(),
+                ),
+            )]),
+        );
+
+        let update = decoder_holding(Box::new(pool))
+            .await
+            .apply_deltas_ephemeral(&deltas, BlockHeader::default())
+            .await
+            .expect("an Angstrom hook rebuilds from the delta");
+
+        let state = update
+            .states
+            .get(EPHEMERAL_POOL)
+            .expect("the pool must appear in the ephemeral update")
+            .as_any()
+            .downcast_ref::<UniswapV4State>()
+            .expect("the ephemeral state must still be a UniswapV4State");
+        assert!(state.hook.is_some(), "the transition must keep the hook attached");
     }
 }

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
@@ -648,6 +648,10 @@ impl ProtocolSim for AerodromeSlipstreamsState {
         fee_before != self.get_fee().ok()
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_v1/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_v1/state.rs
@@ -261,6 +261,10 @@ impl ProtocolSim for AerodromeV1State {
         }
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/cowamm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/cowamm/state.rs
@@ -806,6 +806,10 @@ impl ProtocolSim for CowAMMState {
         crate::evm::query_pool_swap::query_pool_swap(self, params)
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/curve/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/state.rs
@@ -255,6 +255,14 @@ impl ProtocolSim for CurveState {
         Ok(())
     }
 
+    /// True only when the delta carries `pool_state_adjusted`. Without it the transition falls
+    /// back to reading the view getters against the confirmed VM storage.
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        delta
+            .updated_attributes
+            .contains_key(vm::POOL_STATE_ADJUSTED)
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }
@@ -320,6 +328,20 @@ mod tests {
 
     fn delta(attributes: HashMap<String, Bytes>) -> ProtocolStateDelta {
         ProtocolStateDelta { updated_attributes: attributes, ..Default::default() }
+    }
+
+    /// Without `pool_state_adjusted` the transition reads the view getters against the confirmed
+    /// VM storage, which a pending block never reaches.
+    #[test]
+    fn test_delta_alone_suffices_only_with_the_readings_attribute() {
+        let curve = state(vec![u("1"), u("1"), u("1")]);
+        let attribute = encode_readings(&readings(vec![u("2"), u("2"), u("2")])).expect("encode");
+
+        let with_readings =
+            delta(HashMap::from([(vm::POOL_STATE_ADJUSTED.to_string(), attribute)]));
+
+        assert!(curve.transitions_from_delta_alone(&with_readings));
+        assert!(!curve.transitions_from_delta_alone(&delta(HashMap::new())));
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/ekubo/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo/state.rs
@@ -125,6 +125,10 @@ impl ProtocolSim for EkuboState {
         self.finish_transition(delta.updated_attributes, delta.deleted_attributes)
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/state.rs
@@ -170,6 +170,10 @@ impl ProtocolSim for EkuboV3State {
         crate::evm::query_pool_swap::query_pool_swap(self, params)
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/etherfi/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/etherfi/state.rs
@@ -452,6 +452,10 @@ impl ProtocolSim for EtherfiState {
         crate::evm::query_pool_swap::query_pool_swap(self, params)
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/fluid/v1.rs
+++ b/crates/tycho-simulation/src/evm/protocol/fluid/v1.rs
@@ -430,6 +430,14 @@ impl ProtocolSim for FluidV1 {
         Ok(())
     }
 
+    /// True only when the delta carries `pool_reserves_adjusted`. Without it the transition
+    /// falls back to reading the resolver against the confirmed VM database.
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        delta
+            .updated_attributes
+            .contains_key(vm::POOL_RESERVES_ADJUSTED_ATTRIBUTE)
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }
@@ -1316,6 +1324,24 @@ mod test {
                 10,
         );
         (wsteth, eth, pool)
+    }
+
+    /// Without `pool_reserves_adjusted` the transition reads the resolver against the confirmed
+    /// VM database, which a pending block never reaches.
+    #[test]
+    fn test_delta_alone_suffices_only_with_the_reserves_attribute() {
+        let (_, _, pool) = setup_fluid_pool(U256::from(1));
+
+        let with_reserves = ProtocolStateDelta {
+            updated_attributes: HashMap::from([(
+                vm::POOL_RESERVES_ADJUSTED_ATTRIBUTE.to_string(),
+                Bytes::from(vec![1u8, 2, 3]),
+            )]),
+            ..Default::default()
+        };
+
+        assert!(pool.transitions_from_delta_alone(&with_reserves));
+        assert!(!pool.transitions_from_delta_alone(&ProtocolStateDelta::default()));
     }
 
     fn limits_wide() -> DexLimits {

--- a/crates/tycho-simulation/src/evm/protocol/lunarbase/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/lunarbase/state.rs
@@ -231,6 +231,10 @@ impl ProtocolSim for LunarBaseState {
         crate::evm::query_pool_swap::query_pool_swap(self, params)
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/native_wrapper/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/native_wrapper/state.rs
@@ -112,6 +112,10 @@ impl ProtocolSim for NativeWrapperState {
         Ok(())
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/state.rs
@@ -145,6 +145,10 @@ impl ProtocolSim for PancakeswapV2State {
         }
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/ramses_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ramses_v3/state.rs
@@ -515,6 +515,10 @@ impl ProtocolSim for RamsesV3State {
         }
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/ring_swap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ring_swap_v2/state.rs
@@ -291,6 +291,10 @@ impl ProtocolSim for RingSwapV2State {
         }
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/rocketpool/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/rocketpool/state.rs
@@ -437,6 +437,10 @@ impl ProtocolSim for RocketpoolState {
         Ok(())
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/sky/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/sky/state.rs
@@ -372,6 +372,10 @@ impl ProtocolSim for SkyState {
         Ok(())
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v2/state.rs
@@ -145,6 +145,10 @@ impl ProtocolSim for UniswapV2State {
         }
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -541,6 +541,10 @@ impl ProtocolSim for UniswapV3State {
         }
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/hooks/angstrom/hook_handler.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/hooks/angstrom/hook_handler.rs
@@ -168,6 +168,10 @@ impl HookHandler for AngstromHookHandler {
         Ok(())
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn spot_price(&self, _base: &Token, _quote: &Token) -> Result<f64, SimulationError> {
         Err(SimulationError::RecoverableError(
             "spot_price is not implemented for AngstromHook".to_string(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/hooks/hook_handler.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/hooks/hook_handler.rs
@@ -65,6 +65,20 @@ pub trait HookHandler: Debug + Send + Sync + 'static {
         tokens: &HashMap<Bytes, Token>,
         balances: &Balances,
     ) -> Result<(), TransitionError>;
+
+    /// Whether this handler can serve the block `delta` describes after
+    /// [`delta_transition`](Self::delta_transition), reading nothing beyond its arguments.
+    ///
+    /// Mirrors
+    /// [`ProtocolSim::transitions_from_delta_alone`](tycho_common::simulation::protocol_sim::ProtocolSim::transitions_from_delta_alone)
+    /// for the hook half of a pool: a
+    /// handler that simulates against the shared VM database returns `false`, because that
+    /// database only ever holds confirmed state.
+    #[allow(unused)]
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        false
+    }
+
     fn clone_box(&self) -> Box<dyn HookHandler>;
 
     fn as_any(&self) -> &dyn std::any::Any;

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -905,6 +905,15 @@ impl ProtocolSim for UniswapV4State {
         Ok(())
     }
 
+    /// The pool's own attributes all travel in the delta. A hook, if present, decides for
+    /// itself — one that quotes through the shared VM database cannot serve a pending block.
+    fn transitions_from_delta_alone(&self, delta: &ProtocolStateDelta) -> bool {
+        match &self.hook {
+            Some(hook) => hook.transitions_from_delta_alone(delta),
+            None => true,
+        }
+    }
+
     /// See [`ProtocolSim::query_pool_swap`] for the trait documentation.
     ///
     /// This method uses Uniswap V4 internal swap logic by swapping an infinite amount of token_in

--- a/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/state.rs
@@ -457,6 +457,10 @@ impl ProtocolSim for VelodromeSlipstreamsState {
         crate::evm::query_pool_swap::query_pool_swap(self, params)
     }
 
+    fn transitions_from_delta_alone(&self, _delta: &ProtocolStateDelta) -> bool {
+        true
+    }
+
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
         Box::new(self.clone())
     }

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -592,10 +592,14 @@ impl ProtocolStreamBuilder {
     /// The exchange must decode into a state whose `delta_transition` can rebuild it from the
     /// `state_deltas` the indexer produces, because that is all
     /// [`apply_deltas_ephemeral`](crate::evm::decoder::TychoStreamDecoder::apply_deltas_ephemeral)
-    /// applies. Native and hybrid states qualify; the generic VM adapter does not, because it
-    /// re-reads pool state from the VM database — an indexer registered for one still gets its
-    /// balance and block-environment attributes applied, but every storage-derived value stays at
-    /// the confirmed block, with no error.
+    /// applies. Each state reports that per delta through
+    /// [`ProtocolSim::transitions_from_delta_alone`], and a delta for a state that reports
+    /// `false` fails the pending update instead of quoting confirmed data. Hybrid states such as
+    /// Fluid and Curve therefore qualify only while the indexer supplies the attribute they
+    /// rebuild from; the generic VM adapter never does.
+    ///
+    /// [`build_with_pending`](Self::build_with_pending) rejects an `extractor` that no
+    /// [`exchange`](Self::exchange) call registered — its deltas would reach no state at all.
     pub fn with_pending_indexer(
         mut self,
         extractor: &str,
@@ -743,12 +747,36 @@ impl ProtocolStreamBuilder {
     ///
     /// Call [`generate_pending_update`](PendingBlockProcessor::generate_pending_update) to
     /// simulate a candidate bundle; it drains the channel automatically before computing.
+    ///
+    /// # Errors
+    /// Returns [`StreamError::SetUpError`] if a
+    /// [`with_pending_indexer`](Self::with_pending_indexer) call named an exchange that was
+    /// never registered with [`exchange`](Self::exchange).
     pub async fn build_with_pending(
         mut self,
     ) -> Result<
         (impl Stream<Item = Result<Update, StreamDecodeError>>, PendingBlockProcessor),
         StreamError,
     > {
+        let mut unregistered = self
+            .pending_indexers
+            .keys()
+            .filter(|extractor| {
+                !self
+                    .registered_exchanges
+                    .contains(*extractor)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if !unregistered.is_empty() {
+            unregistered.sort();
+            return Err(StreamError::SetUpError(format!(
+                "pending indexers registered for unknown exchanges: {}. Register each with \
+                 exchange() first — otherwise their deltas reach no state.",
+                unregistered.join(", ")
+            )));
+        }
+
         initialize_hook_handlers().map_err(|e| {
             StreamError::SetUpError(format!("Error initializing hook handlers: {e:?}"))
         })?;
@@ -973,6 +1001,43 @@ mod tests {
             !second.states.contains_key(&expected_id),
             "second message should NOT have native_wrapper state"
         );
+    }
+
+    /// A pending indexer named after an exchange nobody registered has its deltas applied to
+    /// nothing. `build_with_pending` must say so instead of running.
+    #[tokio::test]
+    async fn test_build_with_pending_rejects_an_unregistered_exchange() {
+        use tycho_common::models::blockchain::{BlockAggregatedChanges, PendingBlock};
+
+        use crate::evm::protocol::uniswap_v2::state::UniswapV2State;
+
+        struct NoopIndexer;
+
+        impl TxDeltaIndexer for NoopIndexer {
+            fn apply_block(&mut self, _block: &BlockAggregatedChanges) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn generate_deltas(&self, _pending: &PendingBlock) -> BlockAggregatedChanges {
+                BlockAggregatedChanges::default()
+            }
+        }
+
+        let result = ProtocolStreamBuilder::new("tycho-beta.propellerheads.xyz", Chain::Ethereum)
+            .exchange::<UniswapV2State>(
+                "uniswap_v2",
+                ComponentFilter::with_tvl_range(5.0, 10.0),
+                None,
+            )
+            .with_pending_indexer("uniswap_v3", Box::new(NoopIndexer))
+            .expect("registering an indexer must not fail")
+            .build_with_pending()
+            .await;
+
+        match result {
+            Err(e) => assert!(e.to_string().contains("uniswap_v3"), "{e}"),
+            Ok(_) => panic!("an indexer for an unregistered exchange must be refused"),
+        }
     }
 
     /// Verifies that `with_step_controller` returns both a modified builder and a controller.


### PR DESCRIPTION
*🤖 Generated by AI.*

`with_pending_indexer` used to refuse any extractor named `vm:*`. The name is not the property that matters: `vm:curve` decodes into the native `CurveState` and qualifies, while `erc4626`, `fluid_v1` and `uniswap_v4_hooks` read the shared VM database despite native-looking names. The base branch dropped that gate and put nothing in its place, so an indexer registered for a state that cannot absorb its deltas had them applied to nothing, and the pool kept quoting confirmed prices with no error.

## What this adds

`ProtocolSim::transitions_from_delta_alone(delta)`. A state reports whether its `delta_transition` — and the quote taken after it — depend on nothing but the delta. `apply_deltas_ephemeral` asks per pool and fails the update when the answer is no, naming the pool and the extractor.

The property is per state and per delta, not per protocol name. `uniswap_v4` and `uniswap_v4_hooks` decode into the same type and differ only in whether a VM-backed hook is attached. Fluid and Curve qualify only while the indexer supplies the attribute they rebuild from (`pool_reserves_adjusted`, `pool_state_adjusted`); without it both fall back to a VM read that only holds confirmed state.

| Reports | States |
|---|---|
| `true` | 15 native states (Uniswap V2/V3, Ekubo, Aerodrome, Rocketpool, …) |
| `true` only with its attribute | `FluidV1`, `CurveState` |
| delegates to its hook | `UniswapV4State` |
| `false` (default) | `EVMPoolState`, `ERC4626State`, `BalancerV3State`, `GenericVMHookHandler`, RFQ states |

The default is `false`, so a protocol is refused from the pending path until its author has checked both the transition and the quote. That costs one opt-in per native state and makes the failure loud instead of silent.

`HookHandler` gets the same method so a V4 pool can defer to its hook. `SwapQuoter` gets it too, and the blanket `ProtocolSim` impl forwards, so protocols moving to that trait are not silently exempt.

`build_with_pending` separately rejects an indexer registered for an exchange no `exchange()` call added — the other way deltas reach no state.

## Breaking change

`ProtocolSim` and `SwapQuoter` gain a defaulted method. Downstream native states must return `true` to take part in pending-block simulation; nothing else breaks at compile time.

## Verification

`cargo +nightly fmt` and `cargo clippy --workspace --all-targets --all-features` clean. `cargo nextest run -p tycho-simulation --all-features`: 1121 passed, 1 failed. That failure, `vm::state::tests::test_engine_block_advance_invalidates_cached_limits`, reproduces on `feat/curve-core-crate` with this branch's changes stashed. `cargo nextest run -p tycho-common`: 100 passed.

`tycho-storage`, `tycho-indexer` and `tycho-execution` tests did not run locally — the test link needs `libpq`, which is not installed on this machine. They compile under `clippy --all-targets`. `serial_db` and `#[ignore]`d tests were skipped (no DB, no `RPC_URL`).

Six new tests: the two `apply_deltas_ephemeral` outcomes plus the missing-state skip, the Fluid and Curve attribute conditions, and the `build_with_pending` rejection.
