### PR TITLE
fix(router-trades): isolate sink state by chain

### DIFF
--- a/crates/tycho-execution/substreams/README.md
+++ b/crates/tycho-execution/substreams/README.md
@@ -117,8 +117,9 @@ make run   CHAIN=ethereum START=25654569 STOP=+50      # print decoded trades
 make sink  CHAIN=ethereum                              # stream into Postgres
 ```
 
-Run one `make sink` per chain against the same database; the `chain` column is part of every
-primary key and params make each chain's module hash (and therefore sink cursor) distinct.
+Run one `make sink` per chain against the same database. The `chain` column is part of every
+business-table primary key. Deployed sinks use per-chain cursor and history tables so their block
+positions and reorg bookkeeping remain independent.
 
 `make sink` passes `--batch-block-flush-interval 100`: with the default (1000) the sink
 v4.13.1 did not flush the trailing partial batch when a bounded run reached its stop block.

--- a/crates/tycho-execution/substreams/docker/entrypoint.sh
+++ b/crates/tycho-execution/substreams/docker/entrypoint.sh
@@ -30,12 +30,17 @@ sink)
 		echo "no package for chain '$CHAIN'" >&2
 		exit 1
 	}
+	system_table_args=(
+		--cursors-table "cursors_${CHAIN}"
+		--history-table "substreams_history_${CHAIN}"
+	)
 	args=("$DSN" "$spkg")
 	[ -n "${START_BLOCK:-}${STOP_BLOCK:-}" ] && args+=("${START_BLOCK:-}:${STOP_BLOCK:-}")
 	[ -n "${SUBSTREAMS_ENDPOINT:-}" ] && args+=(-e "$SUBSTREAMS_ENDPOINT")
 	wait_for_db "$DSN"
-	substreams-sink-sql setup "$DSN" "$spkg"
+	substreams-sink-sql setup "$DSN" "$spkg" "${system_table_args[@]}"
 	exec substreams-sink-sql run "${args[@]}" \
+		"${system_table_args[@]}" \
 		--batch-block-flush-interval "${FLUSH_INTERVAL:-100}" \
 		--metrics-listen-addr "${METRICS_ADDR:-:9102}"
 	;;


### PR DESCRIPTION
## Summary

Use one cursor table and one reorg-history table per chain while keeping all trade tables shared.

The initial deployment let Ethereum create the shared cursor first. Every other sink then rejected that cursor because its module hash differed. Shared history was also unsafe because chains have unrelated block heights and reorgs.

## Verification

- `bash -n`
- `shellcheck`
- `shfmt -d`
- Complete AMD64 Docker image build
- All eight Substreams packages built successfully