### PR TITLE
fix(client): increase Robinhood feed timeout

### DIFF
--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -137,7 +137,7 @@ impl TychoStreamBuilder {
             Chain::Unichain => (1, 10, 100),
             Chain::Polygon => (2, 12, 50),   // ~2s block time
             Chain::Plasma => (1, 10, 100),   // ~1s block time
-            Chain::Robinhood => (1, 2, 100), // Arbitrum Orbit, typically closer to 0.25s
+            Chain::Robinhood => (1, 5, 100), // Arbitrum Orbit, typically closer to 0.25s
             _ => {
                 let block_time = chain.block_time_secs();
                 (block_time, block_time * 3, 50)


### PR DESCRIPTION
## Summary

- Increase the default Robinhood client timeout from 2 seconds to 5 seconds.
- Increase the effective wait from 3 seconds to 6 seconds with Robinhood's 1-second block time.
- Allow delayed Robinhood updates to arrive before the client emits an empty feed message.
- Keep the existing failure behavior when the delay exceeds the new timeout.
