### PR TITLE
fix(router-trades): correct the bsc and robinhood start blocks

### DIFF
--- a/crates/tycho-execution/substreams/README.md
+++ b/crates/tycho-execution/substreams/README.md
@@ -94,6 +94,60 @@ release `router-trades-db` there (namespace `dev-tycho`) is a Postgres 16 Statef
 writing to `router-trades-db:5432`. Grafana reaches the database through the same service with
 the read-only `grafana` role.
 
+## Updating a deployed sink
+
+Two properties of `substreams-sink-sql` decide what an update costs, and both bite silently.
+
+**The cursor is keyed by the output module hash.** That hash covers every module definition —
+including `initialBlock` and `params` — and the compiled wasm. The sinks run with the default
+`--on-module-hash-mismatch=error`, so when the hash changes the container exits at startup with a
+mismatch against the row in `cursors_<chain>`, and it keeps crashlooping until that row is
+deleted. What changed decides the blast radius:
+
+| change | new hash for |
+|---|---|
+| one chain's manifest (`initialBlock`, router `params`) | that chain only |
+| anything under `src/`, `Cargo.lock`, the wasm build | **every chain** |
+
+A local `cargo build` is not byte-identical to the Docker build, so production hashes cannot be
+precomputed on a laptop; CI builds of the same source are stable, so an image rebuild without a
+source change keeps every cursor valid.
+
+**The sink does not upsert.** `db_out` uses `create_row`, which is `OPERATION_CREATE`, and the
+postgres dialect turns that into a plain `INSERT` with no `ON CONFLICT`. Any block the sink reads
+a second time fails on the `TEXT PRIMARY KEY` and takes the container down. So whenever a chain
+restarts below its previous cursor, delete that chain's rows in the range that will be re-read —
+in practice, all of them.
+
+### Procedure
+
+1. Merge the change and let the release build the image; `promote-to-dev` writes the tag into
+   `helmwave/dev/versions.yml` and the dev deployment rolls the pod.
+2. Chains whose hash changed exit on the mismatch; the others resume from their cursors. This is
+   expected, and it is contained: the sinks have no readiness probe and Postgres is a separate
+   release.
+3. Clear the state of each affected chain, now that its sink is down and not flushing:
+
+   ```sql
+   DELETE FROM cursors_<chain>;
+   DELETE FROM substreams_history_<chain>;
+   -- only when the chain will re-read blocks it has already written
+   DELETE FROM trades             WHERE chain = '<chain>';
+   DELETE FROM trade_hops         WHERE chain = '<chain>';
+   DELETE FROM fees_taken         WHERE chain = '<chain>';
+   DELETE FROM fee_config_events  WHERE chain = '<chain>';
+   DELETE FROM router_call_errors WHERE chain = '<chain>';
+   ```
+
+4. The container recovers on its next backoff restart. Confirm the new range in its log:
+   `restarting_at: None` together with the expected `resolved_start_block`.
+
+Never reach for `--on-module-hash-mismatch=ignore` to skip step 3: it resumes from the highest
+cursor in the table, which is block 0 for a chain that has never produced data.
+
+`cursors_<chain>` holds one bookmark row and `substreams_history_<chain>` is the reorg-undo
+journal. Neither holds trade data, so clearing them loses no trade.
+
 ## Module graph
 
 ```

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
@@ -21,7 +21,7 @@ binaries:
 modules:
   - name: map_fee_config_events
     kind: map
-    initialBlock: 50000000
+    initialBlock: 98458505
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -30,7 +30,7 @@ modules:
 
   - name: store_fee_config
     kind: store
-    initialBlock: 50000000
+    initialBlock: 98458505
     updatePolicy: set
     valueType: string
     inputs:
@@ -38,7 +38,7 @@ modules:
 
   - name: map_trades
     kind: map
-    initialBlock: 50000000
+    initialBlock: 98458505
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -48,7 +48,7 @@ modules:
 
   - name: db_out
     kind: map
-    initialBlock: 50000000
+    initialBlock: 98458505
     inputs:
       - map: map_trades
       - map: map_fee_config_events

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
@@ -21,7 +21,7 @@ binaries:
 modules:
   - name: map_fee_config_events
     kind: map
-    initialBlock: 1
+    initialBlock: 24417223
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -30,7 +30,7 @@ modules:
 
   - name: store_fee_config
     kind: store
-    initialBlock: 1
+    initialBlock: 24417223
     updatePolicy: set
     valueType: string
     inputs:
@@ -38,7 +38,7 @@ modules:
 
   - name: map_trades
     kind: map
-    initialBlock: 1
+    initialBlock: 24417223
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -48,7 +48,7 @@ modules:
 
   - name: db_out
     kind: map
-    initialBlock: 1
+    initialBlock: 24417223
     inputs:
       - map: map_trades
       - map: map_fee_config_events


### PR DESCRIPTION
## Problem

Two chain manifests start far below the first router deployment, so the sinks scan tens of millions of blocks that cannot contain a trade.

| chain | `initialBlock` was | first router deployed | head | wasted |
|---|---|---|---|---|
| bsc | 50,000,000 | **98,458,505** (2026-05-15) | 119,759,802 | 48.5M blocks |
| robinhood | 1 | **24,417,223** (2026-07-31) | 53,560,032 | 24.4M blocks |

Effect in dev right now: `sink-bsc` has written nothing in over 2 hours — cursor 0, zero data messages, zero progress messages — while it builds `store_fee_config` across a 69.8M-block range. `sink-robinhood` is at block 29,343,413 and roughly 10 hours from the head.

Deployment blocks were found by binary-searching `eth_getCode` against the dev RPC of each chain, and match the values the team confirmed. The other bsc routers are at 113,251,750 and 119,364,698; the other robinhood router at 51,848,044.

## Change

`initialBlock` on all four modules of `chains/bsc.yaml` → 98458505, and of `chains/robinhood.yaml` → 24417223. For bsc this cuts the range from 69.8M to 21.3M blocks.

The start blocks of ethereum, base, polygon and arbitrum are already correct. `unichain` is at a round 16,000,000 that nobody has checked against its deployment; it is left alone because changing it would force a re-sync of a chain that is currently live.

## Required at rollout

Two separate reasons the state must be cleared for these two chains.

**1. The module hash changes.** `initialBlock` is part of it, verified locally with `substreams pack` (same wasm, only `initialBlock` changed: `547393002c…` → `26a2253de8…`). The sinks run with the default `--on-module-hash-mismatch=error`, so a stale cursor row makes the container exit at startup.

**2. The sink does not upsert.** `db_out` uses `tables.create_row(...)`, which is `OPERATION_CREATE`; the sinker maps that to `loader.Insert()`, and the postgres dialect emits a plain `INSERT INTO … VALUES (…)` with no `ON CONFLICT` (`db_changes/db/dialect_postgres.go`, only `OperationTypeUpsert` gets `ON CONFLICT … DO UPDATE`). So re-scanning a block whose rows already exist fails with a duplicate primary key.

robinhood has 3 rows in `fee_config_events`, at blocks 24,656,318 and 29,343,413. Both are above the new start block of 24,417,223, so they would be re-inserted and would kill the sink a few minutes into the backfill. They must be deleted too. bsc has no rows in any table.

```sql
-- bsc: sink bookmark and reorg journal only, no data rows exist
DELETE FROM cursors_bsc;
DELETE FROM substreams_history_bsc;

