### PR TITLE
feat(integration-test): allow --test-every-n-blocks with --partial-blocks

### DIFF
--- a/crates/tycho-integration-test/CLAUDE.md
+++ b/crates/tycho-integration-test/CLAUDE.md
@@ -43,9 +43,9 @@ shows up as a failure.
 ## Module Structure
 
 - **`main.rs`**: CLI (`Cli` struct), top-level orchestration loop — subscribes to Tycho,
-  dispatches blocks to stream processors, calls `poll_rpc_for_block` (every-block mode) or
-  `await_target_block` (`--test-every-n-blocks` > 1, fetches the sampled block by number) for
-  on-chain comparison
+  dispatches blocks to stream processors, calls `poll_rpc_for_block` (every-block mode, and
+  sampled mode under `--partial-blocks`) or `await_target_block` (`--test-every-n-blocks` > 1
+  without `--partial-blocks`, fetches the sampled block by number) for on-chain comparison
 - **`stream_processor/`**:
   - `protocol_stream_processor.rs`: Handles on-chain protocol updates — applies deltas to
     `ProtocolSim` instances, runs `get_amount_out` simulations, validates via RPC execution

--- a/crates/tycho-integration-test/CLAUDE.md
+++ b/crates/tycho-integration-test/CLAUDE.md
@@ -30,7 +30,7 @@ Key optional flags: `--no-tls`, `--disable-onchain`, `--disable-rfq`,
 `--disable-price-level-stream`, `--disable-execution`, `--protocols uniswap_v2,curve`,
 `--max-blocks 100`, `--parallel-simulations 5`, `--always-test-components <id,...>`,
 `--price-level-stream-block-interval 1`, `--price-level-stream-stale-threshold-secs 10`,
-`--test-every-n-blocks 10`, `--bypass-executor-timelock`.
+`--test-every-n-updates 10`, `--bypass-executor-timelock`.
 
 `--bypass-executor-timelock` writes `executorsActivationTimestamp = 1` for every executor of the
 chain into the execution simulation's state overrides, so an executor that is unapproved or still
@@ -43,9 +43,11 @@ shows up as a failure.
 ## Module Structure
 
 - **`main.rs`**: CLI (`Cli` struct), top-level orchestration loop — subscribes to Tycho,
