### PR TITLE
docs: sync codebase and per-crate claude docs with current code

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -1,4 +1,4 @@
-<!-- docs-synced-at: 2342f18bda260cfaf2d403d8fdc079d56d7ea476 -->
+<!-- docs-synced-at: 39b44a1b29eeb5fc1b6a8f5da0c9684fa78b39d6 -->
 # Tycho Codebase Guide
 
 Low-latency, reorg-aware indexer that streams DEX liquidity state from on-chain data to consumers.
@@ -26,7 +26,8 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
 
 | Crate | Description |
 |---|---|
-| [`tycho-common`](../crates/tycho-common/CLAUDE.md) | Domain types (`Chain`, `Block`, `ProtocolComponent`, `Token`), DTOs, async gateway/extraction traits, simulation abstractions (`SwapQuoter`) |
+| [`tycho-common`](../crates/tycho-common/CLAUDE.md) | Domain types (`Chain`, `Block`, `ProtocolComponent`, `Token`), DTOs, async gateway/extraction traits, simulation abstractions (`SwapQuoter`), custom-chain registry (`models/chain_config.rs`) |
+| `tycho-protobuf` | Substreams protobuf bindings (`pb/`) plus the `TryFromMessage` conversions that decode them into `tycho-common` models; consumed by `tycho-indexer` |
 | `tycho` | Meta-crate re-exporting a compatible, versioned set of ecosystem crates for downstream consumers |
 
 **Features on `tycho-common`**: `diesel` (Diesel derives), `test-utils` (mockall mocks).
@@ -37,15 +38,16 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
 |---|---|
 | [`tycho-indexer/extractor`](../crates/tycho-indexer/CLAUDE.md) | `ProtocolExtractor` processes Substreams messages, `ReorgBuffer` handles finality, `ProtocolMemoryCache` for in-process state, DCI plugin for VM tracing |
 | [`tycho-indexer/services`](../crates/tycho-indexer/CLAUDE.md) | HTTP RPC endpoints, WebSocket broadcaster, `PendingDeltasBuffer` for RPC consistency, access control, plan restrictions, compression |
-| [`tycho-ethereum`](../crates/tycho-ethereum/CLAUDE.md) | Ethereum RPC client (alloy), `AccountExtractor`, `TokenPreProcessor`, `TokenAnalyzer`, `EntryPointTracer` |
+| [`tycho-ethereum`](../crates/tycho-ethereum/CLAUDE.md) | Ethereum RPC client (alloy), `AccountExtractor`, `TokenPreProcessor`, `TokenAnalyzer`, `EntryPointTracer`, `BalanceSlotDetector`/`AllowanceSlotDetector`, `FeePriceGetter` |
 | [`tycho-storage`](../crates/tycho-storage/CLAUDE.md) | Postgres backend (Diesel): `CachedGateway` (buffered writes), `DirectGateway` (testing), temporal versioning, FK-safe write ordering |
 
 ### Simulation & Execution
 
 | Crate | Description |
 |---|---|
-| `tycho-simulation` | DEX swap simulation library: protocol-specific state machines (`ProtocolSim`) for 20+ DEXs; `evm` module for EVM storage-based protocols, `protocol` module for custom implementations, `rfq` for request-for-quote protocols, `price_level_stream` for the Titan pAMM price level stream |
+| `tycho-simulation` | DEX swap simulation library: protocol-specific state machines (`ProtocolSim`) for 20+ DEXs; all protocol implementations live under `evm/protocol/`, `rfq` for request-for-quote protocols, `price_level_stream` for the Titan pAMM price level stream |
 | `tycho-execution` | Swap encoding and execution: Solidity TychoRouterV3 contract + Rust encoding library; multi-hop swaps with fee-taking, vault-based accounting, delegatecall executor dispatch |
+| `tycho-execution/model` (`tycho-router-model`) | Rust security model of the caller-controlled executors, used to reason about router invariants |
 
 ### Consumer SDK
 
@@ -75,7 +77,8 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
 ### Ingestion
 
 1. Substreams gRPC delivers `BlockScopedData` (protobuf) to `ProtocolExtractor`
-2. `ProtocolExtractor` deserializes into `BlockChanges` (tx-level state/balance/token deltas)
+2. `ProtocolExtractor` deserializes into `BlockChanges` (tx-level state/balance/token deltas) via
+   `tycho-protobuf`'s `TryFromMessage` conversions
    - `PartialBlockBuffer` accumulates sub-block messages until full-block signal arrives
    - `TokenPreProcessor` fetches metadata (symbol, decimals) via Ethereum RPC for unknown tokens
 3. `BlockChanges` inserted into `ReorgBuffer` (one per `ProtocolExtractor`)
@@ -83,11 +86,15 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
    - Drain to DB when `count_blocks_before(finalized_block_height) >= commit_batch_size` — only finalized blocks ever reach DB
 4. Drained blocks: `BlockChanges` → `BlockAggregatedChanges` (merge all tx-level deltas into one state per component/account)
 5. DB write via `CachedGateway` → Postgres (upsert blocks, tokens, components, state, balances); sets `db_committed_block_height` on outgoing message
-6. Broadcast `BlockAggregatedChanges` on internal channel (all blocks, including pending/non-committed)
+6. Broadcast a `DeltaCommand` on the internal channel — `Block(BlockAggregatedChanges)` for all
+   blocks (including pending/non-committed), or `ExtractorRestarted` when the supervisor rebuilt
+   the extractor
 
 ### Server
 
-7. WebSocket subscribers (`services/ws.rs`) receive broadcast directly; revert flag signals chain reorg
+7. WebSocket subscribers (`services/ws.rs`) receive broadcast directly; revert flag signals chain
+   reorg. On `ExtractorRestarted`, `ws.rs` sends `Response::SubscriptionEnded` and `PendingDeltas`
+   resets that extractor's buffer
 8. `PendingDeltasBuffer` (`services/deltas_buffer.rs`) receives broadcast
    - Inserts every full block (partial blocks skipped)
    - Auto-drains blocks ≤ `db_committed_block_height` (already in DB, no longer "pending")
@@ -97,10 +104,12 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
 
 9. `StateSynchronizer` (one per extractor subscription):
    - Subscribes to WebSocket stream via `WsDeltasClient`
-   - On first message: fetches HTTP snapshot via `HttpRPCClient` at that block height
-   - Buffers WebSocket deltas received before snapshot arrives; applies them on top to catch up
+   - Discards WebSocket messages that arrive before the sync loop starts, then fetches the HTTP
+     snapshot via `HttpRPCClient` **synchronously** at the first message's block height
+   - Components discovered later are snapshotted in background tasks and their deltas buffered
+     until the snapshot lands, so the delta loop never blocks on RPC
 10. `BlockSynchronizer` (across all extractors):
-    - Tracks state per synchronizer: `Ready` / `Delayed` / `Stale`
+    - Tracks state per synchronizer: `Started` / `Ready` / `Delayed` / `Stale` / `Advanced` / `Ended`
     - Delayed synchronizers consume buffered messages to catch up
     - When all synchronizers reach the same block: emits `FeedMessage` (unified view of all protocol state at that block) to consumer
 
