### PR TITLE
feat(substreams): parameterize uniswap-v3-logs-only protocol type

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -1334,6 +1334,8 @@ dependencies = [
  "itertools 0.13.0",
  "num-bigint",
  "prost 0.11.9",
+ "serde",
+ "serde_qs 0.13.0",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0)",

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Take `protocol_type_name` as a `map_pools_created` parameter instead of hardcoding
   `uniswap_v3_pool`, so a fork indexed by this package emits its own protocol type. Every manifest
   now passes its parameters as a query string.
+- Fix the declared `map_pools_created` output type in the Arbitrum, BSC, and Robinhood manifests.
+  They said `BlockChanges` while the module returns `BlockEntityChanges`, so `substreams run` and
+  `substreams gui` could not decode that module's output. The three manifests also omitted
+  `tycho/evm/v1/entity.proto`, which is why they could not name the right type; it is now imported.
+  The wire data was always `BlockEntityChanges` — only the declaration was wrong, and
+  `map_protocol_changes`, the module the indexer consumes, was unaffected.
 
 ## v0.1.3
 

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.4
+
+- Take `protocol_type_name` as a `map_pools_created` parameter instead of hardcoding
+  `uniswap_v3_pool`, so a fork indexed by this package emits its own protocol type. Every manifest
+  now passes its parameters as a query string.
+
 ## v0.1.3
 
 - Add the Robinhood Chain Uniswap V3 logs-only manifest.

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]
@@ -14,6 +14,8 @@ hex = "0.4.3"
 itertools = "0.13.0"
 num-bigint = "0.4.4"
 prost = "0.11"
+serde = { version = "1.0.204", features = ["derive"] }
+serde_qs = "0.13.0"
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "arbitrum_uniswap_v3_logs_only"
-  version: v0.1.2
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:
@@ -125,4 +125,4 @@ modules:
       type: proto:tycho.evm.v1.BlockChanges
 
 params:
-  map_pools_created: "1F98431c8aD98523631AE4a59f267346ea31F984"
+  map_pools_created: "factory_address=1F98431c8aD98523631AE4a59f267346ea31F984&protocol_type_name=uniswap_v3_pool"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
@@ -6,6 +6,7 @@ package:
 
 protobuf:
   files:
+    - tycho/evm/v1/entity.proto
     - tycho/evm/v1/common.proto
     - tycho/evm/v1/utils.proto
     - uniswap.proto
@@ -29,7 +30,7 @@ modules:
       - params: string
       - source: sf.ethereum.type.v2.Block
     output:
-      type: proto:tycho.evm.v1.BlockChanges
+      type: proto:tycho.evm.v1.BlockEntityChanges
 
   - name: store_pools
     kind: store

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_uniswap_v3_logs_only"
-  version: v0.1.2
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:
@@ -126,4 +126,4 @@ modules:
       type: proto:tycho.evm.v1.BlockChanges
 
 params:
-  map_pools_created: "33128a8fC17869897dcE68Ed026d694621f6FDfD"
+  map_pools_created: "factory_address=33128a8fC17869897dcE68Ed026d694621f6FDfD&protocol_type_name=uniswap_v3_pool"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/bsc-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/bsc-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "bsc_uniswap_v3_logs_only"
-  version: v0.1.2
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:
@@ -125,4 +125,4 @@ modules:
       type: proto:tycho.evm.v1.BlockChanges
 
 params:
-  map_pools_created: "dB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7"
+  map_pools_created: "factory_address=dB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7&protocol_type_name=uniswap_v3_pool"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/bsc-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/bsc-uniswap-v3.yaml
@@ -6,6 +6,7 @@ package:
 
 protobuf:
   files:
+    - tycho/evm/v1/entity.proto
     - tycho/evm/v1/common.proto
     - tycho/evm/v1/utils.proto
     - uniswap.proto
@@ -29,7 +30,7 @@ modules:
       - params: string
       - source: sf.ethereum.type.v2.Block
     output:
-      type: proto:tycho.evm.v1.BlockChanges
+      type: proto:tycho.evm.v1.BlockEntityChanges
 
   - name: store_pools
     kind: store

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v3_logs_only"
-  version: v0.1.2
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:
@@ -123,4 +123,4 @@ modules:
       type: proto:tycho.evm.v1.BlockChanges
 
 params:
-  map_pools_created: "1F98431c8aD98523631AE4a59f267346ea31F984"
+  map_pools_created: "factory_address=1F98431c8aD98523631AE4a59f267346ea31F984&protocol_type_name=uniswap_v3_pool"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_uniswap_v3_logs_only"
-  version: v0.1.3
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:
@@ -125,4 +125,4 @@ modules:
       type: proto:tycho.evm.v1.BlockChanges
 
 params:
-  map_pools_created: "1f7d7550B1b028f7571E69A784071F0205FD2EfA"
+  map_pools_created: "factory_address=1f7d7550B1b028f7571E69A784071F0205FD2EfA&protocol_type_name=uniswap_v3_pool"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
@@ -6,6 +6,7 @@ package:
 
 protobuf:
   files:
+    - tycho/evm/v1/entity.proto
     - tycho/evm/v1/common.proto
     - tycho/evm/v1/utils.proto
     - uniswap.proto
@@ -29,7 +30,7 @@ modules:
       - params: string
       - source: sf.ethereum.type.v2.Block
     output:
