### PR TITLE
fix(router-trades): imply the price of the side that did not value a trade

### DIFF
--- a/crates/tycho-execution/substreams/README.md
+++ b/crates/tycho-execution/substreams/README.md
@@ -52,9 +52,11 @@ column was not merely mislabelled there but wrong.
 `pricing/price_trades.sql` values a trade from one side only, preferring a side that holds a
 pinned token (lowest `priority` first: stablecoins, then the native token and its wrapper, then
 BTC wrappers) and otherwise any side Tycho happens to price. The unit price of the token on the
-other side is then implied from the trade itself. That is what gives the long tail a price at all:
-Tycho prices 7852 tokens on ethereum but only 29 on unichain and 126 on arbitrum, while nearly
-every trade has a stablecoin, WETH or the native token on one side.
+other side is always implied from the trade itself, even when Tycho prices that token too. That is
+what gives the long tail a price at all — Tycho prices 7852 tokens on ethereum but only 29 on
+unichain and 126 on arbitrum — and it keeps a row consistent, so `price x amount` equals
+`volume_usd` on both sides. A Tycho price there would be a price of today on a trade that may be
+a year old.
 
 Pinning is by address, never by symbol. Tycho holds many tokens with a copied symbol — base has
 about 40 `cbBTC` rows and ethereum a second 18-decimal `USDC` — and their prices are nonsense.
@@ -67,6 +69,14 @@ A stablecoin is worth 1 USD whenever the trade happened, so a stable-anchored tr
 any age and a backfill can be priced correctly. Every other basis would stamp today's price on an
 old trade, so those are limited to trades younger than `MAX_AGE`. `price_source` records the basis
 as `<in|out>_<stable|preferred|tycho>`; filter on it before summing `volume_usd`.
+
+The pricer polls: it runs a pass over every chain each `INTERVAL` seconds (60 in dev), so a new
+trade is valued about a minute after the sink writes it. Nothing prices a row on insert. A trade
+stays eligible while `priced_at IS NULL`, so a pass that is skipped costs nothing — with one
+exception: a trade that needs a non-stable basis is only eligible for `MAX_AGE` after its block
+time, so a pricer that is down longer than that leaves those rows unpriced for good. Re-running
+the values later is possible with `pricing/reprice.sql`, which offers priced rows to the logic
+again.
 
 The trades live in their own database (all chains in one table). Each chain has its own Tycho
 database, reached through `postgres_fdw`: one server and one `tycho_<chain>` schema per chain,