-- robinhood: bookmark, journal, and the rows that fall inside the new range
DELETE FROM cursors_robinhood;
DELETE FROM substreams_history_robinhood;
DELETE FROM fee_config_events  WHERE chain = 'robinhood';   -- 3 rows
DELETE FROM trades             WHERE chain = 'robinhood';   -- 0 rows today
DELETE FROM trade_hops         WHERE chain = 'robinhood';   -- 0 rows today
DELETE FROM fees_taken         WHERE chain = 'robinhood';   -- 0 rows today
DELETE FROM router_call_errors WHERE chain = 'robinhood';   -- 0 rows today
```

`cursors_<chain>` holds one bookmark row (module hash, cursor, block number) and `substreams_history_<chain>` is the reorg-undo journal. Neither holds trade data, so no trade is lost by clearing them.

Do not use `--on-module-hash-mismatch=ignore` instead: it resumes from the highest cursor, which is block 0 for bsc.

The other five chains are untouched. This PR changes no Rust source, so the wasm and their module hashes stay identical and their cursors keep working.

## Timing note for robinhood

Re-pointing robinhood restarts its backfill at 24,417,223, which is 29.1M blocks to the head versus the 24.2M it has left — about 2 hours extra at the observed 680 blocks/s. Doing it later, once the chain is live, costs the full 29.1M-block re-sync instead. Now is the cheaper moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
