### PR TITLE
fix(indexer): instrument commit task body, not its JoinHandle

### DIFF
--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -60,7 +60,7 @@ pub struct Inner {
     first_message_processed: bool,
 }
 
-type BatchCommitHandle = tracing::instrument::Instrumented<JoinHandle<Result<(), ExtractionError>>>;
+type BatchCommitHandle = JoinHandle<Result<(), ExtractionError>>;
 
 #[derive(Default)]
 struct GatewayInner<G> {
@@ -774,9 +774,7 @@ where
             let (extractor_name, chain) = (self.name.clone(), self.chain);
 
             if let Some(db_commit_handle_to_join) = commit_handle_guard.take() {
-                let needs_await = !db_commit_handle_to_join
-                    .inner()
-                    .is_finished();
+                let needs_await = !db_commit_handle_to_join.is_finished();
                 let now = chrono::Utc::now().naive_utc();
 
                 let result = db_commit_handle_to_join
@@ -803,31 +801,10 @@ where
                 }
             }
 
-            let new_handle = tokio::spawn(async move {
-                let now = std::time::Instant::now();
-
-                let mut it = blocks_to_commit.iter().peekable();
-                while let Some(block) = it.next() {
-                    let force_db_commit = if is_syncing { false } else { it.peek().is_none() };
-
-                    gateway
-                        .advance(block.block_update(), block.cursor(), force_db_commit)
-                        .await
-                        .map_err(ExtractionError::Storage)?;
-                }
-
-                let mut committed_hieght_guard = committed_block_height.lock().await;
-                *committed_hieght_guard = Some(last_block_height);
-
-                trace!(batch_size, block_height = last_block_height, extractor_id = extractor_name, chain = %chain, "CommitTaskCompleted");
-
-                histogram!(
-                    "database_commit_duration_ms", "chain" => chain.to_string(), "extractor" => extractor_name
-                )
-                .record(now.elapsed().as_millis() as f64);
-
-                Ok(())
-            });
+            // Detached from the caller because the commit outlives the block that queued it;
+            // the caller is recorded as a follows-from link instead. The span wraps the task
+            // body, not its `JoinHandle` -- instrumenting the handle would only cover the
+            // await and leave every gateway call inside the task without a parent.
             let commit_span = info_span!(
                 parent: None,
                 "commit_blocks_task",
@@ -837,7 +814,36 @@ where
                 chain = %self.chain,
             );
             commit_span.follows_from(tracing::Span::current().id());
-            let new_handle = new_handle.instrument(commit_span);
+
+            let new_handle = tokio::spawn(
+                async move {
+                    let now = std::time::Instant::now();
+
+                    let mut it = blocks_to_commit.iter().peekable();
+                    while let Some(block) = it.next() {
+                        let force_db_commit =
+                            if is_syncing { false } else { it.peek().is_none() };
+
+                        gateway
+                            .advance(block.block_update(), block.cursor(), force_db_commit)
+                            .await
+                            .map_err(ExtractionError::Storage)?;
+                    }
+
+                    let mut committed_hieght_guard = committed_block_height.lock().await;
+                    *committed_hieght_guard = Some(last_block_height);
+
+                    trace!(batch_size, block_height = last_block_height, extractor_id = extractor_name, chain = %chain, "CommitTaskCompleted");
+
+                    histogram!(
+                        "database_commit_duration_ms", "chain" => chain.to_string(), "extractor" => extractor_name
+                    )
+                    .record(now.elapsed().as_millis() as f64);
+
+                    Ok(())
+                }
+                .instrument(commit_span),
+            );
 
             *commit_handle_guard = Some(new_handle);
 