--- a/crates/tycho-execution/substreams/pricing/price_trades.sql
+++ b/crates/tycho-execution/substreams/pricing/price_trades.sql
@@ -134,15 +134,18 @@ final AS (
            c.volume_usd::double precision AS volume_usd,
            c.in_decimals,
            c.out_decimals,
-           -- The valued side keeps its own unit price; the other side is implied by this trade.
-           COALESCE(
-               c.in_unit,
-               c.volume_usd / (NULLIF(c.amount_in, 0) / power(10::numeric, c.in_decimals))
-           )::double precision AS price_in_usd,
-           COALESCE(
-               c.out_unit,
-               c.volume_usd / (NULLIF(c.amount_out, 0) / power(10::numeric, c.out_decimals))
-           )::double precision AS price_out_usd,
+           -- The side that valued the trade keeps its own unit price. The other side is always
+           -- implied from this trade, never taken from Tycho, for two reasons: Tycho holds one
+           -- current price and this trade may be a year old, and an implied price keeps the row
+           -- consistent, so price x amount equals volume_usd on both sides.
+           (CASE
+               WHEN c.side = 'in' THEN c.in_unit
+               ELSE c.volume_usd / (NULLIF(c.amount_in, 0) / power(10::numeric, c.in_decimals))
+           END)::double precision AS price_in_usd,
+           (CASE
+               WHEN c.side = 'out' THEN c.out_unit
+               ELSE c.volume_usd / (NULLIF(c.amount_out, 0) / power(10::numeric, c.out_decimals))
+           END)::double precision AS price_out_usd,
            c.side || '_' || CASE
                WHEN c.on_stable    THEN 'stable'
                WHEN c.on_preferred THEN 'preferred'

--- a/crates/tycho-execution/substreams/pricing/reprice.sql
+++ b/crates/tycho-execution/substreams/pricing/reprice.sql
@@ -1,0 +1,7 @@
+-- Offers every priced trade to the pricing logic again.
+--
+-- Run this by hand after a change to price_trades.sql that alters values already written. It is
+-- deliberately not part of the pricer start-up: a restart must not re-price the whole table.
+--
+--   psql "$DSN" -f pricing/reprice.sql
+UPDATE trades SET priced_at = NULL WHERE priced_at IS NOT NULL;

--- a/crates/tycho-execution/substreams/pricing/test_assertions.sql
+++ b/crates/tycho-execution/substreams/pricing/test_assertions.sql
@@ -41,9 +41,14 @@ BEGIN
         RAISE EXCEPTION 'priority between two preferred sides wrong: % %',
             v.volume_usd, v.price_source;
     END IF;
-    -- The in token is preferred and keeps its own price rather than the implied one.
-    IF v.price_in_usd IS DISTINCT FROM 4000.0 THEN
-        RAISE EXCEPTION 'preferred in token lost its own unit price: %', v.price_in_usd;
+    -- Tycho prices the in token at 4000, but it did not value the trade, so it takes the price
+    -- this trade implies: 3000 USD for the 1 token that went in.
+    IF v.price_in_usd IS DISTINCT FROM 3000.0 THEN
+        RAISE EXCEPTION 'the side that did not value the trade must take the implied price, got %',
+            v.price_in_usd;
+    END IF;
+    IF v.price_out_usd IS DISTINCT FROM 1.0 THEN
+        RAISE EXCEPTION 'the valued side must keep its own unit price, got %', v.price_out_usd;
     END IF;
 
     -- The native sentinel is one native token.
@@ -62,6 +67,29 @@ BEGIN
     SELECT * INTO v FROM trades WHERE id = 'base-preferred';
     IF v.volume_usd IS DISTINCT FROM 2000.0 OR v.price_source IS DISTINCT FROM 'out_preferred' THEN
         RAISE EXCEPTION 'base preferred pricing wrong: % %', v.volume_usd, v.price_source;
+    END IF;
+
+    -- Every priced row must be internally consistent: the unit price of a side times its amount
+    -- is the volume. This is what an implied price on the non-valued side buys, and it breaks as
+    -- soon as a current Tycho price is stamped on one side of an old trade.
+    IF EXISTS (
+        SELECT 1 FROM trades
+        WHERE volume_usd > 0 AND amount_in > 0 AND amount_out > 0
+          AND decimals_in IS NOT NULL AND decimals_out IS NOT NULL
+          AND (abs(price_in_usd * (amount_in / power(10::numeric, decimals_in)) - volume_usd)
+                   / volume_usd > 0.0001
+            OR abs(price_out_usd * (amount_out / power(10::numeric, decimals_out)) - volume_usd)
+                   / volume_usd > 0.0001)
+    ) THEN
+        RAISE EXCEPTION 'a priced trade is not internally consistent: %', (
+            SELECT string_agg(id, ', ') FROM trades
+            WHERE volume_usd > 0 AND amount_in > 0 AND amount_out > 0
+              AND decimals_in IS NOT NULL AND decimals_out IS NOT NULL
+              AND (abs(price_in_usd * (amount_in / power(10::numeric, decimals_in)) - volume_usd)
+                       / volume_usd > 0.0001
+                OR abs(price_out_usd * (amount_out / power(10::numeric, decimals_out)) - volume_usd)
+                       / volume_usd > 0.0001)
+        );
     END IF;
 
     IF EXISTS (


### PR DESCRIPTION
## Problem

The pricer values a trade from one trusted side, then gave the *other* side its own current Tycho price whenever Tycho had one. Tycho keeps one current price per token and no history, so a backfilled trade got today's price on that side.

Measured on the live dev data, for trades valued by a stablecoin on the in side (`price_out_usd × amount_out ÷ volume_usd`, a ratio that is decimals-independent):

| trade age | n | p05 | median | p95 |
|---|---|---|---|---|
| fresh (<2h) | 65 | 0.996 | **1.000** | 1.015 |
| backfill | 54,056 | 0.525 | **1.095** | 1.435 |

Fresh rows agree to 0.1%, so the arithmetic was right and trade age was the whole cause. Worst chain was base at a 0.590 median, its data being about a year old. The rows also disagreed with themselves: the two sides implied two different volumes.

## Change

The side that valued the trade keeps its own unit price; the other side always takes the price this trade implies — not just when Tycho lacks a price for it. That is time-correct by construction and makes each row consistent, so `price × amount = volume_usd` on both sides.

`volume_usd` is unaffected. It always came from the trusted side, and on live data the ratio between `volume_usd` and a stablecoin side's own amount is 1.0000–1.0003 on all five chains with data, polygon included.

The age gate was already correct and is unchanged: a trade older than `MAX_AGE` is only ever priced through a stablecoin, whose USD value does not move. The 14 non-stable rows now older than two hours were priced while they were still fresh.

## Tests

- New assertion: for every priced trade, each side's unit price times its amount must equal `volume_usd` within 0.01%.
- The two-preferred-sides fixture changes expectation from 4000 (Tycho's price for the in token) to 3000 (what the trade implies) — the direct test of this fix.
- `scripts/test_pricing.sh --outage-check` passes.
- Mutation check: restoring the old oracle-first behaviour fails the suite with exit 3 and `the side that did not value the trade must take the implied price, got 4000`.

## Deploying

`pricing/reprice.sql` offers already-priced rows to the logic again; run it once after this lands, since the pricer's own migration deliberately skips rows that already carry a `price_source`. It is not part of container start-up, because a restart must not re-price the whole table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
