### PR TITLE
feat(testing): add the Robinhood Substreams endpoint

### DIFF
--- a/protocols/testing/src/tycho_runner.rs
+++ b/protocols/testing/src/tycho_runner.rs
@@ -333,6 +333,7 @@ pub fn get_default_endpoint(chain: &Chain) -> Option<String> {
         Chain::Base => Some("https://base-mainnet.streamingfast.io:443".to_string()),
         Chain::Unichain => Some("https://mainnet.unichain.streamingfast.io:443".to_string()),
         Chain::Polygon => Some("https://polygon.streamingfast.io:443".to_string()),
+        Chain::Robinhood => Some("https://robinhood.substreams.pinax.network:443".to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
One line. `protocols/testing` resolves its Substreams endpoint through `get_default_endpoint`, which
had no `Chain::Robinhood` arm, so both call sites panicked with `Unknown endpoint for chain robinhood`
and no Robinhood integration test could run.

Kept separate from the three Robinhood protocol PRs (#1389, #1390, #1391) because all three need it
equally — folding it into any one of them would make the other two wait on that PR's merge order.
It is also harness infrastructure rather than a protocol integration, and it collides with #1235,
which adds a `Chain::Arbitrum` arm to the same match; keeping it here makes that conflict visible
instead of buried in a protocol diff.

## Verified

The endpoint answers and accepts the existing `SUBSTREAMS_API_TOKEN`. Ran three Robinhood manifests
against it live:

| manifest | module | block | result |
|---|---|---:|---|
| `robinhood-uniswap-v3.yaml` (#1388) | `map_pools_created` | 9490 | `uniswap_v3_pool`, fee `0x0bb8` |
| `robinhood-sushiswap-v3.yaml` (#1389) | `map_protocol_changes` | 10548743 | `sushiswap_v3_pool`, component + balances |
| `robinhood-ramses-v3.yaml` (#1391) | `map_pools_created` | 52907861 | `ramses_v3_pool`, `tick_spacing 0x05` |

Note for whoever runs the full harness next: a Robinhood **archive** RPC is still needed.
`RPCProvider::get_token_balance` is called at each test's stop block, and the public endpoint
`https://rpc.mainnet.chain.robinhood.com` prunes state — it answers `metadata is not found` a few
thousand blocks back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)