### PR TITLE
feat(substreams): add factory-3-only Slipstreams manifest

### DIFF
--- a/protocols/substreams/base-aerodrome-slipstreams/base-aerodrome-slipstreams-f3.yaml
+++ b/protocols/substreams/base-aerodrome-slipstreams/base-aerodrome-slipstreams-f3.yaml
@@ -1,0 +1,112 @@
+specVersion: v0.1.0
+package:
+  name: "base_aerodrome_slipstreams_f3"
+  version: v0.1.0
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/base-aerodrome-slipstreams"
+
+# Indexes only the third Slipstream factory, from its deployment block. The main manifest
+# covers all three factories but emits a component only on its PoolCreated block, so an
+# extractor already past block 44,394,724 never sees the pools this factory created before
+# its cursor. This manifest backfills them under a separate protocol system, which is then
+# merged into aerodrome_slipstreams.
+#
+# Starting at the factory's own deployment block keeps the run self-contained: the factory
+# enables a tick spacing before it can create a pool on it, so store_tick_spacing_fee always
+# holds the fee by the time map_pools_created needs it.
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/entity.proto
+    - tycho/evm/v1/utils.proto
+    - slipstreams.proto
+  importPaths:
+    - ./proto/v1
+    - ../../../proto/
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/base_aerodrome_slipstreams.wasm
+
+modules:
+  - name: map_tick_spacing_fee
+    kind: map
+    initialBlock: &initial_block 44394724
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.aerodrome.TickSpacingFees
+
+  - name: store_tick_spacing_fee
+    kind: store
+    updatePolicy: set
+    valueType: proto:slipstreams.TickSpacingFees
+    inputs:
+      - map: map_tick_spacing_fee
+
+  - name: map_pools_created
+    kind: map
+    initialBlock: *initial_block
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+      - store: store_tick_spacing_fee
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    updatePolicy: set_if_not_exists
+    valueType: proto:slipstreams.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: store_dynamic_fee_config
+    kind: store
+    initialBlock: *initial_block
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: *initial_block
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: *initial_block
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - store: store_pools
+      - store: store_dynamic_fee_config
+        mode: deltas
+      - store: store_dynamic_fee_config
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_balance_changes
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_tick_spacing_fee: &slipstreams_params "factories[]=f8f2eB4940CFE7d13603DDDD87f123820Fc061Ef&dynamic_fee_modules[]=87D8f999BBa9343E8099552426775B51C338E8CB"
+  map_pools_created: *slipstreams_params
+  store_dynamic_fee_config: *slipstreams_params
+  map_protocol_changes: *slipstreams_params


### PR DESCRIPTION
Adds a second manifest to `base-aerodrome-slipstreams` that indexes only the third Slipstream factory `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef`, starting at its deployment block 44,394,724.

## Why

Components are emitted only on their `PoolCreated` block. The base indexer's cursor is already well past 44,394,724, so bumping the main package to v0.1.4 picks up new pools of this factory but not the ~783 it created before the cursor.

Rewinding the main extractor to backfill them does not work: the write path assumes an extractor has seen every block since its start. A mid-history start produces attribute deletions whose creations precede it, and `apply_partitioned_versioning` treats a deletion with no active row as a hard error, which kills the extractor deterministically on the first commit batch.

Starting a separate extractor at the factory's own deployment block avoids that — the factory has no history before it, so every creation precedes its deletion and the run is an ordinary initial sync. Its components land under `aerodrome_slipstreams_f3` and are merged into `aerodrome_slipstreams` with a single `UPDATE` on `protocol_component.protocol_system_id`, the only column carrying protocol system anywhere in the schema.

## Contents

The manifest reuses the existing wasm binary and module graph. Only four things differ from `base-aerodrome-slipstreams.yaml`: package name, package version, `initialBlock`, and the params. Multiple manifests over one crate is the existing pattern here — `ethereum-uniswap-v2` carries eleven.

Starting at the factory's deployment block is safe for the fee lookup: a factory enables a tick spacing before it can create a pool on it, so `store_tick_spacing_fee` always holds the fee by the time `map_pools_created` needs it.

## Testing

`cargo build --locked --target wasm32-unknown-unknown --release` and `substreams pack` both succeed. In the packed spkg all eight modules report initial block 44,394,724, including the three stores that inherit it, and the four parameterised modules carry only the third factory and its fee module. `map_protocol_changes` hashes to `ce2deac9...` against the main package's `ac2b2e14...`, so the modules get their own substreams cache and back-process from 44,394,724 rather than 13,843,704. Packing produces the same three warnings as the existing manifest and no new ones.

No Rust changed, so the package's existing tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)