-      type: proto:tycho.evm.v1.BlockChanges
+      type: proto:tycho.evm.v1.BlockEntityChanges
 
   - name: store_pools
     kind: store

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/1_map_pool_created.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/1_map_pool_created.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use ethabi::ethereum_types::Address;
+use serde::Deserialize;
 use substreams::scalar::BigInt;
 use substreams_ethereum::pb::eth::v2::{self as eth};
 
@@ -10,15 +11,21 @@ use crate::abi::factory::events::PoolCreated;
 
 use tycho_substreams::prelude::*;
 
+#[derive(Debug, Deserialize)]
+struct Params {
+    factory_address: String,
+    protocol_type_name: String,
+}
+
 #[substreams::handlers::map]
 pub fn map_pools_created(
     params: String,
     block: eth::Block,
 ) -> Result<BlockEntityChanges, substreams::errors::Error> {
     let mut new_pools: Vec<TransactionEntityChanges> = vec![];
-    let factory_address = params.as_str();
+    let params: Params = serde_qs::from_str(params.as_str()).expect("Unable to deserialize params");
 
-    get_new_pools(&block, &mut new_pools, factory_address);
+    get_new_pools(&block, &mut new_pools, &params);
 
     Ok(BlockEntityChanges { block: None, changes: new_pools })
 }
@@ -27,7 +34,7 @@ pub fn map_pools_created(
 fn get_new_pools(
     block: &eth::Block,
     new_pools: &mut Vec<TransactionEntityChanges>,
-    factory_address: &str,
+    params: &Params,
 ) {
     // Extract new pools from PoolCreated events
     let mut on_pool_created = |event: PoolCreated, _tx: &eth::TransactionTrace, _log: &eth::Log| {
@@ -78,7 +85,7 @@ fn get_new_pools(
                 ],
                 change: i32::from(ChangeType::Creation),
                 protocol_type: Option::from(ProtocolType {
-                    name: "uniswap_v3_pool".to_string(),
+                    name: params.protocol_type_name.clone(),
                     financial_type: FinancialType::Swap.into(),
                     attribute_schema: vec![],
                     implementation_type: ImplementationType::Custom.into(),
@@ -106,7 +113,9 @@ fn get_new_pools(
 
     let mut eh = EventHandler::new(block);
 
-    eh.filter_by_address(vec![Address::from_str(factory_address).unwrap()]);
+    eh.filter_by_address(vec![
+        Address::from_str(&params.factory_address).expect("Invalid factory address")
+    ]);
 
     eh.on::<PoolCreated, _>(&mut on_pool_created);
     eh.handle_events();

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/unichain-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/unichain-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_uniswap_v3"
-  version: v0.1.2
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:
@@ -123,4 +123,4 @@ modules:
       type: proto:tycho.evm.v1.BlockChanges
 
 params:
-  map_pools_created: "1F98400000000000000000000000000000000003"
+  map_pools_created: "factory_address=1F98400000000000000000000000000000000003&protocol_type_name=uniswap_v3_pool"


### PR DESCRIPTION
Two commits, both across the same six manifests.

## 1. Parameterize the protocol type

`map_pools_created` hardcoded `uniswap_v3_pool` as the protocol type of every component it emitted.
It now reads `protocol_type_name` from the module parameters, so a fork indexed by this package
emits its own protocol type.

Parameters move from a bare factory address to a query string, matching how `ethereum-uniswap-v2`
already parameterizes its forks:

```
map_pools_created: "factory_address=1F98431c8aD98523631AE4a59f267346ea31F984&protocol_type_name=uniswap_v3_pool"
```

All six manifests (Ethereum, Base, Arbitrum, BSC, Unichain, Robinhood) are updated and keep
`uniswap_v3_pool`, so their output is unchanged. #1389 and #1390 build on this.

## 2. Fix the declared `map_pools_created` output type

The Arbitrum, BSC and Robinhood manifests declared `map_pools_created` as returning `BlockChanges`,
but the module returns `BlockEntityChanges`, so decoding that module with `substreams run` or
`substreams gui` failed:

```
error unmarshalling message into tycho.evm.v1.BlockChanges:
cannot parse field tycho.evm.v1.Attribute.name from group-encoded wire type
```

Those three manifests also omitted `tycho/evm/v1/entity.proto`, which is why they could not name the
right type. It is now imported, as Ethereum, Base and Unichain already do.

Only the declaration was wrong. The wire data was always `BlockEntityChanges`, and
`map_protocol_changes` — the module the indexer consumes — was unaffected, so no indexed state was
ever wrong.

## Rollout

Nothing to coordinate. Parameters live in the manifest, which is packed into the `.spkg`, and
`ExtractorConfig` has no `params` field — so the new wasm and the new parameter format always ship
in the same artifact. An `.spkg` built before this change keeps working with its own wasm.

## Test

Ran the fixed Robinhood manifest against the live chain (Substreams endpoint
`robinhood.substreams.pinax.network:443`) at the first Uniswap V3 pool on Robinhood, block `9490`:

```
componentChanges[0].id           0x8be7e807fba21f5c16d2f0079b1a7c84c0866ea5
staticAtt                        fee 0x0bb8, tick_spacing 0x3c, pool_address …
protocolType.name                uniswap_v3_pool
```

Same protocol type as before the change, and the module output now decodes.
`cargo check -p ethereum-uniswap-v3-logs-only --target wasm32-unknown-unknown` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)