@@ -2365,7 +2371,7 @@ mod test {
             let guard = ex.gateway.commit_handle.lock().await;
             guard
                 .as_ref()
-                .is_some_and(|h| !h.inner().is_finished())
+                .is_some_and(|h| !h.is_finished())
         };
         let commit_task_is_none = async |ex: &ProtocolExtractor<_, _, _>| -> bool {
             ex.gateway

--- a/crates/tycho-indexer/src/ot.rs
+++ b/crates/tycho-indexer/src/ot.rs
@@ -95,5 +95,11 @@ where
         .install_batch(runtime::Tokio)
         .context("install tracer")?;
 
-    Ok(tracing_opentelemetry::layer().with_tracer(tracer))
+    // Source location and thread identity are constant per span name and repeat on every
+    // exported span. Drop them; the span name and its parent chain already identify the code
+    // path. Busy/idle timings stay on, they differ per span.
+    Ok(tracing_opentelemetry::layer()
+        .with_tracer(tracer)
+        .with_location(false)
+        .with_threads(false))
 }

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -475,7 +475,9 @@ enum ExtractorEvent {
 /// restart). It lets the actor send `SubscriptionEnded` to the client and clean up the
 /// subscription without dropping the entire WebSocket connection.
 impl StreamHandler<ExtractorEvent> for WsActor {
-    #[instrument(skip_all, fields(WsActor.id = %self.id))]
+    // Debug level: the actor mailbox separates this from the block that produced the message,
+    // so at info it exports one parentless single-span trace per message per subscriber.
+    #[instrument(level = "debug", skip_all, fields(WsActor.id = %self.id))]
     fn handle(&mut self, msg: ExtractorEvent, ctx: &mut Self::Context) {
         match msg {
             ExtractorEvent::Message(subscription_id, deltas) => {


### PR DESCRIPTION
## What this changes

Three changes to indexer trace export.

**1. `commit_blocks_task` span wraps the task body** (`protocol_extractor.rs`)

`Instrument` on a `JoinHandle` enters the span only while the handle is polled. The spawned commit task therefore ran with no span context, and every `gateway.advance()` call inside it was exported as its own parentless trace. The span now wraps the task body, so a batch's DB writes nest under one trace.

`BatchCommitHandle` is now a plain `JoinHandle`, which removes the `inner()` hops at the await site and in the test helper. The `parent: None` + `follows_from` link is unchanged — the commit outlives the block that queued it, so it stays a linked root rather than a child.

**2. Constant span attributes are no longer exported** (`ot.rs`)

`code.filepath`, `code.namespace`, `code.lineno`, `thread.id` and `thread.name` are identical on every span of a given name and were re-sent with each one. Busy/idle timings are kept; they vary per span.

**3. `WsActor::handle` span is at debug level** (`ws.rs`)

The actor mailbox separates this handler from the block that produced the message, so the span has no parent and was exported as a single-span trace per message per subscriber. At `RUST_LOG=INFO` it is now filtered out.

## Why

Tempo caps live traces per tenant (default 10,000). The indexers were creating ~1,000 traces/sec and Tempo was discarding roughly 60% of spans, so traces were incomplete regardless of load.

Sampling 40 traces from the cluster showed the split:

| shape | traces | spans each |
|---|---|---|
| `extractor` (per-block, well formed) | 4 | 11 |
| `handle` | 14 | 1 |
| `upsert_block` | 10 | 1 |
| `save_cursor` | 10 | 2 |
| `add_component_balances` | 2 | 1 |

90% of traces were 1–2 span fragments. No child span had a missing parent, so the fragments were real rather than an artifact of the discards. One sampled `upsert_block` fragment reported `busy_ns = 898` — `CachedGateway::upsert_block` is a channel send, and it was producing a standalone trace.

Change 1 folds the `upsert_block` / `save_cursor` / `add_component_balances` fragments into their batch trace with no spans lost. Change 3 removes the `handle` fragments. Together that is most of the trace count.

## What is lost

- The `WsActor::handle` spans, unless `RUST_LOG` is raised to debug.
- Source location and thread name on spans. Where a span name is ambiguous (`upsert_block` exists in `cache.rs`, `direct.rs` and `chain.rs`) the parent chain now disambiguates it. Reverting is one line if the attributes turn out to be wanted.

No change to indexing behaviour.

## Testing

- `cargo test -p tycho-indexer --lib` — 394 pass, 0 fail (the 5 `serial_db` tests run against a local Postgres).
- `cargo +nightly-2026-06-28 fmt --all --check` clean.
- `cargo +nightly-2026-06-28 clippy -p tycho-indexer --all-targets --all-features -- -D warnings` clean.

Span parenting itself is not covered by a new test. Asserting it needs a subscriber that observes a spawned task, which means a global default subscriber and would be unreliable in a parallel test run. `test_handle_tick_scoped_respects_batch_async_commit` covers the commit-task lifecycle and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)