@@ -110,17 +119,20 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
     - Custom protocols: update decoded state fields directly
     - VM protocols: patch EVM storage slots, code, balances in a local `SimulationDB`
 12. Consumer queries `ProtocolSim::get_amount_out` / `spot_price` to price swap routes
-13. `tycho-execution` encodes a chosen route into calldata for `TychoRouterV3`
+13. `tycho-execution` encodes a chosen route (`Solution`) into an `EncodedSolution` for `TychoRouterV3`
     - Selects the appropriate executor contract for each DEX hop
-    - Constructs `SwapSequence` with per-hop amounts, tokens, and executor addresses
-14. Consumer submits the encoded transaction to the chain via `TychoRouterV3.swap()`
+    - Batches consecutive hops on the same groupable protocol into `SwapGroup`s
+14. Consumer submits the encoded transaction to one of the router's 9 entry points —
+    `{single,sequential,split}Swap` × `{plain, Permit2, UsingVault}`
 
 ## Key Architectural Patterns
 
 ### Extractor-per-protocol
 
-Each protocol runs as a separate `ExtractorRunner` tokio task. Config in `extractors.yaml`.
-Extractors are stateful: they track components, state history, and Substreams cursor.
+Each protocol is owned by an `ExtractorSupervisor` tokio task, which builds an extractor +
+`ExtractorRunner` via `ExtractorFactory` and rebuilds them with exponential backoff on failure.
+Config in `extractors.yaml`. Extractors are stateful: they track components, state history, and
+Substreams cursor.
 
 ### Implementation types: Custom, VM, and Hybrid
 
@@ -128,10 +140,12 @@ The `ImplementationType` enum has two variants (`Custom`, `Vm`), but three patte
 
 - **Custom**: State fully described by Substreams output (reserves, fees). Uniswap V2/V3.
 - **VM**: Requires full contract storage for simulation. Tracks code, storage slots, balances.
-  Balancer V2, Curve. Often paired with DCI for dynamic contract discovery.
+  Balancer V2, Maverick V2. Often paired with DCI for dynamic contract discovery.
 - **Hybrid**: Combines explicit protocol state attributes (from Substreams) with contract storage
   tracking. Simulation uses both: decoded state for known fields, raw storage for on-chain VM
-  execution. Runtime pattern, not a separate enum variant.
+  execution. Runtime pattern, not a separate enum variant. Fluid V1, Balancer V3, Curve. Note that
+  Balancer V3 and Curve keep VM-shaped indexing (`vm:` component keys, full contract storage) —
+  only their quote path is native Rust.
 
 ### ReorgBuffer + finality
 
@@ -142,7 +156,12 @@ blocks are served to RPC via `PendingDeltasBuffer`.
 ### Temporal versioning
 
 Every mutable Postgres entity carries `valid_from`/`valid_to`. `apply_versioning()` sets
-`valid_to` on the previous row when a new version is inserted. Historical rows are never mutated.
+`valid_to` on the previous row when a new version is inserted; protocol state, component balances
+and contract storage go through `apply_partitioned_versioning()` instead (partitioned tables).
+Historical rows are never mutated, but history is bounded: pg_cron jobs drop expired partitions
+(`drop_expired_partitions()`) and prune orphaned transactions
+(`cleanup_orphaned_transactions()`), both reading the horizon from the
+`partition_retention_config` table (default 1 month).
 
 ### Dual runtime
 
@@ -150,6 +169,16 @@ The `index` command runs two tokio runtimes: extraction (CPU-bound) and server/g
 Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREADS` (default 3).
 
 ## Configuration
+
+### Chains
+
+Built-in `Chain` variants cover the chains Tycho officially supports. A self-hosted instance can
+add its own via the custom-chain registry (`tycho-common/src/models/chain_config.rs`): a
+`chains.yaml` file (`--chain-config` / `TYCHO_CHAINS_CONFIG`, default `./chains.yaml`) is loaded
+into a process-global `ChainConfigRegistry` and each entry becomes a `Chain::Custom(CustomChainId)`
+carrying its quote tokens and TVL thresholds. **The registry must be installed before any chain
+name is parsed** — `Chain::from_str` is registry-backed and fallible, so an unresolvable name is an
+error rather than a silent custom chain (`Chain::builtin_from_str` skips the registry).
 
 ### Environment variables
 
@@ -159,8 +188,14 @@ Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREAD
 | `RPC_URL` | Ethereum JSON-RPC endpoint |
 | `AUTH_API_KEY` | API key for RPC access control |
 | `SUBSTREAMS_API_TOKEN` | Substreams gRPC auth |
+| `TYCHO_CHAINS_CONFIG` | Custom-chain registry YAML (default `./chains.yaml`) |
+| `EXTRACTORS_CONFIG` | Extractor config YAML (default `./extractors.yaml`) |
+| `RETENTION_HORIZON` | Datetime before which data is not kept |
 | `EXTRACTION_WORKER_THREADS` | Extraction runtime threads (default 2) |
 | `MAIN_WORKER_THREADS` | Server runtime threads (default 3) |
+| `RPC_MAX_RETRIES` / `RPC_INITIAL_BACKOFF_MS` / `RPC_MAX_BACKOFF_MS` | RPC retry policy |
+| `RPC_MAX_BATCH_SIZE` / `RPC_STORAGE_SLOT_MAX_BATCH_SIZE` | RPC request batching limits |
+| `TYCHO_S3_BUCKET` | S3 bucket the Substreams spkg packages are fetched from |
 | `OTLP_EXPORTER_ENDPOINT` | OpenTelemetry trace exporter |
 | `RUST_LOG` | Tracing filter (e.g. `tycho_indexer=debug`) |
 
@@ -168,10 +203,10 @@ Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREAD
 
 | Command | Purpose |
 |---|---|
-| `index` | Run all extractors from `extractors.yaml` + HTTP/WS server |
-| `run` | Run a single extractor (testing / debugging) |
+| `index` | Run all extractors from `extractors.yaml` + HTTP/WS server; `--chain-config` for custom chains |
+| `run` | Run a single extractor (testing / debugging); `--chain-config` for custom chains |
 | `analyze-tokens` | Token quality analysis cron job; accepts `--settlement-contract <ADDRESS>` (default: CoW Swap settlement `0xc9f2e6ea1637E499406986ac50ddC92401ce1f58`) and `--recovery-lookback-days <N>` (default 1: re-check quality-5 tokens traded within N days; Bad keeps 5) |
-| `rpc` | HTTP RPC server only (no extractors) |
+| `rpc` | HTTP RPC server only (no extractors); takes `--chain` and `--chain-config` |
 
 ### Feature flags
 
@@ -179,15 +214,26 @@ Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREAD
 |---|---|---|
 | `tycho-common` | `diesel` | Diesel derives on `Bytes` and model types |
 | `tycho-common` | `test-utils` | `mockall` auto-mocks on trait abstractions |
+| `tycho-indexer` | `jemalloc` (default) | jemalloc allocator + the `GET /debug/pprof/heap` route |
+| `tycho-execution` | `evm` (default) | alloy + reqwest encoding support |
+| `tycho-execution` | `fork-tests`, `test-utils` | Mainnet-fork tests; test helpers |
+| `tycho-simulation` | `evm`, `rfq`, `price-level-stream` (all default) | See `tycho-simulation/CLAUDE.md` |
+| `tycho-simulation` | `network_tests` | Gates tests needing live network access |
+| `tycho` | `evm` (default), `rfq` | Which ecosystem crates the meta-crate re-exports |
 
-No other crate-level features. Runtime behavior controlled via CLI args, env vars, and YAML config.
+Everything else is controlled via CLI args, env vars, and YAML config.
 
 ## Testing
 
-- `cargo test` for standard tests
+- `cargo nextest run --workspace --all-features --locked` — CI's test runner
 - DB serial tests: name must include `serial_db` (nextest test group, sequential)
 - DB harness: `run_against_db` (tycho-storage) manages setup/teardown
 - Archive RPC tests: `#[ignore]`-d
