### PR TITLE
fix: join Uniswap V4 tick store deltas by key instead of position

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-no-hooks"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ethabi 18.0.0",
  "ethereum-uniswap-v4-shared",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-shared"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-uniswap-v4/Cargo.lock
+++ b/protocols/substreams/ethereum-uniswap-v4/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-no-hooks"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ethabi 18.0.0",
  "ethereum-uniswap-v4-shared",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-shared"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Pull in shared v0.5.3: correct pairing of tick net-liquidity store deltas.
+
 ## v0.4.2
 
 - Add the Robinhood Chain Uniswap V4 no-hooks manifest.

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-no-hooks"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/arbitrum-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/arbitrum-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "arbitrum_uniswap_v4_no_hooks"
-  version: v0.4.1
+  version: v0.4.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/base-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/base-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_uniswap_v4_no_hooks"
-  version: v0.4.1
+  version: v0.4.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/bsc-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/bsc-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "bsc_uniswap_v4_no_hooks"
-  version: v0.4.1
+  version: v0.4.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/ethereum-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/ethereum-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4_no_hooks"
-  version: v0.4.1
+  version: v0.4.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_uniswap_v4_no_hooks"
-  version: v0.4.2
+  version: v0.4.3
   url: "https://github.com/propeller-heads/tycho-indexer/tree/main/protocols/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/unichain-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/unichain-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_uniswap_v4"
-  version: v0.4.1
+  version: v0.4.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/shared/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.3
+
+- Fix tick net-liquidity attribute pairing: join store deltas to tick deltas by store key
+  and ordinal instead of position. The previous positional zip could swap the value and
+  ChangeType between tick_lower and tick_upper of one ModifyLiquidity event.
+
 ## v0.5.2
 
 - Remove redundant references in format arguments to retain compatibility with current Clippy.

--- a/protocols/substreams/ethereum-uniswap-v4/shared/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-shared"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/shared/src/utils/protocol_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/src/utils/protocol_changes.rs
@@ -4,7 +4,10 @@ use crate::pb::uniswap::v4::{
 };
 use itertools::Itertools;
 use std::{collections::HashMap, str::FromStr, vec};
-use substreams::{pb::substreams::StoreDeltas, scalar::BigInt};
+use substreams::{
+    pb::substreams::{StoreDelta, StoreDeltas},
+    scalar::BigInt,
+};
 use substreams_helper::hex::Hexable;
 use tycho_substreams::{balances::aggregate_balances_changes, prelude::*};
 
@@ -72,12 +75,33 @@ pub fn collect_transaction_changes(
                 });
         });
 
-    // Insert ticks net-liquidity changes
-    ticks_store_deltas
+    // Insert ticks net-liquidity changes. Both ticks of a ModifyLiquidity event share one log
+    // ordinal and the store module's unstable sort may reorder them, so positional zip pairing
+    // is unsound; join store deltas to tick deltas by (store key, ordinal) instead.
+    let mut ticks_store_deltas_by_key: HashMap<(String, u64), StoreDelta> = ticks_store_deltas
         .deltas
         .into_iter()
-        .zip(ticks_map_deltas.deltas)
-        .for_each(|(store_delta, tick_delta)| {
+        .map(|delta| ((delta.key.clone(), delta.ordinal), delta))
+        .collect();
+
+    ticks_map_deltas
+        .deltas
+        .into_iter()
+        .for_each(|tick_delta| {
+            let store_key = format!(
+                "pool:{0}:tick:{1}",
+                tick_delta.pool_address.to_hex(),
+                tick_delta.tick_index
+            );
+            let store_delta = ticks_store_deltas_by_key
+                .remove(&(store_key.clone(), tick_delta.ordinal))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no tick store delta for key {store_key} at ordinal {}",
+                        tick_delta.ordinal
+                    )
+                });
+
             let new_value_bigint =
                 BigInt::from_str(&String::from_utf8(store_delta.new_value).unwrap()).unwrap();
 
@@ -221,5 +245,122 @@ fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddres
             ]
         }
         _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use substreams::pb::substreams::StoreDelta;