-  dispatches blocks to stream processors, calls `poll_rpc_for_block` (every-block mode, and
-  sampled mode under `--partial-blocks`) or `await_target_block` (`--test-every-n-blocks` > 1
-  without `--partial-blocks`, fetches the sampled block by number) for on-chain comparison
+  dispatches blocks to stream processors, tests every Nth protocol update
+  (`--test-every-n-updates`, alias `--test-every-n-blocks`), calls `poll_rpc_for_block`
+  (every-update mode, and sampled mode under `--partial-blocks`) or `await_target_block`
+  (sampled mode without `--partial-blocks`, fetches the sampled block by number) for on-chain
+  comparison
 - **`stream_processor/`**:
   - `protocol_stream_processor.rs`: Handles on-chain protocol updates — applies deltas to
     `ProtocolSim` instances, runs `get_amount_out` simulations, validates via RPC execution

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1021,13 +1021,11 @@ async fn process_update(
             let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
             let by_number =
-                fetch_sampled_block_by_number(cli.test_every_n_blocks, cli.partial_blocks);
+                should_fetch_block_by_number(cli.test_every_n_blocks, cli.partial_blocks);
 
             let block = if by_number {
-                // Sampled full-block mode: on fast chains the head is expected to be past the
-                // update, so the target block is fetched by number instead of racing the head.
-                // Sampled runs with --partial-blocks never take this path — a flashblock's
-                // pending state cannot be fetched by number — and use the polling path below.
+                // On fast chains the head is expected to be past the update, so fetch the target
+                // block by number instead of racing the head.
                 match await_target_block(
                     &rpc_tools,
                     update_block_number,
@@ -2035,12 +2033,12 @@ fn is_sampled_block(block_number: u64, interval: u64) -> bool {
     block_number.is_multiple_of(interval)
 }
 
-/// True when a sampled update's target block should be fetched by number (sampled full-block
-/// mode, e.g. Robinhood where the head races past the update). With --partial-blocks, sampling
-/// only gates WHICH updates are tested; block fetching stays on the pending/latest polling path
-/// because a flashblock's pending state cannot be fetched by number after the fact.
-fn fetch_sampled_block_by_number(test_every_n_blocks: u64, partial_blocks: bool) -> bool {
-    test_every_n_blocks > 1 && !partial_blocks
+/// True when a sampled update's target block should be fetched by number rather than polled for.
+///
+/// A flashblock's pending state cannot be fetched by number after the fact, so under
+/// `--partial-blocks` sampling only gates which updates are tested.
+fn should_fetch_block_by_number(interval: u64, partial_blocks: bool) -> bool {
+    interval > 1 && !partial_blocks
 }
 
 /// Selector of the priority-update-registry's `StaleUpdate()` error, the freshness guard of the
@@ -2172,7 +2170,7 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        fetch_sampled_block_by_number, is_oracle_stale_revert, is_sampled_block, pamm_venue, Cli,
+        is_oracle_stale_revert, is_sampled_block, pamm_venue, should_fetch_block_by_number, Cli,
     };
 
     #[rstest]
@@ -2231,17 +2229,9 @@ mod tests {
         assert_eq!(is_sampled_block(block, interval), expected);
     }
 
-    #[rstest]
-    #[case::sampled_full_block_mode(10, false, true)]
-    #[case::sampled_with_partial_blocks_polls(10, true, false)]
-    #[case::unsampled_polls(1, false, false)]
-    #[case::unsampled_with_partial_blocks_polls(1, true, false)]
-    fn sampled_fetch_by_number_only_without_partial_blocks(
-        #[case] test_every_n_blocks: u64,
-        #[case] partial_blocks: bool,
-        #[case] expected: bool,
-    ) {
-        assert_eq!(fetch_sampled_block_by_number(test_every_n_blocks, partial_blocks), expected);
+    #[test]
+    fn sampled_with_partial_blocks_polls_instead_of_fetching_by_number() {
+        assert!(!should_fetch_block_by_number(10, true));
     }
 
     #[test]

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1020,8 +1020,10 @@ async fn process_update(
 
             let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
-            let block = if fetch_sampled_block_by_number(cli.test_every_n_blocks, cli.partial_blocks)
-            {
+            let by_number =
+                fetch_sampled_block_by_number(cli.test_every_n_blocks, cli.partial_blocks);
+
+            let block = if by_number {
                 // Sampled full-block mode: on fast chains the head is expected to be past the
                 // update, so the target block is fetched by number instead of racing the head.
                 // Sampled runs with --partial-blocks never take this path — a flashblock's

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1109,6 +1109,9 @@ async fn process_update(
                              {update_block_number}, skipping."
                         );
                         metrics::record_protocol_update_skipped();
+                        for protocol in update.update.sync_states.keys() {
+                            metrics::record_protocol_sync_state_skipped(protocol);
+                        }
                         return Ok(());
                     }
                 }

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -242,6 +242,15 @@ struct TychoState {
     states: HashMap<String, Box<dyn ProtocolSim>>,
     components: HashMap<String, ProtocolComponent>,
     component_ids_by_protocol: HashMap<String, HashSet<String>>,
+    protocol_updates_seen: u64,
+}
+
+impl TychoState {
+    /// Counts one received protocol update and returns its 1-based sequence number.
+    fn next_update_seq(&mut self) -> u64 {
+        self.protocol_updates_seen += 1;
+        self.protocol_updates_seen
+    }
 }
 
 /// Shared, periodically-refreshed token-price snapshot (raw token units per ETH).
@@ -976,7 +985,7 @@ async fn process_update(
     let block = match update.update_type {
         UpdateType::Protocol => {
             // Update state cache before block alignment check
-            {
+            let update_seq = {
                 let mut current_state = tycho_state
                     .write()
                     .map_err(|e| miette!("Failed to acquire write lock on Tycho state: {e}"))?;
@@ -1009,11 +1018,12 @@ async fn process_update(
                 for (protocol, component_ids) in &current_state.component_ids_by_protocol {
                     metrics::record_protocol_pool_count(protocol, component_ids.len());
                 }
-            }
+                current_state.next_update_seq()
+            };
 
             let update_block_number = update.update.block_number_or_timestamp;
 
-            if !is_sampled_block(update_block_number, cli.test_every_n_blocks) {
+            if !update_seq.is_multiple_of(cli.test_every_n_blocks) {
                 metrics::record_protocol_update_sampled_out();
                 return Ok(());
             }
@@ -2028,11 +2038,6 @@ fn reached_max_blocks(max_blocks: u64, statistics: Option<&Arc<RwLock<TestStatis
     stats.blocks_processed >= max_blocks
 }
 
-/// True when `block_number` is selected by the `--test-every-n-blocks` sampling interval.
-fn is_sampled_block(block_number: u64, interval: u64) -> bool {
-    block_number.is_multiple_of(interval)
-}
-
 /// True when a sampled update's target block should be fetched by number rather than polled for.
 ///
 /// A flashblock's pending state cannot be fetched by number after the fact, so under
@@ -2170,7 +2175,7 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        is_oracle_stale_revert, is_sampled_block, pamm_venue, should_fetch_block_by_number, Cli,
+        is_oracle_stale_revert, pamm_venue, should_fetch_block_by_number, Cli, TychoState,
     };
 
     #[rstest]
@@ -2215,18 +2220,11 @@ mod tests {
         assert!(!is_oracle_stale_revert(pamm, reason));
     }
 
-    #[rstest]
-    #[case::interval_one_selects_every_block(1, 41513952, true)]
-    #[case::interval_one_selects_multiples_too(1, 41513950, true)]
-    #[case::multiple_of_interval(10, 41513950, true)]
-    #[case::not_a_multiple(10, 41513952, false)]
-    #[case::block_zero(10, 0, true)]
-    fn sampling_selects_multiples_of_interval(
-        #[case] interval: u64,
-        #[case] block: u64,
-        #[case] expected: bool,
-    ) {
-        assert_eq!(is_sampled_block(block, interval), expected);
+    #[test]
+    fn update_sequence_starts_at_one_and_increments() {
+        let mut state = TychoState::default();
+        assert_eq!(state.next_update_seq(), 1);
+        assert_eq!(state.next_update_seq(), 2);
     }
 
     #[test]

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -187,18 +187,17 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     partial_blocks: bool,
 
-    /// Run the protocol-stream test pipeline only on blocks whose number is a multiple of this
-    /// value. 1 tests every block (current behavior). Use a higher value on fast chains (e.g.
-    /// Robinhood) where the harness cannot keep up with the head, or with --partial-blocks to
-    /// cap RPC usage (e.g. Base flashblocks). With --partial-blocks, every partial update of a
-    /// sampled block is tested (bursty by design) and blocks are still fetched via the
-    /// pending/latest polling path. State from every block is ingested either way.
+    /// Run the protocol-stream test pipeline on every Nth protocol update. 1 tests every update.
+    /// Use a higher value on fast chains where the harness cannot keep up with the head, or with
+    /// --partial-blocks to cap the RPC rate: one update arrives per flashblock, so the tested
+    /// updates spread evenly in time. State from every update is ingested either way.
     #[arg(
         long,
+        visible_alias = "test-every-n-blocks",
         default_value_t = 1,
         value_parser = clap::value_parser!(u64).range(1..)
     )]
-    test_every_n_blocks: u64,
+    test_every_n_updates: u64,
 
     /// Seconds without a protocol update before marking all known protocols as stale in metrics.
     /// 0 disables the watchdog.
@@ -1023,7 +1022,7 @@ async fn process_update(
 
             let update_block_number = update.update.block_number_or_timestamp;
 
-            if !update_seq.is_multiple_of(cli.test_every_n_blocks) {
+            if !update_seq.is_multiple_of(cli.test_every_n_updates) {
                 metrics::record_protocol_update_sampled_out();
                 return Ok(());
             }
@@ -1031,7 +1030,7 @@ async fn process_update(
             let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
             let by_number =
-                should_fetch_block_by_number(cli.test_every_n_blocks, cli.partial_blocks);
+                should_fetch_block_by_number(cli.test_every_n_updates, cli.partial_blocks);
 
             let block = if by_number {
                 // On fast chains the head is expected to be past the update, so fetch the target
@@ -2233,19 +2232,32 @@ mod tests {
     }
 
     #[test]
-    fn test_every_n_blocks_works_with_partial_blocks() {
-        let cli = Cli::try_parse_from([
+    fn test_every_n_updates_accepts_partial_blocks() {
+        Cli::try_parse_from([
             "tycho-integration-test",
             "--tycho-url",
             "localhost:4242",
             "--rpc-url",
             "http://localhost:8545",
             "--partial-blocks",
+            "--test-every-n-updates",
+            "10",
+        ])
+        .expect("--test-every-n-updates must be accepted alongside --partial-blocks");
+    }
+
+    #[test]
+    fn test_every_n_blocks_alias_sets_test_every_n_updates() {
+        let cli = Cli::try_parse_from([
+            "tycho-integration-test",
+            "--tycho-url",
+            "localhost:4242",
+            "--rpc-url",
+            "http://localhost:8545",
             "--test-every-n-blocks",
             "10",
         ])
-        .expect("--test-every-n-blocks must be accepted alongside --partial-blocks");
-        assert!(cli.partial_blocks);
-        assert_eq!(cli.test_every_n_blocks, 10);
+        .expect("--test-every-n-blocks must stay accepted as an alias");
+        assert_eq!(cli.test_every_n_updates, 10);
     }
 }

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1019,10 +1019,12 @@ async fn process_update(
 
             let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
-            let block = if cli.test_every_n_blocks > 1 {
-                // Sampled mode: on fast chains the head is expected to be past the update, so the
-                // target block is fetched by number instead of racing the head. clap rejects
-                // --partial-blocks in this mode, so the block is always full.
+            let block = if fetch_sampled_block_by_number(cli.test_every_n_blocks, cli.partial_blocks)
+            {
+                // Sampled full-block mode: on fast chains the head is expected to be past the
+                // update, so the target block is fetched by number instead of racing the head.
+                // Sampled runs with --partial-blocks never take this path — a flashblock's
+                // pending state cannot be fetched by number — and use the polling path below.
                 match await_target_block(
                     &rpc_tools,
                     update_block_number,
@@ -2030,6 +2032,14 @@ fn is_sampled_block(block_number: u64, interval: u64) -> bool {
     block_number.is_multiple_of(interval)
 }
 
+/// True when a sampled update's target block should be fetched by number (sampled full-block
+/// mode, e.g. Robinhood where the head races past the update). With --partial-blocks, sampling
+/// only gates WHICH updates are tested; block fetching stays on the pending/latest polling path
+/// because a flashblock's pending state cannot be fetched by number after the fact.
+fn fetch_sampled_block_by_number(test_every_n_blocks: u64, partial_blocks: bool) -> bool {
+    test_every_n_blocks > 1 && !partial_blocks
+}
+
 /// Selector of the priority-update-registry's `StaleUpdate()` error, the freshness guard of the
 /// registry-priced pAMMs (FermiSwap, Kipseli, Bebop, TaurusFi).
 const STALE_UPDATE_SELECTOR: &str = "666a2814";
@@ -2158,7 +2168,9 @@ mod tests {
     use clap::Parser;
     use rstest::rstest;
 
-    use super::{is_oracle_stale_revert, is_sampled_block, pamm_venue, Cli};
+    use super::{
+        fetch_sampled_block_by_number, is_oracle_stale_revert, is_sampled_block, pamm_venue, Cli,
+    };
 
     #[rstest]
     #[case::direct("pricelevelstream:fermiswap", Some("fermiswap"))]
@@ -2214,6 +2226,19 @@ mod tests {
         #[case] expected: bool,
     ) {
         assert_eq!(is_sampled_block(block, interval), expected);
+    }
+
+    #[rstest]
+    #[case::sampled_full_block_mode(10, false, true)]
+    #[case::sampled_with_partial_blocks_polls(10, true, false)]
+    #[case::unsampled_polls(1, false, false)]
+    #[case::unsampled_with_partial_blocks_polls(1, true, false)]
+    fn sampled_fetch_by_number_only_without_partial_blocks(
+        #[case] test_every_n_blocks: u64,
+        #[case] partial_blocks: bool,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(fetch_sampled_block_by_number(test_every_n_blocks, partial_blocks), expected);
     }
 
     #[test]

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -189,13 +189,14 @@ struct Cli {
 
     /// Run the protocol-stream test pipeline only on blocks whose number is a multiple of this
     /// value. 1 tests every block (current behavior). Use a higher value on fast chains (e.g.
-    /// Robinhood) where the harness cannot keep up with the head. State from every block is
-    /// still ingested. Incompatible with --partial-blocks.
+    /// Robinhood) where the harness cannot keep up with the head, or with --partial-blocks to
+    /// cap RPC usage (e.g. Base flashblocks). With --partial-blocks, every partial update of a
+    /// sampled block is tested (bursty by design) and blocks are still fetched via the
+    /// pending/latest polling path. State from every block is ingested either way.
     #[arg(
         long,
         default_value_t = 1,
-        value_parser = clap::value_parser!(u64).range(1..),
-        conflicts_with = "partial_blocks"
+        value_parser = clap::value_parser!(u64).range(1..)
     )]
     test_every_n_blocks: u64,
 
@@ -2242,8 +2243,8 @@ mod tests {
     }
 
     #[test]
-    fn test_every_n_blocks_conflicts_with_partial_blocks() {
-        let result = Cli::try_parse_from([
+    fn test_every_n_blocks_works_with_partial_blocks() {
+        let cli = Cli::try_parse_from([
             "tycho-integration-test",
             "--tycho-url",
             "localhost:4242",
@@ -2252,7 +2253,9 @@ mod tests {
             "--partial-blocks",
             "--test-every-n-blocks",
             "10",
-        ]);
-        assert!(result.is_err());
+        ])
+        .expect("--test-every-n-blocks must be accepted alongside --partial-blocks");
+        assert!(cli.partial_blocks);
+        assert_eq!(cli.test_every_n_blocks, 10);
     }
 }

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -292,7 +292,7 @@ pub fn record_protocol_update_skipped() {
     counter!("tycho_integration_protocol_updates_skipped_total").increment(1);
 }
 
-/// Record a protocol update whose block was not selected by `--test-every-n-blocks` sampling.
+/// Record a protocol update not selected by `--test-every-n-updates` sampling.
 ///
 /// Deliberately separate from `tycho_integration_protocol_updates_skipped_total`: skipped means
 /// the harness wanted to test the block but could not; sampled-out is a configured decision.

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -230,10 +230,11 @@ pub fn record_protocol_pool_count(protocol: &str, count: usize) {
     .set(count as f64);
 }
 
-/// Record that an update was skipped because the RPC block was ahead of the update block.
+/// Record that an update was skipped because the RPC did not serve its block: the RPC was
+/// already ahead of the update block, or never reached it within the poll attempts.
 ///
 /// The protocol's `SynchronizerState` may report Ready in this case — the lag is only
-/// observable by comparing the update block against the RPC's latest block.
+/// observable by comparing the update block against the RPC's block.
 pub fn record_protocol_sync_state_skipped(protocol: &str) {
     gauge!(
         "tycho_integration_protocol_sync_state",


### PR DESCRIPTION
## Problem

On 2026-08-28 the three Base integration-test runners exhausted the Chainstack RPC plan (`-32005 RPS limit`). Since then every trace call fails, counts as a revert, and "Execution success rate low" fires for every Base protocol. With `--partial-blocks` a runner runs ~120–200 simulations per second.

## Root cause

`--test-every-n-blocks` caps the test rate, but clap rejected it with `--partial-blocks`: sampled mode fetched the target block by number, and a flashblock's pending state cannot be fetched by number.

## Fix

`fetch_sampled_block_by_number` picks the fetch path. Sampled runs without `--partial-blocks` (Robinhood) keep fetch-by-number. With `--partial-blocks` the runner keeps the pending/latest polling path, so sampling only gates which updates are tested. The clap conflict is removed.

## Notes for reviewers

Sampling is by block number, so every partial update of a sampled block is tested. That is bursty by design and stays representative of flashblock execution. Default `--test-every-n-blocks 1` is unchanged.

## Follow-ups

- Roll out on Base: propeller-heads/helm-configuration#1014 (dev), then prod.
- RPC transport errors still count as reverts.