-- Lint: `cargo clippy --workspace --lib --all-targets --all-features`
-- Format: `cargo +nightly fmt --check`
+- Lint: `cargo +nightly-2026-06-28 clippy --workspace --all-targets --all-features -- -D warnings`
+- Format: `cargo +nightly-2026-06-28 fmt --all --check`
+- Also gated in CI: `cargo doc --workspace --no-deps --all-features --locked` and
+  `cargo check --workspace --no-default-features --locked`
+
+Exact commands and the nextest filter expressions live in `.github/workflows/ci-rust.yaml`; the
+`run-ci` skill runs them locally.
 

--- a/.claude/skills/run-ci/SKILL.md
+++ b/.claude/skills/run-ci/SKILL.md
@@ -84,12 +84,22 @@ checks run). Otherwise, map changed file patterns to check categories:
 
 | File pattern | Category |
 |---|---|
-| `crates/tycho-*/src/**/*.rs`, `Cargo.toml`, `Cargo.lock` | `rust` |
+| `crates/tycho-*/src/**/*.rs`, `protocols/testing/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml` | `rust` |
 | `crates/tycho-client-py/**` | `python` |
+| `crates/tycho-execution/contracts/**`, `protocols/adapter-integration/evm/**`, `crates/tycho-simulation/token-proxy-contracts/**` | `solidity` |
+| `protocols/substreams/**` | `substreams` |
 | `.github/workflows/**` | `ci` (always run full) |
+
+The `rust` patterns mirror the `changes` job filter in `ci-rust.yaml`; the `solidity` patterns
+mirror `ci-foundry.yaml`; `substreams` mirrors `ci-substreams.yaml`.
 
 If only `python` files changed, skip Rust format/clippy/tests entirely and only run Python checks.
 If only `rust` files changed, skip Python checks. If both changed (or `ci`), run everything.
+
+`solidity` and `substreams` are **not covered by this skill** — it runs the Rust pipeline only.
+When either is in scope, say so in the report and point at the workflow that covers it
+(`ci-foundry.yaml` / `ci-substreams.yaml`, plus `ci-rust-evm.yaml`, `ci-router-trades.yaml`, and
+`security.yaml`), so the user knows what is still unverified.
 
 Report the detected scope before proceeding: `Scope: rust`, `Scope: python`, `Scope: rust + python`,
 or `Scope: full`.
@@ -98,8 +108,12 @@ or `Scope: full`.
 
 Run formatting first because it modifies source files that all subsequent checks depend on.
 
