### PR TITLE
feat(router-trades): release the spkg packages apart from the image

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,6 +16,7 @@ Reusable build/deploy steps are delegated to [propeller-heads/ci-cd-templates](h
 | `ci-substreams.yaml` | PR (`substreams/`), manual | Lint and unit tests for changed substreams packages |
 | `ci-substreams-integration.yaml` | PR (`protocols/substreams/`, `protocols/testing/`), manual | Full protocol integration tests against a live DB |
 | `ci-router-trades.yaml` | PR/push (`crates/tycho-execution/substreams/`), manual | Router-trades lint, WASM build, unit tests, and PostgreSQL pricing integration |
+| `release-router-trades.yaml` | Manual | Build and publish one router-trades `.spkg` per chain to S3, where the sink containers fetch the version pinned in helm |
 | `cd-deploy-dev.yaml` | Manual | Build a branch image and deploy it to dev |
 | `promote-to-prod.yaml` | Manual | Promote a tagged dev image to production |
 | `release.yaml` | GitHub Release published, manual | Upload binaries to GitHub + S3, publish crates to crates.io |

--- a/.github/workflows/release-router-trades.yaml
+++ b/.github/workflows/release-router-trades.yaml
@@ -1,0 +1,71 @@
+name: Release Router Trades Substreams
+
+# Builds one .spkg per chain and uploads it to S3. The sink containers fetch the package they are
+# pinned to, so this workflow — not the image build — is what changes what runs in production.
+#
+# A release needs the version in tycho-router-trades/Cargo.toml bumped, merged, and a matching
+# `tycho-router-trades-<semver>` tag on that commit; release.sh refuses a mismatch and S3 refuses
+# a key that already exists. Without such a tag the run publishes a `pre.<sha>` package, which may
+# be overwritten and is meant for testing.
+#
+# Pin the resulting key per chain in helm-configuration:
+#   helmwave/dev/values/tycho/router-trades/router-trades.yml -> spkgs.<chain>
+on:
+  workflow_dispatch:
+    inputs:
+      chains:
+        required: false
+        description: "Space-separated chains to release, e.g. 'ethereum bsc'. Empty releases all."
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release-router-trades-spkg:
+    name: Release router trades packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+          submodules: false
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6  # v2.7.8
+        with:
+          cache-on-failure: true
+          workspaces: crates/tycho-execution/substreams
+
+      - name: Install Substreams CLI
+        run: |
+          LINK=$(curl -s https://api.github.com/repos/streamingfast/substreams/releases/latest \
+            | awk "/download.url.*linux_$(uname -m)/ {print \$2}" | sed 's/"//g')
+          curl -L "$LINK" | tar zxf - -C /usr/local/bin
+          chmod +x /usr/local/bin/substreams
+          substreams --version
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          audience: sts.amazonaws.com
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Build and release the packages
+        working-directory: crates/tycho-execution/substreams
+        env:
+          CHAINS: ${{ inputs.chains }}
+        run: |
+          # shellcheck disable=SC2086  # the input is a space-separated chain list on purpose
+          ./release.sh $CHAINS

--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -321,14 +321,21 @@ other side's price from the trade. See `substreams/README.md`.
    verify the implied price; symbols are duplicated by fake tokens.
 5. `substreams/scripts/gen_tables.py` re-run, so `src/executors_table.rs` names the new chain's
    executors.
-6. `substreams/docker-compose.yaml` and, in `helm-configuration`, the `$chains` list plus a
-   `TYCHO_<CHAIN>_DATABASE_URL` entry in
-   `helmwave/dev/values/tycho/router-trades/router-trades.yml`.
+6. `substreams/docker-compose.yaml`, a released `.spkg` for the chain, and in
+   `helm-configuration` the `$chains` list plus the `spkgs` pin and a `TYCHO_<CHAIN>_DATABASE_URL`
+   entry in `helmwave/dev/values/tycho/router-trades/router-trades.yml`.
+
+**The `.spkg` packages are released separately from the image** by `substreams/release.sh` to
+`s3://repo.propellerheads-propellerheads/substreams/tycho-router-trades/<chain>-<version>.spkg`,
+and each sink container fetches the key it is pinned to. So the image build carries no module hash
+and rebuilding it is safe, while changing what a chain indexes takes three steps: bump
+`tycho-router-trades/Cargo.toml`, run the **Release Router Trades Substreams** workflow, and pin
+the new key under `spkgs` in helm. Releases are immutable; a rollback is a pin back.
 
 **Changing a manifest or the Rust source changes the module hash**, which the sink cursors are
-keyed by; the affected containers then exit until their `cursors_<chain>` row is cleared, and
-because the sink writes plain `INSERT`s, any chain that re-reads written blocks needs its rows
-deleted too. See "Updating a deployed sink" in `substreams/README.md`.
+keyed by; a chain pinned to the new package then exits until its `cursors_<chain>` row is cleared,
+and because the sink writes plain `INSERT`s, any chain that re-reads written blocks needs its rows
+deleted too. See "Releasing a package" and "Updating a deployed sink" in `substreams/README.md`.
 
 ## Build & Test
 

--- a/crates/tycho-execution/substreams/Dockerfile
+++ b/crates/tycho-execution/substreams/Dockerfile
@@ -1,37 +1,25 @@
-# Builds the wasm module, packs one .spkg per chain and ships them with substreams-sink-sql.
+# Ships substreams-sink-sql with the SQL and scripts it needs.
+#
+# The .spkg packages are NOT built here. release.sh publishes them to S3 and each sink container
+# fetches the one it is pinned to, so this image carries no module hash: rebuilding it, for any
+# reason, cannot change what a sink reads or invalidate a cursor.
+#
 # Build from the repository root:
 #   docker build -f crates/tycho-execution/substreams/Dockerfile -t tycho-router-trades .
-ARG SUBSTREAMS_VERSION=v1.22.0
 ARG SINK_SQL_VERSION=v4.13.1
-
-FROM rust:1.91-bookworm AS build
-ARG SUBSTREAMS_VERSION
-ARG TARGETARCH=amd64
-RUN case "$TARGETARCH" in amd64) ARCH=x86_64 ;; arm64) ARCH=arm64 ;; *) echo "unsupported arch $TARGETARCH" && exit 1 ;; esac \
-    && curl -fsSL --retry 5 --retry-all-errors -o /tmp/substreams.tgz \
-       "https://github.com/streamingfast/substreams/releases/download/${SUBSTREAMS_VERSION}/substreams_linux_${ARCH}.tar.gz" \
-    && tar -xzf /tmp/substreams.tgz -C /usr/local/bin substreams && rm /tmp/substreams.tgz
-WORKDIR /build
-COPY crates/tycho-execution/substreams/rust-toolchain.toml .
-RUN rustup set profile minimal && rustup show
-COPY crates/tycho-execution/substreams/ .
-RUN cargo build --target wasm32-unknown-unknown --release --target-dir target
-RUN mkdir -p /spkg && for manifest in tycho-router-trades/chains/*.yaml; do \
-        chain=$(basename "$manifest" .yaml); \
-        substreams pack "$manifest" -o "/spkg/${chain}.spkg"; \
-    done
 
 FROM debian:bookworm-slim
 ARG SINK_SQL_VERSION
+# Kaniko does not set TARGETARCH, so it needs a default.
 ARG TARGETARCH=amd64
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl postgresql-client \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl postgresql-client awscli \
     && apt-get clean \
-    && case "$TARGETARCH" in amd64) ARCH=x86_64 ;; arm64) ARCH=arm64 ;; esac \
+    && case "$TARGETARCH" in amd64) ARCH=x86_64 ;; arm64) ARCH=arm64 ;; *) echo "unsupported arch $TARGETARCH" && exit 1 ;; esac \
     && curl -fsSL --retry 5 --retry-all-errors -o /tmp/sink.tgz \
        "https://github.com/streamingfast/substreams-sink-sql/releases/download/${SINK_SQL_VERSION}/substreams-sink-sql_linux_${ARCH}.tar.gz" \
     && tar -xzf /tmp/sink.tgz -C /usr/local/bin substreams-sink-sql && rm /tmp/sink.tgz
 WORKDIR /opt/router-trades
-COPY --from=build /spkg ./spkg
 COPY crates/tycho-execution/substreams/schema.sql ./
 COPY crates/tycho-execution/substreams/pricing ./pricing
 COPY crates/tycho-execution/substreams/scripts/price_trades.sh crates/tycho-execution/substreams/scripts/fdw_setup.sh ./scripts/

--- a/crates/tycho-execution/substreams/Makefile
+++ b/crates/tycho-execution/substreams/Makefile
@@ -31,8 +31,18 @@ fmt:
 protogen:
 	cd tycho-router-trades && substreams protogen chains/ethereum.yaml --output-path src/pb --exclude-paths="sf/substreams,google,sf/ethereum"
 
+# Packs into target/spkg/, where docker-compose mounts it for the local sinks. release.sh does the
+# same for the published packages.
 pack: build
-	substreams pack $(MANIFEST) -o tycho-router-trades-$(CHAIN).spkg
+	mkdir -p target/spkg
+	substreams pack $(MANIFEST) -o target/spkg/$(CHAIN).spkg
+
+pack-all: build
+	mkdir -p target/spkg
+	for manifest in tycho-router-trades/chains/*.yaml; do \
+		chain=$$(basename "$$manifest" .yaml); \
+		substreams pack "$$manifest" -o "target/spkg/$$chain.spkg"; \
+	done
 
 # Stream decoded trades to the terminal for a block range, e.g.
 #   make run CHAIN=ethereum START=25654569 STOP=+100

--- a/crates/tycho-execution/substreams/README.md
+++ b/crates/tycho-execution/substreams/README.md
@@ -90,16 +90,24 @@ stand-in tables in `tycho_ethereum` instead of the foreign tables.
 
 ## Container
 
-`Dockerfile` (build from the repository root) compiles the wasm, packs one `.spkg` per chain and
-ships them with `substreams-sink-sql` and `psql`. The image has two modes:
+`Dockerfile` (build from the repository root) ships `substreams-sink-sql` with `psql`, the AWS CLI
+and the SQL. It builds no wasm and carries no `.spkg`: `release.sh` publishes those separately and
+each container fetches the one it is pinned to, so rebuilding the image cannot change what a sink
+reads. The image has two modes:
 
 ```bash
 docker build -f crates/tycho-execution/substreams/Dockerfile -t tycho-router-trades .
 # one container per chain, all writing to the same database
-docker run -e CHAIN=ethereum -e DSN='psql://...' -e SUBSTREAMS_API_TOKEN=... tycho-router-trades sink
+docker run -e CHAIN=ethereum -e SPKG=substreams/tycho-router-trades/ethereum-v0.1.0.spkg \
+  -e DSN='psql://...' -e SUBSTREAMS_API_TOKEN=... tycho-router-trades sink
 # one container running the pricing loop
 docker run -e DSN='postgres://...' tycho-router-trades price
 ```
+
+`SPKG` is a local path when that file exists and otherwise a key in the release bucket
+(`TYCHO_S3_BUCKET`, default `repo.propellerheads-propellerheads`), cached under `SPKG_CACHE_DIR`.
+That is the same rule the indexer uses for its own packages, so a pinned release and a
+bind-mounted local build both work.
 
 Both modes wait until the database accepts connections. `sink` runs `substreams-sink-sql setup`
 (idempotent) and then `run` with `--batch-block-flush-interval 100`; optional
@@ -108,13 +116,16 @@ default `:9102`). `price` registers one `postgres_fdw` server per `TYCHO_<CHAIN>
 variable (`scripts/fdw_setup.sh`, re-run on every start). It runs `price_trades.sql` separately
 for each chain every `INTERVAL` seconds (default 60,
 `MAX_AGE` default `1 hour`). A failed chain is logged without blocking the others.
-`docker-compose.yaml` wires the database, the eight sinks and the pricer for a local run
-(`docker compose --profile sinks up`).
+`docker-compose.yaml` wires the database, the eight sinks and the pricer for a local run: run
+`make pack-all` first, which writes the packages to `target/spkg/` where the compose file mounts
+them (`docker compose --profile sinks up`).
 
 ### Kubernetes
 
 `main-workflow.yaml` builds the image as `tycho-router-trades:<release version>` on every
 monorepo release and promotes the tag to `helmwave/dev/versions.yml` in `helm-configuration`. The
+image only carries the sink and the SQL, so that promotion is routine: what each chain indexes is
+decided by the package pinned under `spkgs`, released separately. The
 release `router-trades-db` there (namespace `dev-tycho`) is a Postgres 16 StatefulSet; release
 `router-trades` is one pod with a `sink` container per chain and one `price` container, all
 writing to `router-trades-db:5432`. Grafana reaches the database through the same service with
@@ -128,16 +139,14 @@ Two properties of `substreams-sink-sql` decide what an update costs, and both bi
 including `initialBlock` and `params` — and the compiled wasm. The sinks run with the default
 `--on-module-hash-mismatch=error`, so when the hash changes the container exits at startup with a
 mismatch against the row in `cursors_<chain>`, and it keeps crashlooping until that row is
-deleted. What changed decides the blast radius:
+deleted.
 
-| change | new hash for |
-|---|---|
-| one chain's manifest (`initialBlock`, router `params`) | that chain only |
-| anything under `src/`, `Cargo.lock`, the wasm build | **every chain** |
-
-A local `cargo build` is not byte-identical to the Docker build, so production hashes cannot be
-precomputed on a laptop; CI builds of the same source are stable, so an image rebuild without a
-source change keeps every cursor valid.
+Nothing changes that hash by accident, because it belongs to a released `.spkg` rather than to the
+image. A chain's hash moves only when someone pins a different package for that chain under
+`spkgs` in `helmwave/<env>/values/tycho/router-trades/router-trades.yml`, and it moves for that
+chain alone. Rebuilding or promoting the image — from a change here or from an unrelated monorepo
+release — changes nothing. A wasm build is in any case not byte-identical across environments, so
+a hash is only ever known from the package that CI published.
 
 **The sink does not upsert.** `db_out` uses `create_row`, which is `OPERATION_CREATE`, and the
 postgres dialect turns that into a plain `INSERT` with no `ON CONFLICT`. Any block the sink reads
@@ -147,10 +156,11 @@ in practice, all of them.
 
 ### Procedure
 
-1. Merge the change and let the release build the image; `promote-to-dev` writes the tag into
-   `helmwave/dev/versions.yml` and the dev deployment rolls the pod.
-2. Chains whose hash changed exit on the mismatch; the others resume from their cursors. This is
-   expected, and it is contained: the sinks have no readiness probe and Postgres is a separate
+1. Merge the change, release the packages (see "Releasing a package") and pin the new keys for
+   the affected chains under `spkgs` in
+   `helmwave/<env>/values/tycho/router-trades/router-trades.yml`. The dev deployment rolls the pod.
+2. Chains whose package changed exit on the mismatch; the others resume from their cursors. This
+   is expected, and it is contained: the sinks have no readiness probe and Postgres is a separate
    release.
 3. Clear the state of each affected chain, now that its sink is down and not flushing:
 
@@ -173,6 +183,36 @@ cursor in the table, which is block 0 for a chain that has never produced data.
 
 `cursors_<chain>` holds one bookmark row and `substreams_history_<chain>` is the reorg-undo
 journal. Neither holds trade data, so clearing them loses no trade.
+
+## Releasing a package
+
+`release.sh` builds the wasm once and packs one `.spkg` per chain to
+`s3://repo.propellerheads-propellerheads/substreams/tycho-router-trades/<chain>-<version>.spkg`.
+It mirrors `protocols/substreams/release.sh`, including its rules:
+
+* the version comes from `tycho-router-trades/Cargo.toml`, so bump it in the PR that changes the
+  package;
+* a release needs a `tycho-router-trades-<semver>` tag on HEAD whose version matches, and a clean
+  tree. **Releases are immutable** — S3 rejects a key that already exists, so a changed package
+  takes a new version and never an overwrite;
+* without such a tag the run publishes `pre.<sha>`, which may be overwritten and is meant for
+  testing.
+
+Run it from CI with the **Release Router Trades Substreams** workflow (`workflow_dispatch`, with
+an optional space-separated `chains` input). It prints the `db_out` module hash of every package.
+That hash is the identity the cursors are keyed by, so compare it with the running
+`cursors_<chain>.id` before pinning, to know whether a chain will resume or restart.
+
+Then pin the published keys per chain in helm:
+
+```yaml
+spkgs:
+  ethereum: substreams/tycho-router-trades/ethereum-v0.2.0.spkg
+  bsc:      substreams/tycho-router-trades/bsc-v0.3.0.spkg
+```
+
+Chains are independent: each runs the version it is pinned to, and a rollback is a pin back to the
+previous key.
 
 ## Adding a chain
 
@@ -214,11 +254,11 @@ Six places, and the deployment fails quietly if any of the last three is missed.
    name.
 
 6. **Wire the deployment.** Add a `sink-<chain>` service to `docker-compose.yaml` for local runs.
-   In `helm-configuration`, add the chain to the `$chains` list of
-   `helmwave/dev/values/tycho/router-trades/router-trades.yml`, which gives it a sink container, a
-   metrics port and a scrape entry, and add a `TYCHO_<CHAIN>_DATABASE_URL` entry pointing at that
-   chain's Tycho database so the pricer can reach its prices. The image bakes the packed `.spkg`
-   files, so the chain only runs after a release rebuilds it.
+   Release the chain's package (see "Releasing a package"). In `helm-configuration`, add the chain
+   to the `$chains` list of `helmwave/dev/values/tycho/router-trades/router-trades.yml`, which
+   gives it a sink container, a metrics port and a scrape entry, pin its package under `spkgs`,
+   and add a `TYCHO_<CHAIN>_DATABASE_URL` entry pointing at that chain's Tycho database so the
+   pricer can reach its prices.
 
 Nothing has to be cleared in the database: a chain with no cursor row starts at its
 `initialBlock`.

--- a/crates/tycho-execution/substreams/docker-compose.yaml
+++ b/crates/tycho-execution/substreams/docker-compose.yaml
@@ -1,6 +1,7 @@
 # Local setup: Postgres, one sink per chain and the pricing loop.
 #
 #   docker compose up -d db                      # database only (then `make sink CHAIN=...`)
+#   make pack-all                                # the sinks read these, the image ships none
 #   docker compose --profile sinks up -d         # database + all chain sinks + pricer
 #
 # Set SUBSTREAMS_API_TOKEN in the environment (or a .env file next to this file).
@@ -15,6 +16,8 @@ x-sink: &sink
   depends_on:
     db:
       condition: service_healthy
+  volumes:
+    - ./target/spkg:/opt/router-trades/spkg:ro
   environment: &sink-env
     DSN: psql://tycho:tycho@db:5432/router_trades?sslmode=disable
     SUBSTREAMS_API_TOKEN: ${SUBSTREAMS_API_TOKEN}
@@ -39,28 +42,28 @@ services:
 
   sink-ethereum:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: ethereum }
+    environment: { <<: *sink-env, CHAIN: ethereum, SPKG: /opt/router-trades/spkg/ethereum.spkg }
   sink-base:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: base }
+    environment: { <<: *sink-env, CHAIN: base, SPKG: /opt/router-trades/spkg/base.spkg }
   sink-unichain:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: unichain }
+    environment: { <<: *sink-env, CHAIN: unichain, SPKG: /opt/router-trades/spkg/unichain.spkg }
   sink-arbitrum:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: arbitrum }
+    environment: { <<: *sink-env, CHAIN: arbitrum, SPKG: /opt/router-trades/spkg/arbitrum.spkg }
   sink-bsc:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: bsc }
+    environment: { <<: *sink-env, CHAIN: bsc, SPKG: /opt/router-trades/spkg/bsc.spkg }
   sink-polygon:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: polygon }
+    environment: { <<: *sink-env, CHAIN: polygon, SPKG: /opt/router-trades/spkg/polygon.spkg }
   sink-plasma:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: plasma }
+    environment: { <<: *sink-env, CHAIN: plasma, SPKG: /opt/router-trades/spkg/plasma.spkg }
   sink-robinhood:
     <<: *sink
-    environment: { <<: *sink-env, CHAIN: robinhood }
+    environment: { <<: *sink-env, CHAIN: robinhood, SPKG: /opt/router-trades/spkg/robinhood.spkg }
 
   pricer:
     <<: *sink

--- a/crates/tycho-execution/substreams/docker/entrypoint.sh
+++ b/crates/tycho-execution/substreams/docker/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Runs one sink (per chain) or the pricing loop.
 #
-#   entrypoint sink   CHAIN, DSN, SUBSTREAMS_API_TOKEN; optional SUBSTREAMS_ENDPOINT,
-#                     START_BLOCK, STOP_BLOCK, FLUSH_INTERVAL (default 100), METRICS_ADDR
+#   entrypoint sink   CHAIN, SPKG, DSN, SUBSTREAMS_API_TOKEN; optional SUBSTREAMS_ENDPOINT,
+#                     START_BLOCK, STOP_BLOCK, FLUSH_INTERVAL (default 100), METRICS_ADDR,
+#                     TYCHO_S3_BUCKET, SPKG_CACHE_DIR
 #   entrypoint price  DSN, TYCHO_<CHAIN>_DATABASE_URL...; optional MAX_AGE (default "1 hour"),
 #                     INTERVAL (default 60), LOCAL_PRICING=1 for local stand-in tables
 #
@@ -10,6 +11,24 @@
 # `sink` applies schema.sql with `substreams-sink-sql setup`; `price` registers the postgres_fdw
 # servers (scripts/fdw_setup.sh). Both steps are idempotent.
 set -euo pipefail
+
+# SPKG is a local path when that file exists, otherwise a key in the release bucket. Same rule as
+# the indexer's ensure_spkg, so a pinned S3 key and a bind-mounted file both work.
+resolve_spkg() {
+	local ref="$1" bucket dest
+	if [ -f "$ref" ]; then
+		printf '%s' "$ref"
+		return
+	fi
+	bucket="${TYCHO_S3_BUCKET:-repo.propellerheads-propellerheads}"
+	dest="${SPKG_CACHE_DIR:-/tmp/spkg}/$(basename "$ref")"
+	if [ ! -f "$dest" ]; then
+		mkdir -p "$(dirname "$dest")"
+		echo "fetching s3://$bucket/$ref" >&2
+		aws s3 cp "s3://$bucket/$ref" "$dest" >&2
+	fi
+	printf '%s' "$dest"
+}
 
 wait_for_db() {
 	local uri="${1/psql:\/\//postgres://}"
@@ -23,13 +42,10 @@ mode="${1:-sink}"
 case "$mode" in
 sink)
 	: "${CHAIN:?set CHAIN (ethereum, base, ...)}"
+	: "${SPKG:?set SPKG to a local path or a release key, e.g. substreams/tycho-router-trades/ethereum-v0.1.0.spkg}"
 	: "${DSN:?set DSN, e.g. psql://user:pass@host:5432/db?sslmode=disable}"
 	: "${SUBSTREAMS_API_TOKEN:?set SUBSTREAMS_API_TOKEN}"
-	spkg="/opt/router-trades/spkg/${CHAIN}.spkg"
-	[ -f "$spkg" ] || {
-		echo "no package for chain '$CHAIN'" >&2
-		exit 1
-	}
+	spkg=$(resolve_spkg "$SPKG")
 	system_table_args=(
 		--cursors-table "cursors_${CHAIN}"
 		--history-table "substreams_history_${CHAIN}"

--- a/crates/tycho-execution/substreams/release.sh
+++ b/crates/tycho-execution/substreams/release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Builds one .spkg per chain and uploads it to S3, where the sink containers fetch it from.
+#
+# Forked from protocols/substreams/release.sh and follows the same rules:
+#   * the version comes from tycho-router-trades/Cargo.toml
+#   * a release needs a git tag `tycho-router-trades-<semver>` on HEAD whose version matches, and
+#     a clean tree. Releases are immutable: S3 rejects a key that exists
+#   * without such a tag the run publishes a pre-release keyed by the commit, which may be
+#     overwritten
+#
+# The module hash of every package is printed. It is the identity the sink cursors are keyed by,
+# so a diff there is the thing to check before pinning a new version in helm.
+#
+#   ./release.sh                # every chain
+#   ./release.sh ethereum bsc   # only these
+set -euo pipefail
+
+cd "$(dirname "$0")"
+package=tycho-router-trades
+
+current_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
+cargo_version=$(cargo pkgid -p "$package" | cut -d# -f2 | cut -d: -f2)
+
+if [ -n "$current_tag" ]; then
+	if [[ ! $current_tag =~ ^${package}-([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+		echo "Error: tag '$current_tag' is not ${package}-<semver>." >&2
+		exit 1
+	fi
+	version="v${BASH_REMATCH[1]}"
+	if [[ "v$cargo_version" != "$version" ]]; then
+		echo "Error: Cargo version v${cargo_version} does not match tag version ${version}." >&2
+		exit 1
+	fi
+	if [ -n "$(git status --porcelain)" ]; then
+		echo "Error: the repository is dirty. Commit or stash your changes." >&2
+		exit 1
+	fi
+else
+	version="pre.$(git rev-parse --short HEAD)"
+	echo "No ${package}-<semver> tag on HEAD, publishing pre-release $version"
+fi
+
+chains=("$@")
+if [ ${#chains[@]} -eq 0 ]; then
+	for manifest in "$package"/chains/*.yaml; do
+		chains+=("$(basename "$manifest" .yaml)")
+	done
+fi
+
+# --locked enforces the committed Cargo.lock and the build runs in this workspace so its own
+# rust-toolchain.toml applies. Both are needed for a reproducible wasm, and the wasm is part of
+# the module hash.
+cargo build --locked --target wasm32-unknown-unknown --release --target-dir target
+mkdir -p target/spkg
+
+REPOSITORY=${REPOSITORY:-"s3://repo.propellerheads-propellerheads/substreams"}
+
+for chain in "${chains[@]}"; do
+	manifest="$package/chains/$chain.yaml"
+	if [ ! -f "$manifest" ]; then
+		echo "Error: no manifest for chain '$chain' at $manifest." >&2
+		exit 1
+	fi
+
+	spkg="target/spkg/$chain-$version.spkg"
+	repository_path="$REPOSITORY/$package/$chain-$version.spkg"
+	bucket_and_key="${repository_path#s3://}"
+
+	echo "------------------------------------------------------"
+	substreams pack "$manifest" -o "$spkg"
+	echo "module hash: $(substreams info "$spkg" | awk '/^Name: db_out$/{found=1} found && /^Hash:/{print $2; exit}')"
+
+	if [[ "$version" == pre.* ]]; then
+		aws s3 cp "$spkg" "$repository_path"
+	else
+		if ! aws s3api put-object \
+			--bucket "${bucket_and_key%%/*}" \
+			--key "${bucket_and_key#*/}" \
+			--body "$spkg" \
+			--if-none-match '*' >/dev/null; then
+			echo "Error: upload rejected. A PreconditionFailed error above means $repository_path already exists — releases are immutable, bump the package version instead." >&2
+			exit 1
+		fi
+	fi
+
+	echo "RELEASED SUBSTREAMS PACKAGE: '$repository_path'"
+done


