### PR TITLE
fix: retry substreams auth failures once credential is proven

### DIFF
--- a/crates/tycho-indexer/src/substreams/mock.rs
+++ b/crates/tycho-indexer/src/substreams/mock.rs
@@ -1,9 +1,11 @@
 //! Generic mock for the Substreams Stream/Blocks gRPC service.
 //!
-//! Captures every `Request` protobuf sent by the client and returns an empty
-//! stream (trailers-only `grpc-status: 0`), which makes `stream_blocks` yield
-//! `BlockResponse::Ended` and the runner exit cleanly.
+//! Captures every `Request` protobuf sent by the client and answers it from a
+//! script of [`MockResponse`]s, one per request. Requests beyond the end of the
+//! script get an empty stream (trailers-only `grpc-status: 0`), which makes
+//! `stream_blocks` yield `BlockResponse::Ended` and the runner exit cleanly.
 use std::{
+    collections::VecDeque,
     convert::Infallible,
     future::Future,
     net::SocketAddr,
@@ -12,29 +14,93 @@ use std::{
     task::{Context, Poll},
 };
 
-use prost::Message;
+use prost::{bytes::Bytes, Message};
 use tonic::{
     body::BoxBody,
-    codegen::{http, Body as HttpBody},
+    codegen::{
+        http::{self, HeaderMap, HeaderValue},
+        Body as HttpBody,
+    },
     server::NamedService,
+    Status,
 };
 
-use crate::pb::sf::substreams::rpc::v3::Request;
+use crate::pb::sf::substreams::rpc::{
+    v2::{response::Message as ResponseMessage, BlockScopedData, Response},
+    v3::Request,
+};
+
+/// gRPC status code for `Unauthenticated`, as sent on the wire.
+const GRPC_STATUS_UNAUTHENTICATED: &str = "16";
+
+/// How the mock answers a single incoming request.
+pub enum MockResponse {
+    /// Trailers-only `grpc-status: 0` — the client sees an empty stream.
+    Ok,
+    /// Trailers-only `grpc-status: 16` — rejected before any block was sent.
+    Unauthenticated,
+    /// One `BlockScopedData` carrying `cursor`, then `grpc-status: 16` trailers.
+    BlockThenUnauthenticated { cursor: String },
+}
+
+/// Response body that emits one gRPC data frame and then error trailers.
+///
+/// A trailers-only response cannot express "the stream worked, then failed",
+/// which is the shape the client sees when an endpoint rejects a stream that
+/// was already delivering blocks.
+struct DataThenTrailers {
+    data: Option<Bytes>,
+    grpc_status: &'static str,
+}
+
+impl HttpBody for DataThenTrailers {
+    type Data = Bytes;
+    type Error = Status;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        Poll::Ready(self.get_mut().data.take().map(Ok))
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        let mut trailers = HeaderMap::new();
+        trailers.insert("grpc-status", HeaderValue::from_static(self.grpc_status));
+        Poll::Ready(Ok(Some(trailers)))
+    }
+}
+
+/// Wrap a protobuf message in a gRPC length-prefixed frame.
+fn grpc_frame(message: &impl Message) -> Bytes {
+    let payload = message.encode_to_vec();
+    let mut frame = Vec::with_capacity(5 + payload.len());
+    frame.push(0); // not compressed
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+    Bytes::from(frame)
+}
 
 /// Mock gRPC server that captures Substreams `Request` messages.
 ///
 /// Implements `tower::Service` directly — no generated server code needed.
 /// Every incoming request is decoded from the gRPC wire format and pushed into