+
+    use super::*;
+    use crate::pb::uniswap::v4::{TickDelta, TickDeltas, Transaction as V4Transaction};
+
+    fn tick_delta(pool: &[u8], tick: i32, ordinal: u64, tx_index: u64) -> TickDelta {
+        TickDelta {
+            pool_address: pool.to_vec(),
+            tick_index: tick,
+            liquidity_net_delta: vec![],
+            ordinal,
+            transaction: Some(V4Transaction {
+                hash: vec![0x11; 32],
+                from: vec![0x22; 20],
+                to: vec![0x33; 20],
+                index: tx_index,
+            }),
+        }
+    }
+
+    fn store_delta(pool: &[u8], tick: i32, ordinal: u64, old: &str, new: &str) -> StoreDelta {
+        StoreDelta {
+            operation: 0,
+            ordinal,
+            key: format!("pool:{}:tick:{}", pool.to_hex(), tick),
+            old_value: old.as_bytes().to_vec(),
+            new_value: new.as_bytes().to_vec(),
+        }
+    }
+
+    fn collect_ticks_only(
+        map_deltas: TickDeltas,
+        store_deltas: StoreDeltas,
+    ) -> Vec<TransactionChanges> {
+        collect_transaction_changes(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            map_deltas,
+            store_deltas,
+            Default::default(),
+            Default::default(),
+        )
+    }
+
+    fn attributes_by_name(changes: &[TransactionChanges]) -> HashMap<String, (Vec<u8>, i32)> {
+        changes
+            .iter()
+            .flat_map(|tx| tx.entity_changes.iter())
+            .flat_map(|ec| ec.attributes.iter())
+            .map(|a| (a.name.clone(), (a.value.clone(), a.change)))
+            .collect()
+    }
+
+    #[test]
+    fn tick_store_deltas_join_by_key_not_position() {
+        let pool = [0xaa_u8; 32];
+        // One ModifyLiquidity: both ticks share ordinal 5. Store order is swapped
+        // relative to map order, as the store module's unstable sort can produce.
+        let map_deltas =
+            TickDeltas { deltas: vec![tick_delta(&pool, 100, 5, 1), tick_delta(&pool, 200, 5, 1)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![
+                store_delta(&pool, 200, 5, "", "75"),
+                store_delta(&pool, 100, 5, "100", "150"),
+            ],
+        };
+
+        let changes = collect_ticks_only(map_deltas, store_deltas);
+        let attrs = attributes_by_name(&changes);
+
+        let (value, change) = &attrs["ticks/100/net-liquidity"];
+        assert_eq!(*value, BigInt::from(150).to_signed_bytes_be());
+        assert_eq!(*change, i32::from(ChangeType::Update));
+
+        let (value, change) = &attrs["ticks/200/net-liquidity"];
+        assert_eq!(*value, BigInt::from(75).to_signed_bytes_be());
+        assert_eq!(*change, i32::from(ChangeType::Creation));
+    }
+
+    #[test]
+    fn same_tick_written_in_two_transactions() {
+        let pool = [0xaa_u8; 32];
+        // Two events touch the same tick in one block: creation in tx 1, then the
+        // liquidity returns to zero in tx 2, which must classify as a deletion.
+        let map_deltas =
+            TickDeltas { deltas: vec![tick_delta(&pool, 100, 5, 1), tick_delta(&pool, 100, 9, 2)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![
+                store_delta(&pool, 100, 5, "", "40"),
+                store_delta(&pool, 100, 9, "40", "0"),
+            ],
+        };
+
+        let changes = collect_ticks_only(map_deltas, store_deltas);
+        let by_tx: HashMap<u64, (Vec<u8>, i32)> = changes
+            .iter()
+            .map(|tx_changes| {
+                let attr = tx_changes.entity_changes[0].attributes[0].clone();
+                (tx_changes.tx.as_ref().unwrap().index, (attr.value, attr.change))
+            })
+            .collect();
+
+        assert_eq!(
+            by_tx[&1],
+            (BigInt::from(40).to_signed_bytes_be(), i32::from(ChangeType::Creation))
+        );
+        assert_eq!(
+            by_tx[&2],
+            (BigInt::from(0).to_signed_bytes_be(), i32::from(ChangeType::Deletion))
+        );
     }
 }

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/ethereum-uniswap-v4-with-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/ethereum-uniswap-v4-with-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4_with_hooks"
-  version: v0.7.0
+  version: v0.7.1
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/with-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/tests.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/tests.rs
@@ -166,7 +166,8 @@ mod hooks_tests {
         let mut block = Block { number: 23120299, ..Default::default() };
 
         // Create the transaction trace based on the real transaction
-        let mut tx = TransactionTrace { index: 0, ..Default::default() }; // Assuming this was the first transaction in the block for simplicity
+        // Index 0 assumes this was the first transaction in the block
+        let mut tx = TransactionTrace { index: 0, ..Default::default() };
         tx.hash = hex::decode("b2347c7bd922fe5c7f5027523e3f3b4c2e72e7b535e4d0ddd2f4ea4f21c6edbf")
             .unwrap();
         tx.to = hex::decode("000AFbF798467f9b3b97F90D05Bf7Df592d89A6CF0").unwrap(); // EulerSwap factory (padded to 20 bytes)
@@ -269,7 +270,8 @@ mod hooks_tests {
 
         let (key, pool_id) = &result[0];
         assert!(key.starts_with("hook:"));
-        assert!(key.contains("0xd585c8baa6c0099d2cc59a5a089b8366cb3ea8a8")); // Lowercase hex of hook address
+        // Lowercase hex of hook address
+        assert!(key.contains("0xd585c8baa6c0099d2cc59a5a089b8366cb3ea8a8"));
         assert_eq!(pool_id, "real_pool_id_from_tx");
 
         println!("Real transaction test - Created mapping: {} -> {}", key, pool_id);

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/unichain-uniswap-v4-with-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/unichain-uniswap-v4-with-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_uniswap_v4_with_hooks"
-  version: v0.7.0
+  version: v0.7.1
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/with-hooks"
 
 protobuf:


### PR DESCRIPTION
## Problem

On Base dev (2026-09-02/03) the indexer fires `extractor_revert_attr_miss{component_state_found="true"}`
about 3 times per 6 hours. Uniswap V4 `ticks/<idx>/net-liquidity` attributes carry the value of the
wrong tick, and a tick's first write gets the label `Update` instead of `Creation`. On revert the
indexer then finds no prior value. The wrong net-liquidity value also feeds simulation.

## Root cause

`map_ticks_changes` emits two tick deltas per `ModifyLiquidity` event, one for `tick_lower` and one
for `tick_upper`. Both deltas carry the same log ordinal. `store_ticks_liquidity` sorts them with
`sort_unstable_by_key` on that ordinal, so it can swap the tied pair. `collect_transaction_changes`
then paired store deltas with tick deltas by position. After a swap, the attribute name of
`tick_lower` received the store delta of `tick_upper`: wrong value and wrong ChangeType.

## Fix

`collect_transaction_changes` joins store deltas to tick deltas by `(store key, ordinal)`. The store
key `pool:<pool>:tick:<index>` with the ordinal is unique: one event cannot write the same tick
twice, and different events have different log ordinals. The attribute body is unchanged.

## Rollout

Both variants embed the corrected shared code, so both need new spkgs: `no-hooks v0.4.3` and
`with-hooks v0.7.1`.

1. Build and publish the two spkgs through the usual release flow.
2. Pin the new `no-hooks` spkg on Base dev first.
3. Watch `extractor_revert_attr_miss{namespace="dev-tycho", chain="base", component_state_found="true"}`
   stay flat for a few days. Baseline before the fix is about 3 per 6 hours. The "Revert Attribute
   Miss" alert covers a regression.
4. Roll out the remaining pins in `helm-configuration`, dev before prod.

Current `no-hooks` pins to update (21 files, 7 chains):

| Chain | dev | prod |
|---|---|---|
| base | `base-tycho-indexer` v0.4.1, `base-new-tycho-indexer` v0.4.1 | `tycho/base-tycho-indexer-1` v0.4.1, `-2` v0.4.1, `tycho-fynd/base-tycho-indexer` v0.4.1 |
| ethereum | `ethereum-tycho-indexer` v0.4.0, `-new-protocol` v0.4.0, `ethereum-staging` v0.4.0 | `tycho/ethereum-tycho-indexer-1` v0.4.0, `-2` v0.4.0, `tycho-fynd/ethereum-tycho-indexer` v0.4.0 |
| arbitrum | v0.4.2 | v0.4.2 |
| bsc | v0.4.1 | v0.4.1 |
| polygon | v0.4.2 | v0.4.2 |
| robinhood | v0.4.2 | v0.4.2 |
| unichain | v0.4.1 | v0.4.1 |

Current `with-hooks` pins to update (6 files): dev `ethereum` v0.7.0, `ethereum-new-protocol` v0.6.0,
`ethereum-staging` v0.7.0; prod `tycho/ethereum-tycho-indexer-1` and `-2` v0.7.0,
`tycho-fynd/ethereum` v0.7.0. The commented-out unichain `with-hooks` pins need no change.

Note that the arbitrum spkg paths keep a `no-hooks/` sub-directory, unlike the other chains.

## Notes for reviewers

The pool-liquidity zip in the same function stays positional. It is sound today, because
`PoolLiquidityChanged` produces one change per event with a unique ordinal.

The join uses `remove`, and panics if a tick delta has no matching store delta. Every
`store.add` call emits one delta, so the count and the keys always match. The panic marks a broken
invariant instead of dropping changes, which the previous `zip` did without a signal.