### PR DESCRIPTION
## Problem

The image packed a `.spkg` per chain, so **every chain's module hash was a property of the image** — and the image is rebuilt on every monorepo release (`build-and-push-tycho-router-trades` is `needs: release`, no path filter) from a floating base tag (`FROM rust:1.91-bookworm`). Consequences:

- An edit under `src/` gives all seven chains a new hash at once.
- So does a base-image refresh, with **nobody having touched this directory**.
- Recovery is not cheap: with `--on-module-hash-mismatch=error` every sink exits, and because the sink writes plain `INSERT`s each chain needs its rows deleted and a full re-sync from its deployment block (ethereum ~3.3M blocks, base ~20M, robinhood ~29M).
- There was also no way to run different versions per chain.

## Approach

Publish the packages separately and let each container fetch the one it is pinned to — the mechanism `protocols/substreams` already uses.

- **`release.sh`** (forked from `protocols/substreams/release.sh`, same rules) builds the wasm once with `--locked`, packs one `.spkg` per chain and uploads to `s3://repo.propellerheads-propellerheads/substreams/tycho-router-trades/<chain>-<version>.spkg`. The version comes from `tycho-router-trades/Cargo.toml`; a release needs a matching `tycho-router-trades-<semver>` tag on HEAD and a clean tree; **releases are immutable** (`put-object --if-none-match '*'`); without a tag it publishes an overwritable `pre.<sha>`. It prints each `db_out` module hash.
- **`release-router-trades.yaml`** — `workflow_dispatch` with an optional space-separated `chains` input, mirroring the existing release workflow.
- **The Dockerfile loses its Rust stage entirely.** The image is now the sink binary plus `psql`, the AWS CLI and the SQL, so it carries no module hash and rebuilding it cannot invalidate a cursor.
- **The entrypoint resolves `SPKG`**: a local path when that file exists, otherwise a key in `TYCHO_S3_BUCKET` (default `repo.propellerheads-propellerheads`) cached under `SPKG_CACHE_DIR`. Same rule as the indexer's `ensure_spkg`, so a pinned release and a bind-mounted local build both work.
- **Local runs**: `make pack-all` writes packages to `target/spkg/`, which `docker-compose.yaml` mounts.