-/// [`captured`]. The response is always a trailers-only OK (empty stream).
+/// [`captured`], then answered from the script.
 #[derive(Clone)]
 pub struct MockSubstreamsServer {
     captured: Arc<Mutex<Vec<Request>>>,
+    script: Arc<Mutex<VecDeque<MockResponse>>>,
 }
 
 impl MockSubstreamsServer {
-    fn new() -> (Self, Arc<Mutex<Vec<Request>>>) {
+    fn new(script: Vec<MockResponse>) -> (Self, Arc<Mutex<Vec<Request>>>) {
         let captured = Arc::new(Mutex::new(Vec::new()));
-        (Self { captured: captured.clone() }, captured)
+        let server =
+            Self { captured: captured.clone(), script: Arc::new(Mutex::new(script.into())) };
+        (server, captured)
     }
 }
 
@@ -53,6 +119,7 @@ impl tonic::codegen::Service<http::Request<tonic::transport::Body>> for MockSubs
 
     fn call(&mut self, req: http::Request<tonic::transport::Body>) -> Self::Future {
         let captured = self.captured.clone();
+        let script = self.script.clone();
         Box::pin(async move {
             // Collect the request body using http_body::Body::poll_data
             let mut body = req.into_body();
@@ -72,21 +139,47 @@ impl tonic::codegen::Service<http::Request<tonic::transport::Body>> for MockSubs
                 }
             }
 
-            // Trailers-only gRPC OK → client sees an empty response stream
-            Ok(http::Response::builder()
-                .header("content-type", "application/grpc")
-                .header("grpc-status", "0")
-                .body(BoxBody::default())
-                .unwrap())
+            let scripted = script
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(MockResponse::Ok);
+
+            let builder = http::Response::builder().header("content-type", "application/grpc");
+            let response = match scripted {
+                MockResponse::Ok => builder
+                    .header("grpc-status", "0")
+                    .body(BoxBody::default()),
+                MockResponse::Unauthenticated => builder
+                    .header("grpc-status", GRPC_STATUS_UNAUTHENTICATED)
+                    .body(BoxBody::default()),
+                MockResponse::BlockThenUnauthenticated { cursor } => {
+                    let block = Response {
+                        message: Some(ResponseMessage::BlockScopedData(BlockScopedData {
+                            cursor,
+                            ..Default::default()
+                        })),
+                    };
+                    builder.body(BoxBody::new(DataThenTrailers {
+                        data: Some(grpc_frame(&block)),
+                        grpc_status: GRPC_STATUS_UNAUTHENTICATED,
+                    }))
+                }
+            };
+
+            Ok(response.unwrap())
         })
     }
 }
 
-/// Start a mock Substreams gRPC server on an ephemeral port.
+/// Start a mock Substreams gRPC server that answers the n-th request with the
+/// n-th entry of `script`, and an empty stream once the script runs out.
 ///
 /// Returns the captured requests and the address the server is listening on.
