### PR TITLE
fix: share one protocol cache across all extractors

### DIFF
--- a/crates/tycho-indexer/src/extractor/factory.rs
+++ b/crates/tycho-indexer/src/extractor/factory.rs
@@ -152,8 +152,9 @@ where
 /// with a new `ReorgBuffer` and DCI plugin — suitable for restart after failure.
 ///
 /// Reused across restarts:
-/// - `protocol_cache`: populated once at construction; Arc-based so cloning is cheap and all runs
-///   share the same live cache. The TTL mechanism refreshes stale entries automatically.
+/// - `protocol_cache`: one chain-wide instance shared by every extractor, populated once by the
+///   caller; Arc-based so cloning is cheap and all runs share the same live cache. The TTL
+///   mechanism refreshes stale entries automatically.
 /// - `chain_state`: estimated once at construction (block number via RPC); `Copy` so each run gets
 ///   its own copy at no cost.
 /// - `cached_gw`: each `build_runner` call creates a fresh instance via `new_instance()` (fresh
@@ -176,10 +177,12 @@ pub struct ExtractorFactory {
 }
 
 impl ExtractorFactory {
-    /// Creates the factory, making one RPC call to fetch the current block number and populating
-    /// the protocol cache from the database.
+    /// Creates the factory, making one RPC call to fetch the current block number.
     ///
-    /// Both `chain_state` and `protocol_cache` are reused across all subsequent restarts.
+    /// The `protocol_cache` holds the whole chain's token and component universe, so callers
+    /// must pass one shared, already populated instance to every factory on the chain instead
+    /// of populating one per extractor. Both `chain_state` and the cache are reused across all
+    /// subsequent restarts.
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         config: ExtractorConfig,
@@ -193,6 +196,7 @@ impl ExtractorFactory {
         database_insert_batch_size: usize,
         partial_blocks: bool,
         runtime_handle: Option<Handle>,
+        protocol_cache: ProtocolMemoryCache,
     ) -> Result<Self, ExtractionError> {
         let block_number = rpc_client
             .get_block_number()
@@ -203,13 +207,6 @@ impl ExtractorFactory {
             block_number,
             chain.block_time_secs() as i64,
         );
-
-        let protocol_cache = ProtocolMemoryCache::new(
-            config.chain,
-            chrono::Duration::seconds(900),
-            Arc::new(cached_gw.clone()),
-        );
-        protocol_cache.populate().await?;
 
         Ok(Self {
             config,

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -58,6 +58,7 @@ use tycho_indexer::{
     },
     extractor::{
         factory::ExtractorFactory,
+        protocol_cache::ProtocolMemoryCache,
         runner::ExtractorHandle,
         supervisor::{DCIType, ExtractorConfig, ExtractorSupervisor, ProtocolTypeConfig},
         token_analysis_cron::analyze_tokens,
@@ -580,6 +581,17 @@ async fn build_all_extractors(
         .first()
         .expect("No chain provided");
 
+    // One cache for all extractors: it holds the whole chain's token and component universe
+    // (several GB on large chains), so populating one per extractor multiplies both memory
+    // and the bulk database read by the number of extractors.
+    info!("Building protocol cache");
+    let protocol_cache = ProtocolMemoryCache::new(
+        chain,
+        chrono::Duration::seconds(900),
+        Arc::new(cached_gw.clone()),
+    );
+    protocol_cache.populate().await?;
+
     for extractor_config in config.extractors.values() {
         initialize_accounts(
             extractor_config
@@ -608,6 +620,7 @@ async fn build_all_extractors(
             database_insert_batch_size,
             partial_blocks,
             Some(runtime_handle),
+            protocol_cache.clone(),
         )
         .await?;
 


### PR DESCRIPTION
## What

Creates and populates the `ProtocolMemoryCache` once in `build_all_extractors` and passes it into every `ExtractorFactory`, instead of each factory building and populating its own instance.

## Why

The cache holds the chain's full token and component sets (~10 GB on base dev). Since #1026, each extractor populated its own copy, so memory and the bulk startup DB read were multiplied by the extractor count. On rollout this OOM-killed the dev indexer pods on base, ethereum, and bsc (base: 8 extractors against a 14Gi limit; the pod died partway through building the second factory).

## Why sharing is safe

- The cache is insert-only and its entries are chain-level facts: token metadata comes from the contract itself, and components are static definitions keyed by id. An entry left over from a block that was never committed (or later reverted) is never queried again; it cannot produce a wrong answer.
- Component entries are namespaced by protocol system and reads are system-scoped, so one extractor cannot read another's components. Tokens are the only shared namespace, and those are chain-global by design — a token discovered by one extractor is the same token every other extractor needs.
- After a restart, the extractor replays from the last committed block and re-inserts the same entries idempotently, so reused entries match what replay would produce.
- All maps are `Arc<RwLock>`-protected, and one shared instance across all of a chain's extractors is the configuration that ran in production until #1026 merged; restarts reusing the live cache (unchanged here) already rely on the same properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)