Pinning lives in helm, per chain and per environment:

```yaml
spkgs:
  ethereum: substreams/tycho-router-trades/ethereum-v0.2.0.spkg
  bsc:      substreams/tycho-router-trades/bsc-v0.3.0.spkg
```

A chain's hash now moves only when someone changes that one line, and only for that chain.

## Verification

- `release.sh` passes `shellcheck` and `shfmt`; the workflow passes `actionlint` and `zizmor` (the first draft had a real `template-injection` on the `chains` input, now passed through `env:`).
- Image builds; `aws --version` reports 2.9.19 inside it.
- End-to-end run of the new resolution against a locally packed package: no S3 fetch (local path taken), `setup completed successfully`, and `output_module_hash: 299766f1…` read from the mounted `.spkg`.
- `docker compose config` valid.

## Migration — needs care exactly once

CI-published packages will not carry the module hashes the running image produced, because a wasm build is not byte-identical across environments. Pinning freshly built packages would therefore invalidate all seven cursors.

To migrate without a re-sync: extract the `.spkg` files from the **currently deployed image**, upload those exact bytes as the first pinned version, and pin them. The hashes then match the live `cursors_<chain>.id` and every chain resumes untouched.

## Follow-up

The helm side (the `spkgs` map, the `SPKG` env per sink container, and the `eks.amazonaws.com/role-arn` annotation the pod needs for S3) is a separate PR in `helm-configuration`, which must land together with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