-pub async fn start_mock_substreams() -> (Arc<Mutex<Vec<Request>>>, SocketAddr) {
-    let (server, captured) = MockSubstreamsServer::new();
+pub async fn start_scripted_mock_substreams(
+    script: Vec<MockResponse>,
+) -> (Arc<Mutex<Vec<Request>>>, SocketAddr) {
+    let (server, captured) = MockSubstreamsServer::new(script);
 
     // Bind to find an available port, then release so tonic can rebind.
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();

--- a/crates/tycho-indexer/src/substreams/stream.rs
+++ b/crates/tycho-indexer/src/substreams/stream.rs
@@ -69,6 +69,21 @@ impl SubstreamsStream {
 static DEFAULT_BACKOFF: Lazy<ExponentialBackoff> =
     Lazy::new(|| ExponentialBackoff::from_millis(500).max_delay(Duration::from_secs(45)));
 
+/// Consecutive `Unauthenticated` retries allowed once the endpoint has proven the credential by
+/// delivering a block. With `DEFAULT_BACKOFF` these span about three minutes.
+const MAX_UNAUTHENTICATED_RETRIES: u32 = 5;
+
+/// Whether an `Unauthenticated` status from the endpoint should be retried.
+///
+/// Returns false while `block_received` is false: a credential that has never delivered a block
+/// cannot be distinguished from a misconfigured one, and the token is read once at startup, so
+/// retrying it would hide the problem rather than fix it. Once a block has arrived the credential
+/// is proven, so a later rejection is the endpoint's and is retried up to
+/// `MAX_UNAUTHENTICATED_RETRIES` times.
+fn should_retry_unauthenticated(block_received: bool, retries_used: u32) -> bool {
+    block_received && retries_used < MAX_UNAUTHENTICATED_RETRIES
+}
+
 async fn wait_for_next_retry(
     backoff: &mut ExponentialBackoff,
     retry_count: &mut u32,
@@ -108,6 +123,8 @@ fn stream_blocks(
     let mut latest_block = start_block_num as u64;
     let mut retry_count = 0;
     let mut backoff = DEFAULT_BACKOFF.clone();
+    let mut block_received = false;
+    let mut unauthenticated_retries = 0;
 
     try_stream! {
         'retry_loop: loop {
@@ -162,6 +179,11 @@ fn stream_blocks(
                                 // Reset backoff because we got a good value from the stream
                                 backoff = DEFAULT_BACKOFF.clone();
 
+                                // The endpoint accepted the credential, so any later rejection of
+                                // it is the endpoint's problem, not a misconfiguration.
+                                block_received = true;
+                                unauthenticated_retries = 0;
+
                                 let cursor = block_scoped_data.cursor.clone();
                                 yield BlockResponse::New(block_scoped_data);
 
@@ -187,11 +209,19 @@ fn stream_blocks(
                             },
                             BlockProcessedResult::Skip() => {},
                             BlockProcessedResult::TonicError(status) => {
-                                // Unauthenticated errors are not retried, we forward the error back to the
-                                // stream consumer which handles it
                                 if status.code() == tonic::Code::Unauthenticated {
                                     counter!("substreams_failure", "extractor" => extractor_id.clone(), "cause" => "unauthenticated").increment(1);
-                                    return Err(anyhow::Error::new(status.clone()))?;
+
+                                    // Forward the error to the stream consumer, which treats it as fatal
+                                    if !should_retry_unauthenticated(block_received, unauthenticated_retries) {
+                                        error!("Endpoint rejected the credential, giving up: {:#}", status);
+                                        return Err(anyhow::Error::new(status.clone()))?;
+                                    }
+
+                                    unauthenticated_retries += 1;
+                                    warn!(unauthenticated_retries, "Endpoint rejected a proven credential, reconnecting");
+                                    wait_for_next_retry(&mut backoff, &mut retry_count, &extractor_id).await?;
+                                    continue 'retry_loop;
                                 }
 
                                 error!("Received tonic error {:#}", status);
@@ -209,7 +239,26 @@ fn stream_blocks(
                     return;
                 },
                 Err(e) => {
-                    counter!("substreams_failure", "module" => output_module_name.clone(), "cause" => "connection_error").increment(1);
+                    // An endpoint that rejects the credential before opening the stream surfaces it
+                    // here rather than as a stream error.
+                    let unauthenticated = e
+                        .downcast_ref::<tonic::Status>()
+                        .is_some_and(|status| status.code() == tonic::Code::Unauthenticated);
+
+                    if unauthenticated {
+                        counter!("substreams_failure", "extractor" => extractor_id.clone(), "cause" => "unauthenticated").increment(1);
+
+                        if !should_retry_unauthenticated(block_received, unauthenticated_retries) {
+                            error!("Endpoint rejected the credential, giving up: {:#}", e);
+                            return Err(e)?;
+                        }
+
+                        unauthenticated_retries += 1;
+                        warn!(unauthenticated_retries, "Endpoint rejected a proven credential, reconnecting");
+                    } else {
+                        counter!("substreams_failure", "module" => output_module_name.clone(), "cause" => "connection_error").increment(1);
+                    }
+
                     error!("Unable to connect to endpoint: {:#}", e);
 
                     // If we reach this point, we must wait a bit before retrying
@@ -304,5 +353,98 @@ impl Stream for SubstreamsStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.stream.poll_next_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::substreams::mock::{start_scripted_mock_substreams, MockResponse};
+
+    async fn stream_against(script: Vec<MockResponse>) -> (SubstreamsStream, MockRequests) {
+        let (captured, addr) = start_scripted_mock_substreams(script).await;
+        let endpoint = SubstreamsEndpoint::new(format!("http://{addr}"), Some("token".to_string()))
+            .await
+            .expect("endpoint");
+        let stream = SubstreamsStream::new(
+            Arc::new(endpoint),
+            None,
+            None,
+            "test_module".to_string(),
+            42,
+            0,
+            false,
+            "test_extractor".to_string(),
+            false,
+        );
+        (stream, captured)
+    }
+
+    type MockRequests = std::sync::Arc<std::sync::Mutex<Vec<Request>>>;
+
+    #[tokio::test]
+    async fn test_unauthenticated_before_first_block_is_fatal() {
+        let (mut stream, captured) = stream_against(vec![MockResponse::Unauthenticated]).await;
+
+        let item = stream
+            .next()
+            .await
+            .expect("stream should yield an item");
+        let Err(err) = item else {
+            panic!("a credential that never worked must not be retried");
+        };
+
+        assert!(
+            err.to_string()
+                .contains("Unauthenticated"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(captured.lock().unwrap().len(), 1, "the endpoint must not be dialled again");
+    }
+
+    #[tokio::test]
+    async fn test_unauthenticated_after_first_block_reconnects() {
+        let (mut stream, captured) = stream_against(vec![
+            MockResponse::BlockThenUnauthenticated { cursor: "cursor-1".to_string() },
+            MockResponse::Ok,
+        ])
+        .await;
+
+        let block = stream
+            .next()
+            .await
+            .expect("stream should yield a block")
+            .expect("first block should not error");
+        assert!(matches!(block, BlockResponse::New(_)));
+
+        let ended = stream
+            .next()
+            .await
+            .expect("stream should yield an item")
+            .expect("a proven credential must be retried, not surfaced as an error");
+        assert!(matches!(ended, BlockResponse::Ended));
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2, "the stream should have reconnected once");
+        assert_eq!(
+            requests[1].start_cursor, "cursor-1",
+            "the reconnect should resume from the last cursor"
+        );
+    }
+
+    #[test]
+    fn test_unauthenticated_not_retried_before_first_block() {
+        assert!(!should_retry_unauthenticated(false, 0));
+    }
+
+    #[test]
+    fn test_unauthenticated_retried_after_first_block() {
+        assert!(should_retry_unauthenticated(true, 0));
+    }
+
+    #[test]
+    fn test_unauthenticated_retries_are_bounded() {
+        assert!(should_retry_unauthenticated(true, MAX_UNAUTHENTICATED_RETRIES - 1));
+        assert!(!should_retry_unauthenticated(true, MAX_UNAUTHENTICATED_RETRIES));
     }
 }


### PR DESCRIPTION
## What this changes

`Unauthenticated` from the Substreams endpoint was the one gRPC status the stream never retried: it was returned to the consumer, which ends the extractor and exits the process. Every other status goes through the existing exponential backoff.

The stream now decides based on whether the endpoint has ever accepted the credential in this process:

- **No block received yet** — the status ends the stream, as before. A credential that has never delivered a block cannot be told apart from a misconfigured one, and the token is read once at startup, so retrying cannot fix it.
- **A block has been received** — the credential is proven, so the rejection is the endpoint's. The stream reconnects from its last cursor, up to `MAX_UNAUTHENTICATED_RETRIES` (5) consecutive attempts, which spans about three minutes on the existing backoff. The counter resets on the next block.

## Behaviour change to note

An `Unauthenticated` raised before the stream opens surfaces as an error from the initial call rather than as a stream error, so it previously fell into the connection-error branch and was retried indefinitely. It now ends the stream when no block has been received, which makes the fail-fast-on-misconfiguration path apply to both shapes of rejection instead of only one.

## Why

On 2026-09-02 the prod robinhood indexer exited twice, at 14:57:35 and 14:59:55 UTC, both times on `Stream terminated with error. error=status: Unauthenticated` from the `uniswap_v4` extractor. The endpoint accepted the same credential again on the third start, so the rejection lasted about two and a half minutes. The two exits cost roughly five and a half minutes of API downtime, since each restart reloads the token and protocol caches before the server binds. The `uniswap_v2` and `uniswap_v3` extractors hit a broken pipe in the same 5ms window and reconnected on their own.

Chains on other endpoints logged no stream errors in that window, and the same credential kept working for them throughout.

As a side effect the `substreams_failure{cause="unauthenticated"}` counter becomes observable — the process previously exited before the next scrape, so it has never been recorded.

## Tests

- `test_unauthenticated_before_first_block_is_fatal` — the stream errors and does not dial the endpoint again.
- `test_unauthenticated_after_first_block_reconnects` — the stream reconnects and resumes from the last cursor.
- Three cases covering the retry bound.

The mock Substreams server gained a per-request script and a response body that emits one block and then error trailers, which is the shape needed to reject a stream that was already delivering blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)