### PR TITLE
fix(router-trades): unblock release CI

### DIFF
--- a/crates/tycho-execution/substreams/Dockerfile
+++ b/crates/tycho-execution/substreams/Dockerfile
@@ -6,7 +6,7 @@ ARG SINK_SQL_VERSION=v4.13.1
 
 FROM rust:1.91-bookworm AS build
 ARG SUBSTREAMS_VERSION
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 RUN case "$TARGETARCH" in amd64) ARCH=x86_64 ;; arm64) ARCH=arm64 ;; *) echo "unsupported arch $TARGETARCH" && exit 1 ;; esac \
     && curl -fsSL --retry 5 --retry-all-errors -o /tmp/substreams.tgz \
        "https://github.com/streamingfast/substreams/releases/download/${SUBSTREAMS_VERSION}/substreams_linux_${ARCH}.tar.gz" \
@@ -23,7 +23,7 @@ RUN mkdir -p /spkg && for manifest in tycho-router-trades/chains/*.yaml; do \
 
 FROM debian:bookworm-slim
 ARG SINK_SQL_VERSION
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl postgresql-client \
     && apt-get clean \
     && case "$TARGETARCH" in amd64) ARCH=x86_64 ;; arm64) ARCH=arm64 ;; esac \

--- a/crates/tycho-execution/substreams/scripts/test_pricing.sh
+++ b/crates/tycho-execution/substreams/scripts/test_pricing.sh
@@ -18,8 +18,11 @@ trap cleanup EXIT
 wait_for_postgres() {
 	local container="$1"
 	local database="$2"
+	local logs
 	for _ in {1..30}; do
-		if docker exec "$container" pg_isready -q -U tycho -d "$database"; then
+		logs="$(docker logs "$container" 2>&1)"
+		if [[ "$logs" == *"PostgreSQL init process complete; ready for start up."* ]] &&
+			docker exec "$container" pg_isready -q -U tycho -d "$database"; then
 			return
 		fi
 		sleep 1


### PR DESCRIPTION
## Summary

- Default `TARGETARCH` to `amd64` because Kaniko does not provide Docker BuildKit automatic platform arguments.
- Wait for the PostgreSQL image initialization phase to finish before pricing tests use the database. This avoids connecting while the temporary initialization server restarts.

Explicit build arguments still override the architecture default.

## Verification

- `bash -n`
- `shellcheck`
- `shfmt -d`
- `git diff --check`

The full local image and pricing tests were not run because Docker Desktop is not running.