+CI runs `cargo +nightly-2026-06-28 fmt --all --check` (see `ci-rust.yaml` — the pinned nightly is
+the source of truth; if it has moved, use the workflow's value). Locally, write the fixes instead
+of just checking:
+
 ```bash
-cargo +nightly fmt --all
+cargo +nightly-2026-06-28 fmt --all
 ```
 
 Check `git diff --stat -- '*.rs'` and report whether any files were reformatted.
@@ -108,8 +122,11 @@ Check `git diff --stat -- '*.rs'` and report whether any files were reformatted.
 
 Run clippy next. If clippy fails, tests won't compile either, so there's no point running them.
 
+Same pinned nightly as Phase 1, and `-D warnings` — CI fails on any warning, so omitting it hides
+failures:
+
 ```bash
-cargo clippy --workspace --all-targets --all-features
+cargo +nightly-2026-06-28 clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 Report pass/fail. If there are warnings or errors, list them.
@@ -152,6 +169,20 @@ bash .claude/scripts/run-nextest.sh serial-db --include-ignored  # RPC_URL set
 
 Report pass/fail with test count summary. If DB is not available, skip entirely.
 
+#### Docs and no-default-features build (parallel)
+
+Two further CI gates (`ci-rust.yaml`) that neither clippy nor the test runs cover:
+
+```bash
+cargo doc --workspace --no-deps --all-features --locked
+```
+```bash
+cargo check --workspace --no-default-features --locked
+```
+
+Report pass/fail for each. `cargo doc` catches broken intra-doc links; the no-default-features
+check catches code that only compiles with a default feature enabled.
+
 ## Report
 
 After all steps complete, provide a summary table. Combine results from both test runs (unit +
@@ -171,6 +202,8 @@ tests run in the other phase.
 | Format   | pass/fail/skipped | files reformatted or clean           |
 | Clippy   | pass/fail/skipped | warning/error count                  |
 | Tests    | pass/fail/skipped | X passed, Y failed, Z skipped        |
+| Docs     | pass/fail/skipped | `cargo doc` warnings/errors          |
+| No-default-features | pass/fail/skipped | `cargo check` errors      |
 
 If clippy failed, mark tests as "skipped (clippy failed)".
 

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -56,6 +56,8 @@ This repo's documentation lives in two places:
 | `.claude/knowledge/rust.md` | Rust coding conventions for this project |
 | `.claude/knowledge/version_control.md` | Git/PR workflow for this project |
 | `.claude/knowledge/python.md` | Python conventions (tycho-client-py, dto/rpc changes) |
+| `.claude/knowledge/solidity.md` | Solidity / Foundry conventions (contracts, executors) |
+| `.claude/knowledge/gitbook.md` | GitBook conventions for docs under `docs/` |
 
 ### 2. Per-crate `CLAUDE.md` files
 
@@ -102,7 +104,7 @@ it only reports discrepancies.
 > - Compare feature flags table against each crate's `Cargo.toml` `[features]`
 > - Compare "End-to-End Data Flow" diagram against `crates/tycho-indexer/src/extractor/protocol_extractor.rs`,
 >   `crates/tycho-indexer/src/services/`, and `crates/tycho-client/src/feed/`
-> - Compare CLI commands table against `crates/tycho-indexer/src/cli/`
+> - Compare CLI commands table against `crates/tycho-indexer/src/cli.rs`
 > - Compare env vars table against actual usage (search for `env::var` / `std::env`)
 > - Compare testing section against CI config (`.github/workflows/`)
 >
@@ -185,9 +187,9 @@ that hash and HEAD to find changes that demand documentation updates.
 >    - Changed struct/enum definitions (added/removed/renamed fields/variants)
 >    - Changed RPC endpoints in `crates/tycho-indexer/src/services/rpc.rs`
 >    - Changed feature flags in any crate's `Cargo.toml`
->    - Changed CLI commands in `crates/tycho-indexer/src/cli/`
+>    - Changed CLI commands in `crates/tycho-indexer/src/cli.rs`
 >    - Changed data flow or extraction pipeline logic
->    - New DEX integrations added to `crates/tycho-simulation/src/protocol/` or `crates/tycho-execution/src/encoding/`
+>    - New DEX integrations added to `crates/tycho-simulation/src/evm/protocol/` or `crates/tycho-execution/src/encoding/`
 > 4. For each change that affects something documented in `.claude/CODEBASE.md` or any `CLAUDE.md`, report:
 >    - The commit(s) that introduced the change
 >    - Which doc file is affected

--- a/crates/tycho-client/CLAUDE.md
+++ b/crates/tycho-client/CLAUDE.md
@@ -7,9 +7,13 @@ Consumer library implementing the snapshot + deltas pattern for real-time protoc
 ```
 rpc.rs              HTTP snapshot client — fetches protocol state at a block height
 deltas.rs           WebSocket client — streams real-time state deltas
-stream.rs           Builder entry point — wires RPC + WS clients into a TychoStream
+stream.rs           Builder entry point — wires RPC + WS clients into a TychoStream.
+                    build() eagerly loads and validates the chain registry before any network I/O
+client_metadata.rs  X-Tycho-Client-Metadata header (CLIENT_METADATA_HEADER, size caps);
+                    TychoStreamBuilder::add_client_metadata. Server half: indexer services/client_metadata.rs
 feed/
   mod.rs            BlockSynchronizer — aligns N synchronizers by block, emits FeedMessage
+  dto.rs            Consumer-facing feed types: ComponentWithState, Snapshot, StateSyncMessage, FeedMessage
   synchronizer.rs   ProtocolStateSynchronizer — manages snapshot + delta sync for one extractor
   component_tracker.rs  Filters components by TVL threshold or explicit ID list
   block_history.rs  Validates block chain continuity; classifies incoming blocks

--- a/crates/tycho-common/CLAUDE.md
+++ b/crates/tycho-common/CLAUDE.md
@@ -10,8 +10,9 @@ Shared domain types, storage/extraction traits, and simulation abstractions used
 - **`display`** — `DisplayOption` wrapper for tracing logs
 
 ### Domain Models (`models/`)
-- **`mod`** — Type aliases (`Address`, `TxHash`, …) and the `Chain` enum; imported by every other module
-- **`blockchain`** — `Block`, `Transaction`, `BlockAggregatedChanges`; the output type of the indexing pipeline
+- **`mod`** — Type aliases (`Address`, `TxHash`, …) and the `Chain` enum; imported by every other module. `Chain` is `#[non_exhaustive]`: ten built-in variants plus `Custom(CustomChainId)`. `FromStr` is registry-backed and **fallible** — it resolves custom names against `chain_config`; use `Chain::builtin_from_str` to parse only built-ins
+- **`chain_config`** — Custom-chain registry: `ChainConfigRegistry` (`load_default` / `from_yaml_file`) holds `CustomChainConfig` entries (quote tokens, `TvlThresholds` / `TvlThresholdTier`) keyed by `CustomChainId`. `chain_registry()` reads the process-global instance, `init_chain_registry()` installs it. **It must be installed before any chain name is parsed.** This is the mechanism for adding a chain without a code change; see `chains.yaml` / `TYCHO_CHAINS_CONFIG`
+- **`blockchain`** — `Block`, `Transaction`, `BlockChanges`, `TxWithChanges`, `BlockAggregatedChanges` (the output type of the indexing pipeline), plus the pending-block input types `PendingBlock` / `TxInput` / `LogInput`
 - **`contract`** — `Account` / `AccountDelta`; versioned EVM contract state written by tycho-ethereum and persisted by tycho-storage
 - **`protocol`** — `ProtocolComponent` / `ProtocolComponentStateDelta`; DEX/lending pool state alongside `ComponentBalance`
 - **`token`** — `Token` metadata and quality scoring; populated by tycho-ethereum's `TokenAnalyzer`
@@ -21,8 +22,8 @@ Shared domain types, storage/extraction traits, and simulation abstractions used
 - **`dto`** — JSON-serialisable mirrors of `models/` types for HTTP/WebSocket responses; used by tycho-indexer (server) and tycho-client (consumer)
 
 ### Trait Abstractions
-- **`storage`** — Async gateway traits (`ProtocolGateway`, `ContractStateGateway`, …) that tycho-storage implements over Diesel/Postgres
-- **`traits`** — Async extraction traits (`AccountExtractor`, `TokenAnalyzer`, `EntryPointTracer`, …) that tycho-ethereum implements
+- **`storage`** — Async gateway traits that tycho-storage implements over Diesel/Postgres: `ChainGateway`, `ExtractionStateGateway`, `ProtocolGateway`, `EntryPointGateway`, `ContractStateGateway`, and the `Gateway` umbrella trait combining them
+- **`traits`** — Extraction traits: `AccountExtractor`, `TokenAnalyzer`, `TokenOwnerFinding`, `TokenPreProcessor`, `EntryPointTracer`, `BalanceSlotDetector`, `AllowanceSlotDetector`, `FeePriceGetter` (all async, implemented by tycho-ethereum), plus `TxDeltaIndexer` (sync `apply_block` / `generate_deltas`, implemented in tycho-simulation's `evm/pending.rs` for pending-block simulation)
 
 ### Simulation (`simulation/`)
 - **`protocol_sim`** — `ProtocolSim` core trait (quote, price, state transition); implemented by protocol-specific simulators; To be replaced by SwapQuoter trait in the future.

--- a/crates/tycho-ethereum/CLAUDE.md
+++ b/crates/tycho-ethereum/CLAUDE.md
@@ -1,6 +1,6 @@
 # tycho-ethereum
 
-Ethereum-specific implementations of traits defined in `tycho-common`. Consumed exclusively by `tycho-indexer`.
+Ethereum-specific implementations of traits defined in `tycho-common`. Consumed by `tycho-indexer`, `tycho-simulation`, and `tycho-test`.
 
 ## Module Map
 
@@ -27,11 +27,13 @@ services/
        ├─ slot_detector.rs            Detects ERC-20 storage slot layout via trace simulation
        ├─ balance_slot_detector.rs    Locates balance mapping slot
        └─ allowance_slot_detector.rs  Locates allowance mapping slot
+
+test_fixtures.rs        Shared RPC/account fixtures, also consumed by tycho-test
 ```
 
 ## Module Dependencies
 
-All services depend on `rpc/` for RPC calls and on `erc20.rs` for ABI encoding. The entrypoint tracer's slot detectors feed into `account_extractor` when slot layout is unknown.
+All services depend on `rpc/` for RPC calls and on `erc20.rs` for ABI encoding. The slot detectors are consumed by the indexer's `dynamic_contract_indexer/hooks/`, not by `account_extractor`.
 
 ```
 tycho-common traits
@@ -49,4 +51,6 @@ tycho-common traits
 | `token_pre_processor` | `TokenPreProcessor` |
 | `token_analyzer` | `TokenAnalyzer` |
 | `entrypoint_tracer` | `EntryPointTracer` |
+| `entrypoint_tracer/balance_slot_detector` | `BalanceSlotDetector` (`EVMBalanceSlotDetector`) |
+| `entrypoint_tracer/allowance_slot_detector` | `AllowanceSlotDetector` (`EVMAllowanceSlotDetector`) |
 | `rpc` | `FeePriceGetter` (returns `BlockGasPrice` from `gas.rs`) |

--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -51,7 +51,8 @@ Interfaces (`contracts/interfaces/`): `IExecutor` (swap [void],
 getTransferData [returns transferType, receiver, tokenIn, tokenOut, outputToRouter],
 fundsExpectedAddress), `ICallback` (handleCallback, verifyCallback, getCallbackTransferData), `IFeeCalculator` (
 calculateFee [takes FeeInput → FeeRecipient[]], mustOutputThroughRouter [takes clientFeeBps, client → bool],
-getAllClientFees [takes start, count → (address[] clients, CustomFees[] fees)]).
+getAllClientFees [takes start, count → (address[] clients, CustomFees[] fees)]). Also
+`IPropAMM` / `IPropAMMRouter` (the pAMM standard and Titan's fallback router) and `IUniversalRouter`.
 
 ### Vault (`Vault.sol`)
 
@@ -136,9 +137,10 @@ simple: they just call the protocol. All balance tracking, output verification, 
 Dispatcher/TransferManager.
 
 Supported: UniswapV2, UniswapV3, UniswapV4, BalancerV2, BalancerV3, Curve, Ekubo, EkuboV3, Slipstreams, MaverickV2,
-AerodromeV1, LiquidityParty, Bebop (RFQ), Hashflow (RFQ), Liquorice (RFQ), FluidV1, Rocketpool, ERC4626, Etherfi, WETH,
+AerodromeV1, LiquidityParty, BopAMM, FermiSwap, LunarBase, RingSwapV2, Sky, Bebop (RFQ), Hashflow (RFQ),
+Liquorice (RFQ), Metric (RFQ), FluidV1, Rocketpool, ERC4626, Etherfi, NativeWrap (ETH↔WETH and other native wrappers),
 PropAMM (a single generic executor shared by all pAMMs implementing the standard `IPropAMM` interface; the pAMM
-address travels in the swap data).
+address travels in the swap data) and PropAMMFallback (the same liquidity routed via Titan's PropAMMRouter).
 
 ### Executor Flow, Callbacks & Output Verification
 
@@ -151,15 +153,15 @@ amounts and handles fee-on-transfer/rebasing tokens universally.
 
 | Category                   | Executors                                                                                                                                       | `outputToRouter` | Behavior                                                                                         |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|------------------|--------------------------------------------------------------------------------------------------|
-| **Direct-to-receiver**     | UniswapV2, UniswapV3, UniswapV4, BalancerV2, BalancerV3, Ekubo, EkuboV3, Slipstreams, MaverickV2, AerodromeV1, LiquidityParty, ERC4626, FluidV1 | `false`          | Dispatcher measures balance at receiver                                                          |
-| **Output-lands-at-router** | Curve, WETH, Rocketpool, Etherfi, Bebop, Hashflow, Liquorice                                                                                    | `true`           | Dispatcher measures at `address(this)`, then forwards via `_transferOut()` if receiver != router |
+| **Direct-to-receiver**     | UniswapV2, UniswapV3, UniswapV4, BalancerV2, BalancerV3, Ekubo, EkuboV3, Slipstreams, MaverickV2, AerodromeV1, LiquidityParty, ERC4626, FluidV1, BopAMM, FermiSwap, LunarBase, RingSwapV2, Sky, Metric | `false`          | Dispatcher measures balance at receiver                                                          |
+| **Output-lands-at-router** | Curve, NativeWrap, Rocketpool, Etherfi, Bebop, Hashflow, Liquorice                                                                              | `true`           | Dispatcher measures at `address(this)`, then forwards via `_transferOut()` if receiver != router |
 
 **Two input categories**:
 
 **Direct-transfer** (UniswapV2, BalancerV2, Curve): Dispatcher staticcalls `getTransferData()` to get
 the `TransferType`, receiver, tokenIn, tokenOut, and outputToRouter. Performs the transfer, then delegatecalls `swap()`.
 
-**Callback-based** (UniswapV3, UniswapV4, BalancerV3, Ekubo): Also implement `ICallback`. Flow:
+**Callback-based** (UniswapV3, UniswapV4, BalancerV3, Ekubo, EkuboV3, Slipstreams, FluidV1, Metric): Also implement `ICallback`. Flow:
 
 1. `getTransferData()` returns `None` (no pre-swap transfer)
 2. `swap()` calls the protocol pool
@@ -233,16 +235,19 @@ group is PLE-encoded (`[len: u16][data]...`); Ekubo uses concatenation instead (
 | `SplitSwapStrategyEncoder`      | `splitSwap` / `Permit2` / `UsingVault`      | Builds token array [tokenIn, intermediaries, tokenOut], encodes token indices + split percentages (U24) + executor + protocol data |
 
 **Parallel encoding**: `encode_swap_groups` (`strategy_encoders.rs`) and `TychoRouterEncoder::encode_solutions`
-encode groups and solutions in parallel via `map_on_threads` (`evm/utils.rs`), preserving input order.
+spawn threads via `map_on_threads` (`evm/utils.rs`) **only when an encoder in the batch blocks on a quote** —
+`SwapEncoder::blocks_on_quote()` defaults to `false` and is `true` only for the RFQ encoders (Bebop, Hashflow,
+Liquorice, Metric). Otherwise encoding runs serially on the calling thread. Input order is preserved either way.
 
-**Swap grouping** (`evm/group_swaps.rs`): Consecutive swaps on the same groupable protocol (UniswapV4, BalancerV3,
-Ekubo) are batched into a single `SwapGroup` and executed via one delegatecall. The `SingleSwapStrategyEncoder` can also
+**Swap grouping** (`evm/group_swaps.rs`): Consecutive swaps on the same groupable protocol
+(`GROUPABLE_PROTOCOLS` in `evm/constants.rs`: `uniswap_v4`, `uniswap_v4_hooks`, `vm:balancer_v3`,
+`ekubo_v2`, `ekubo_v3`) are batched into a single `SwapGroup` and executed via one delegatecall. The `SingleSwapStrategyEncoder` can also
 encode an entire multi-pool route as a single swap if all hops are on the same groupable protocol.
 
 ### SwapEncoder
 
 **SwapEncoder trait** (`swap_encoder.rs` + `evm/swap_encoder/`): Each protocol
-implements `encode_swap(&Swap, &EncodingContext) -> Vec<u8>`, encoding pool-specific data (pool ID, fee tiers, direction
+implements `encode_swap(&Swap, &EncodingContext) -> Result<Vec<u8>, EncodingError>`, encoding pool-specific data (pool ID, fee tiers, direction
 flags) into packed bytes. Each encoder holds its executor address.
 
 **SwapEncoderRegistry** (`swap_encoder_registry.rs`): Creates encoders by protocol system name. Reads executor addresses
@@ -357,8 +362,9 @@ Features: `evm` (default, enables alloy + reqwest), `fork-tests` (mainnet fork t
 
 ### CI
 
-- **evm-foundry-ci.yml**: Format check + forge test + gas snapshot on PRs and main pushes
-- **slither.yml**: Static analysis
+- **`.github/workflows/ci-foundry.yaml`**: per-project `forge fmt --check` + `forge test` + gas
+  snapshot, a Slither static-analysis job, and a runtime-bytecode-fixtures freshness check
+- **`.github/workflows/ci-router-trades.yaml`**: the `substreams/` router-trades workspace
 
 ## Adding a New Executor
 

--- a/crates/tycho-indexer/CLAUDE.md
+++ b/crates/tycho-indexer/CLAUDE.md
@@ -17,7 +17,7 @@ extractor/
   supervisor.rs             ExtractorSupervisor: restart lifecycle with exponential backoff; owns the subscription map
   factory.rs                ExtractorFactory: builds a fresh extractor + runner per (re)start; extractor config types
   reorg_buffer.rs           ReorgBuffer — finality-aware block queue; chain-reorg purge
-  models.rs                 BlockChanges, BlockAggregatedChanges, TxWithChanges
+  models.rs                 Re-exports the block types (defined in tycho-common's models/blockchain.rs); merge helpers + test fixtures
   protocol_cache.rs         ProtocolMemoryCache — in-process token/component metadata cache
   chain_state.rs            ChainState — tracks current tip and finality horizon
   u256_num.rs               U256 numeric utilities
@@ -47,6 +47,8 @@ services/
   cache.rs                  HTTP response cache
   api_docs.rs               OpenAPI schema generation (utoipa)
   access_control.rs         API-key authentication middleware
+  client_metadata.rs        Parses the X-Tycho-Client-Metadata header into allowlisted Prometheus labels
+  debug.rs                  heap_profile handler behind the `jemalloc` feature
   middleware/
     plan_restrictions.rs    Per-user API limits via X-User-Plan header (plans.yaml)
     compression.rs          Zstd response compression
@@ -64,7 +66,9 @@ extension `E`. It is the single point that turns raw Substreams messages into ty
 
 ### Normal (full-block) path
 
-1. Deserialize `BlockScopedData` → `BlockChanges` (tx-level state/balance deltas).
+1. Deserialize `BlockScopedData` → `BlockChanges` (tx-level state/balance deltas) via
+   `tycho-protobuf`'s `TryFromMessage` conversions; its `DecodeError` converts into
+   `ExtractionError`.
 2. Run post-processor if configured.
 3. Call `E::process_block_update()` (DCI — see below).
 4. Fetch metadata for any new token addresses via `T` (ERC-20 symbol / decimals over RPC).
@@ -185,4 +189,8 @@ All POST under `/{version_prefix}/` (default `/v1/`), except where noted.
 | `/protocol_systems` | List available protocol systems |
 | `/component_tvl` | Component TVL estimates |
 | `/health` | GET — health check |
-| `/ws/` | GET — WebSocket upgrade for delta subscriptions |
+| `/ws` | GET — WebSocket upgrade for delta subscriptions (exact match; `/ws/` 404s) |
+
+Registered outside the version prefix: `GET /docs/{...}` (Swagger UI, schema at
+`/api-docs/openapi.json`) and `GET /debug/pprof/heap` (API-key gated, behind the `jemalloc`
+feature).

--- a/crates/tycho-integration-test/CLAUDE.md
+++ b/crates/tycho-integration-test/CLAUDE.md
@@ -6,13 +6,14 @@ results. Exits after `--max-blocks` blocks, or runs indefinitely.
 
 ## Running
 
-Requires three env vars (can be set in `.claude/settings.local.json`):
+Env vars (can be set in `.claude/settings.local.json`):
 
 | Variable | Purpose |
 |---|---|
-| `TYCHO_URL` | WebSocket endpoint of the Tycho server |
-| `TYCHO_API_KEY` | Auth key (`sampletoken` works against local dev instances) |
-| `RPC_URL` | Ethereum-compatible JSON-RPC endpoint for on-chain validation |
+| `TYCHO_URL` | WebSocket endpoint of the Tycho server (required) |
+| `RPC_URL` | Ethereum-compatible JSON-RPC endpoint for on-chain validation (required) |
+| `TYCHO_API_KEY` | Auth key; defaults to `sampletoken`, which works against local dev instances |
+| `TYCHO_NO_TLS` | Set to `true` to talk plain HTTP/WS (same as `--no-tls`) |
 
 Both the token loader and the protocol stream default to TLS (`https`/`wss`). Pass `--no-tls`
 (or set `TYCHO_NO_TLS=true`) when pointing at a local dev instance served over plain HTTP.
@@ -33,7 +34,8 @@ Key optional flags: `--no-tls`, `--disable-onchain`, `--disable-rfq`,
 
 `--bypass-executor-timelock` writes `executorsActivationTimestamp = 1` for every executor of the
 chain into the execution simulation's state overrides, so an executor that is unapproved or still
-inside its 3-day activation timelock does not make `Dispatcher._validateExecutor` revert. The
+inside its activation timelock (`Dispatcher.DELAY_EXECUTOR_ACTIVATION`, 1 day) does not make
+`Dispatcher._validateExecutor` revert. The
 router keeps its deployed bytecode, and only the read-only simulation call is affected. It cannot
 help an executor that has no bytecode deployed. Off by default so that a missing activation still
 shows up as a failure.
@@ -72,6 +74,9 @@ shows up as a failure.
 - **`statistics.rs`**: `TestStatistics` + `ProtocolStatistics` — per-protocol counters for
   simulation success/failure, execution reverts, slippage, `get_limits` / `get_amount_out` calls
 - **`metrics.rs`**: Prometheus metrics (served on `--metrics-port`, default 9898)
+- **`fee_fetcher.rs`**: One-shot start-up read of the router fee on output from the deployed
+  FeeCalculator, so the test backs the current fee out of the simulated amount instead of
+  hard-coding it
 
 ## What it validates
 

--- a/crates/tycho-simulation/CLAUDE.md
+++ b/crates/tycho-simulation/CLAUDE.md
@@ -5,22 +5,33 @@ for any protocol indexed by Tycho.
 
 ## Key Modules (`src/`)
 
-- **`protocol/`**: Core traits and models — `ProtocolSim`, `ProtocolComponent`, `Update`
+- **`protocol/`**: Consumer-facing models — `ProtocolComponent`, `Update`, and the crate's error
+  types. The `ProtocolSim` trait itself lives in `tycho-common` (`simulation/protocol_sim.rs`)
 - **`evm/simulation.rs`**: `SimulationEngine` — runs EVM transactions via `revm`
 - **`evm/engine_db/`**: Database backends (`SimulationDB` in-memory, `TychoDB` RPC-backed)
-- **`evm/stream.rs`**: Tycho feed integration — decodes live `FeedMessage` state into protocol
-  instances ready for simulation
+- **`evm/decoder.rs`**: `TychoStreamDecoder` — turns feed snapshots into `ProtocolSim` instances.
+  **A new protocol must be registered here** to be decodable
+- **`evm/stream.rs`**: Tycho feed integration — wires the decoder onto a live `FeedMessage` stream
+- **`evm/pending.rs`**: `TxDeltaIndexer` implementation — replays in-flight blocks to produce
+  pending-state deltas
+- **`evm/protocol/filters.rs`**: Public pool filters consumers pass when registering protocols
 - **`evm/override_stream/`**: live per-block VM state overrides for pAMMs — generic
   `StateOverrideProvider`/`OverrideSnapshot` core plus the Titan quote-stream provider; pools
   resolve the latest snapshot on every simulation and can fall back to indexed state per the
   snapshot's `FailurePolicy`
 - **`evm/protocol/`**: Protocol implementations
-  - **Native** (`uniswap_v2/`, `uniswap_v3/`, `uniswap_v4/`, `ekubo/`, `cowamm/`, `fluid/`,
-    `aerodrome_v1/`, `aerodrome_slipstreams/`, `pancakeswap_v2/`, `etherfi/`, `erc4626/`,
-    `rocketpool/`, `cpmm/`, `clmm/`): Pure Rust math, no EVM execution
+  - **Native** (`uniswap_v2/`, `uniswap_v3/`, `uniswap_v4/`, `ekubo/`, `ekubo_v3/`, `cowamm/`,
+    `aerodrome_v1/`, `aerodrome_slipstreams/`, `velodrome_slipstreams/`, `pancakeswap_v2/`,
+    `ramses_v3/`, `ring_swap_v2/`, `lunarbase/`, `native_wrapper/`, `sky/`, `etherfi/`,
+    `erc4626/`, `rocketpool/`): Pure Rust math, no EVM execution.
+    `cpmm.rs` / `clmm.rs` / `safe_math.rs` / `u256_num.rs` / `utils.rs` are shared math helpers,
+    not protocols
+  - **Hybrid** (`fluid/`, `balancer_v3/`, `curve/`): native Rust quote math over VM-indexed pool
+    state (each has both `state.rs` and `vm.rs`)
   - **VM** (`vm/`): Generic Solidity adapter (`TychoSimulationContract`) executed in `revm` for
     protocols without a native implementation
-- **`rfq/`**: RFQ client for off-chain market makers (WebSocket-based quote streaming)
+- **`rfq/`**: RFQ clients for off-chain market makers (`rfq/protocols/`: `bebop`, `hashflow`,
+  `liquorice`, `metric`). Only Bebop streams over WebSocket; the rest poll over HTTP
 - **`price_level_stream/`**: Titan pAMM price level stream — `PriceLevelStreamBuilder` turns the
   Titan WebSocket's per-pair quote-ladder snapshots directly into `Update`s (no indexer feed
   round-trip); `PriceLevelStreamState` quotes by interpolating the ladder. Components are
@@ -46,7 +57,9 @@ fallback for protocols too complex to port, not a default.
 1. **Native** — pure Rust math; fastest. Use whenever the protocol logic can be expressed in Rust.
 2. **Hybrid** — native Rust math for swap calculation, but reads/updates pool state via the local
    VM (`SimulationDB`). Use when the swap logic can be ported but state is complex to track
-   independently. Example: Fluid V1.
+   independently. Examples: Fluid V1, Balancer V3, Curve. Note that a hybrid protocol keeps its
+   VM-shaped indexing — component keys stay `vm:*` and the indexer still tracks full contract
+   storage; only the quote path changes.
 3. **VM** — Solidity adapter in `revm`; works for any EVM protocol but is slower and requires an
    adapter contract in `protocols/adapter-integration/`. Use only when native is not feasible.
 4. **RFQ** — off-chain quotes via API; for protocols that cannot be simulated on-chain at all.
@@ -62,7 +75,8 @@ fallback for protocols too complex to port, not a default.
 
 ## Conventions
 
-- `cargo +nightly fmt` for formatting; stable toolchain for everything else
+- CI pins a nightly toolchain for both `fmt` and `clippy` (see `.github/workflows/ci-rust.yaml`);
+  stable for builds and tests
 - `rstest`: name each parametrised case with `#[case::descriptive_name(...)]`
 - Mark every test that hits external services `#[ignore = "Requires RPC_URL ..."]`. CI runs
   `--all-features`, so `#[cfg_attr(not(feature = "network_tests"), ignore)]` does not exclude the

--- a/crates/tycho-storage/CLAUDE.md
+++ b/crates/tycho-storage/CLAUDE.md
@@ -16,7 +16,7 @@ postgres/
 ├── token_cache.rs      — in-memory token store answering get_tokens without SQL (opt-in)
 ├── entry_point.rs      — entry point + tracing param/result persistence
 ├── extraction_state.rs — extractor checkpoint (cursor, block hash) persistence
-├── versioning.rs       — VersionedRow / StoredVersionedRow traits + apply_versioning()
+├── versioning.rs       — VersionedRow / StoredVersionedRow + apply_versioning(); PartitionedVersionedRow + apply_partitioned_versioning()
 ├── orm.rs              — Diesel Queryable/Insertable structs for every table
 └── schema.rs           — auto-generated Diesel table! macros
 ```
@@ -27,15 +27,21 @@ All public DB operations go through one of two gateway structs:
 
 - **`CachedGateway`** (normal path): sends `WriteOp` messages over an async channel to
   `DBCacheWriteExecutor`, which batches by block and flushes in a fixed order when the next
-  block arrives. Reads bypass the cache and hit the DB directly.
+  block arrives. Most reads hit the DB directly; the exceptions are `get_tokens` (served from
+  `token_cache` when enabled) and `get_delta` (small LRU).
 - **`DirectGateway`** (testing / low-throughput): same trait surface, no buffering.
+
+`GatewayBuilder::build` requires **exactly one** chain (`ensure_chain`) — an instance is
+single-chain; it hard-fails otherwise.
 
 Both delegate every actual SQL call to `PostgresGateway` (unexported). Domain logic lives in
 `chain`, `contract`, `protocol`, `entry_point`, and `extraction_state`—each adding methods to
 `PostgresGateway` via `impl` blocks in their own file.
 
 `versioning` is the only module without a DB table of its own; it provides the shared traits
-and `apply_versioning()` utility consumed by `contract` and `protocol`.
+and utilities consumed by `contract` and `protocol`. Two paths: `apply_versioning()` for plain
+versioned tables, and `apply_partitioned_versioning()` for the partitioned ones — protocol state,
+component balances, and contract storage.
 
 `token_cache` holds an in-memory copy of the token tables so `get_tokens` never touches SQL.
 Opt-in via `GatewayBuilder::enable_token_cache()` (the `index` and `rpc` commands enable it;
@@ -57,3 +63,9 @@ periodic `modified_ts` delta poll for out-of-process writers. See the module doc
 Every mutable entity carries `valid_from` / `valid_to` timestamps enabling time-travel
 queries. `versioning::apply_versioning()` sets `valid_to` on the previous row when a new
 version is inserted. Historical rows are never mutated.
+
+History is bounded, though: pg_cron jobs prune it outside the Rust code. `drop_expired_partitions()`
+drops expired partitions of `protocol_state`, `component_balance` and `contract_storage`, and
+`cleanup_orphaned_transactions()` deletes transaction rows nothing references any more (tracked via
+`transaction_cleanup_progress`). Both read the horizon from the `partition_retention_config` table
+(default 1 month). See `scripts/prune_transaction_table.md`.

--- a/protocols/adapter-integration/CLAUDE.md
+++ b/protocols/adapter-integration/CLAUDE.md
@@ -11,6 +11,11 @@ an adapter.
 
 Organised by protocol under `evm/src/` and `evm/test/`:
 
-- `src/{protocol}/` — adapter contract source (angle, balancer-v2, balancer-v3, curve, etherfi,
-  integral, maverick-v2, sfrax, sfraxeth, uniswap-v2, template)
-- `test/{Protocol}Adapter.t.sol` — fork tests validating swap encoding and on-chain execution
+- `src/{protocol}/` — adapter contract source (angle, balancer-v2, balancer-v3, bopamm, curve,
+  etherfi, fermiswap, integral, liquidityparty, maverick-v2, sfrax, sfraxeth, uniswap-v2,
+  template); plus shared `src/interfaces/` and `src/libraries/`
+- `test/{Protocol}Adapter.t.sol` or `test/{Protocol}SwapAdapter.t.sol` — fork tests validating swap
+  encoding and on-chain execution. The suffix is not consistent, and a test file's name does not
+  always match its `src/` directory (e.g. `FraxV3SFraxAdapter.t.sol` covers `src/sfrax/`), so
+  grep rather than guess
+- `test/executors/`, `test/mocks/`, `test/interfaces/` — shared test scaffolding

--- a/protocols/substreams/CLAUDE.md
+++ b/protocols/substreams/CLAUDE.md
@@ -6,24 +6,50 @@ messages consumed by `tycho-indexer`. **Separate WASM workspace** — not in roo
 
 ## Layout
 
-One directory per protocol: `{chain}-{protocol}` (e.g. `ethereum-uniswap-v2`). Each contains:
+One directory per package, named `{chain}-{protocol}` after the chain it was first written for
+(e.g. `ethereum-uniswap-v2`). A package is **not** one chain or one protocol: it ships **one
+manifest per (chain, fork)** and the manifest name — not the directory — names the published
+artifact. `ethereum-uniswap-v2/` alone carries `arbitrum-uniswap-v2.yaml`,
+`base-pancakeswap-v2.yaml`, `bsc-uniswap-v2.yaml`, `robinhood-uniswap-v2.yaml` and more.
 
-- `{name}.yaml` — manifest: package metadata, protobuf imports, module graph, initial block
+Each package contains:
+
+- `{chain}-{protocol}.yaml` — manifest: package metadata, protobuf imports, module graph, initial
+  block. One per chain/fork served by the package
 - `src/` — Rust map/store modules emitting `BlockChanges` / `EntityChanges` protobufs
-- `integration_test.tycho.yaml` — block range + assertions for `protocols/testing`
+- `integration_test.tycho.yaml` (plus `integration_test_{chain}_{protocol}.tycho.yaml` per extra
+  manifest) — block range + assertions for `protocols/testing`
+- `CHANGELOG.md` — **mandatory**; a release requires an entry
 - `rust-toolchain.toml` — exact toolchain pin (never `stable`); release builds use it for
   reproducible wasm output
+
+Shared code lives in `crates/`: `tycho-substreams` (the Tycho protobuf models and helpers every
+package builds on) and `substreams-helper`.
 
 ## Adding a new protocol
 
 Copy `ethereum-template-factory` (pool-factory pattern) or `ethereum-template-singleton` (single
 contract) as a starting point. Implement the map modules, update the manifest, add an
-`integration_test.tycho.yaml`.
+`integration_test.tycho.yaml`, and register the package in `protocols/substreams/Cargo.toml`
+`members`.
 
-## Versioning
+## Versioning and release
 
-Every PR that touches a package **must** bump that package's version in its `Cargo.toml` before
-merging to main — never merge changes without a version bump.
+Every PR that touches a package **must** bump that package's version in its `Cargo.toml` and add a
+`CHANGELOG.md` entry before merging to main — never merge changes without a version bump.
 
-- **Minor bump** (e.g. `0.3.2` → `0.3.3`): bug fixes, small adjustments
+- **Patch bump** (e.g. `0.3.2` → `0.3.3`): bug fixes, small adjustments
 - **Major bump** (e.g. `0.3.2` → `0.4.0`): significant changes, breaking output format
+
+Releasing is manual and **tagging alone does nothing**:
+
+1. Merge the version bump + changelog entry to main.
+2. Tag the merge commit `{package}-{version}` (e.g. `ethereum-curve-0.3.3`).
+3. Dispatch the `release-substreams-package` job in
+   `.github/workflows/release-substreams.yaml` with that tag as the ref, the `package` input, and
+   the `config_file` input naming the single manifest (without `.yaml`). Packages with several
+   manifests need one dispatch per manifest.
+
+Publishes are immutable — S3 conditional writes (`--if-none-match '*'`) reject an existing spkg, so
+shipping new code always means a version bump. Pre-releases land as `<pkg>-pre.<short-sha>.spkg`.
+See `protocols/substreams/Readme.md`.


### PR DESCRIPTION
The docs-synced-at marker was 976 source commits behind.

- Feature-flags table claimed only tycho-common had features
- Data flow named SwapSequence and TychoRouterV3.swap(); neither exists
- WebSocket route is /ws, not /ws/; encode_swap returns a Result
- Executor activation timelock is 1 day, not 3
- Adds the custom-chain registry and tycho-protobuf crate
- Balancer V3 and Curve are hybrid, not VM
- Adds 7 missing simulation protocols and 6 missing executors
- CI commands now match ci-rust.yaml
- Fixes stale paths in the sync-docs skill

Marker moves to 39b44a1b2, the audited commit; the 26 commits pulled since are not covered.