### PR TITLE
fix(testing): make Robinhood Chain packages testable

### DIFF
--- a/.github/actions/substreams-docker-single/action.yml
+++ b/.github/actions/substreams-docker-single/action.yml
@@ -16,6 +16,7 @@ runs:
         UNICHAIN_RPC_URL: ${{ env.UNICHAIN_RPC_URL }}
         BSC_RPC_URL: ${{ env.BSC_RPC_URL }}
         POLYGON_RPC_URL: ${{ env.POLYGON_RPC_URL }}
+        ROBINHOOD_RPC_URL: ${{ env.ROBINHOOD_RPC_URL }}
         SUBSTREAMS_API_TOKEN: ${{ env.SUBSTREAMS_API_TOKEN }}
         AUTH_API_KEY: ${{ env.AUTH_API_KEY }}
       run: |

--- a/.github/workflows/ci-foundry.yaml
+++ b/.github/workflows/ci-foundry.yaml
@@ -83,6 +83,7 @@ jobs:
       UNICHAIN_RPC_URL: ${{ secrets.UNICHAIN_RPC_URL_ARCHIVE }}
       BSC_RPC_URL: ${{ secrets.BSC_RPC_URL_ARCHIVE }}
       POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL_ARCHIVE }}
+      ROBINHOOD_RPC_URL: ${{ secrets.ROBINHOOD_RPC_URL_ARCHIVE }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/ci-substreams-integration.yaml
+++ b/.github/workflows/ci-substreams-integration.yaml
@@ -258,6 +258,7 @@ jobs:
       UNICHAIN_RPC_URL: ${{ secrets.UNICHAIN_RPC_URL_ARCHIVE }}
       BSC_RPC_URL: ${{ secrets.BSC_RPC_URL_ARCHIVE }}
       POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL_ARCHIVE }}
+      ROBINHOOD_RPC_URL: ${{ secrets.ROBINHOOD_RPC_URL_ARCHIVE }}
       SUBSTREAMS_API_TOKEN: ${{ secrets.SUBSTREAMS_API_TOKEN }}
       AUTH_API_KEY: ${{ secrets.AUTH_API_KEY }}
     strategy:

--- a/protocols/testing/docker-compose.yaml
+++ b/protocols/testing/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
       UNICHAIN_RPC_URL: "${UNICHAIN_RPC_URL:-}"
       BSC_RPC_URL: "${BSC_RPC_URL:-}"
       POLYGON_RPC_URL: "${POLYGON_RPC_URL:-}"
+      ROBINHOOD_RPC_URL: "${ROBINHOOD_RPC_URL:-}"
       SUBSTREAMS_API_TOKEN: "${SUBSTREAMS_API_TOKEN}"
     # PROTOCOLS to test separated by space and with optional filter
     # e.g. "ethereum-balancer-v2=weighted_legacy_creation ethereum-ekubo-v2"

--- a/protocols/testing/entrypoint.sh
+++ b/protocols/testing/entrypoint.sh
@@ -37,6 +37,7 @@ infer_chain() {
         unichain-*) echo "unichain" ;;
         bsc-*)      echo "bsc" ;;
         polygon-*)  echo "polygon" ;;
+        robinhood-*) echo "robinhood" ;;
         *)          echo "ethereum" ;;
     esac
 }
@@ -51,6 +52,7 @@ get_rpc_url() {
         unichain-*) echo "${UNICHAIN_RPC_URL:-$RPC_URL}" ;;
         bsc-*)      echo "${BSC_RPC_URL:-$RPC_URL}" ;;
         polygon-*)  echo "${POLYGON_RPC_URL:-$RPC_URL}" ;;
+        robinhood-*) echo "${ROBINHOOD_RPC_URL:-$RPC_URL}" ;;
         *)          echo "$RPC_URL" ;;
     esac
 }

--- a/protocols/testing/entrypoint.sh
+++ b/protocols/testing/entrypoint.sh
@@ -52,7 +52,7 @@ get_rpc_url() {
         unichain-*) echo "${UNICHAIN_RPC_URL:-$RPC_URL}" ;;
         bsc-*)      echo "${BSC_RPC_URL:-$RPC_URL}" ;;
         polygon-*)  echo "${POLYGON_RPC_URL:-$RPC_URL}" ;;
-        robinhood-*) echo "${ROBINHOOD_RPC_URL:-$RPC_URL}" ;;
+        robinhood-*) echo "${ROBINHOOD_RPC_URL:?ROBINHOOD_RPC_URL must be set to an archive RPC to test a robinhood-* package}" ;;
         *)          echo "$RPC_URL" ;;
     esac
 }

--- a/protocols/testing/run.Dockerfile
+++ b/protocols/testing/run.Dockerfile
@@ -34,6 +34,8 @@ WORKDIR /build/tycho-protocol-sdk/protocols/substreams
 RUN resolve_base() { \
         case "$1" in \
             base-alienbase-v3) echo "ethereum-uniswap-v3-logs-only" ;; \
+            robinhood-sushiswap-v3|robinhood-robinswap-v3) echo "ethereum-uniswap-v3-logs-only" ;; \
+            robinhood-ramses-v3) echo "polygon-ramses-v3" ;; \
             base-balancer-v3|arbitrum-balancer-v3|gnosis-balancer-v3) echo "ethereum-balancer-v3" ;; \
             ethereum-pancakeswap-v2) echo "ethereum-uniswap-v2" ;; \
             ethereum-sushiswap-v2) echo "ethereum-uniswap-v2" ;; \
@@ -73,6 +75,8 @@ COPY --from=protocol-sdk-builder /build/tycho-protocol-sdk/protocols/substreams 
 RUN resolve_base() { \
         case "$1" in \
             base-alienbase-v3) echo "ethereum-uniswap-v3-logs-only" ;; \
+            robinhood-sushiswap-v3|robinhood-robinswap-v3) echo "ethereum-uniswap-v3-logs-only" ;; \
+            robinhood-ramses-v3) echo "polygon-ramses-v3" ;; \
             base-balancer-v3|arbitrum-balancer-v3|gnosis-balancer-v3) echo "ethereum-balancer-v3" ;; \
             ethereum-pancakeswap-v2) echo "ethereum-uniswap-v2" ;; \
             ethereum-sushiswap-v2) echo "ethereum-uniswap-v2" ;; \


### PR DESCRIPTION
`protocols/testing` decides a package's chain and RPC from its directory-name prefix, and the Docker
image copies only the substreams directory that prefix maps to. None of the three places that encode
this handled `robinhood-*`, and neither CI workflow ever set a Robinhood RPC.

Consequences: a Robinhood package was indexed as `Chain::Ethereum` against `RPC_URL`, and in Docker
the runner aborted before reaching a test, because the image contained no `substreams/` directory at
all:

```
Error: Couldn't find a valid root path (containing substreams/ and adapter-integration/evm/)
in any ancestor of /app
```

That applies to `robinhood-sushiswap-v3` (#1389), `robinhood-robinswap-v3` (#1390) and
`robinhood-ramses-v3` (#1391) — none of the three has ever been runnable through this harness.

## What

**Harness (commit 1)**

| file | change |
|---|---|
| `entrypoint.sh` | `infer_chain`: `robinhood-*` → `robinhood`. `get_rpc_url`: read `ROBINHOOD_RPC_URL`. |
| `docker-compose.yaml` | pass `ROBINHOOD_RPC_URL` into the runner container. |
| `run.Dockerfile` | map the three packages above to the substreams directory each reuses, in **both** stages that carry a copy of the table. |

**CI (commits 2 and 3)**

| file | change |
|---|---|
| `ci-substreams-integration.yaml` | set `ROBINHOOD_RPC_URL` from `secrets.ROBINHOOD_RPC_URL_ARCHIVE` in `test-protocols`. |
| `.github/actions/substreams-docker-single/action.yml` | forward it into compose — the action whitelists each chain's variable. |
| `ci-foundry.yaml` | set the same variable in `forge-test`, whose matrix includes `crates/tycho-execution/contracts`. |
| `entrypoint.sh` | `robinhood-*` no longer falls back to `RPC_URL`; a missing `ROBINHOOD_RPC_URL` aborts naming the variable. |

The removed fallback matters because this PR makes it reachable: changing `run.Dockerfile` makes
`detect-changes` target *every* protocol, so the three Robinhood packages now get past the root-path
abort and would have indexed Robinhood blocks against the Ethereum archive node. Every other chain
keeps its fallback, which is harmless — their generic-RPC runs are the same chain.

`ci-foundry.yaml` is for #1337, which adds `robinhood = "${ROBINHOOD_RPC_URL}"` to
`crates/tycho-execution/contracts/foundry.toml` and a `testVe33Swap` pinned to a Robinhood fork, but
touches no workflow: without this line its endpoint resolves empty in CI.

## Operational: the secret has to be created before this lands

Add a repository secret **`ROBINHOOD_RPC_URL_ARCHIVE`** (Settings → Secrets and variables → Actions),
pointing at a Robinhood Chain **archive** endpoint. One secret serves both workflows.

- It must be archive. The public `https://rpc.mainnet.chain.robinhood.com` prunes state and answers
  `metadata is not found` a few thousand blocks back, so it can serve neither the harness balance
  check (`get_token_balance` at the test's stop block) nor #1337's pinned fork at block 39,875,978.
- The `_ARCHIVE` suffix matches the existing `ARBITRUM_RPC_URL_ARCHIVE` / `UNICHAIN_RPC_URL_ARCHIVE` /
  `BSC_RPC_URL_ARCHIVE` / `POLYGON_RPC_URL_ARCHIVE` secrets that both workflows already read.
- Fork PRs read secrets through the `integration-tests` environment, so the secret must exist at the
  repository level (or be mirrored into that environment) for fork runs to work.
- Until it exists, a Robinhood package fails loudly with
  `ROBINHOOD_RPC_URL must be set to an archive RPC to test a robinhood-* package` instead of
  silently indexing the wrong chain. **CI on this PR itself will hit that**, since the
  `run.Dockerfile` change targets every protocol, including the three Robinhood ones.

Locally: export `ROBINHOOD_RPC_URL` before `docker compose up`, or add it to `docker/.env`.

## Test

Verified with the stacked UP V3 integration (branch `hp/feat/robinhood-up-v3`), which adds a fourth
`run.Dockerfile` entry and a Robinhood `integration_test` config, against a Chainstack archive
endpoint:

```
Running 'range' tests for protocol: robinhood-up-v3 (chain: robinhood)
Running Tycho indexer from block 6184096 to 6201038...
All token balances match the values found onchain
Batch execution complete: 6 successes, 0 failures
Passed 1/1
```

Before this PR the same command died at the root-path error above; with only the `entrypoint.sh`
chain arm it would have run against the Ethereum RPC. `get_rpc_url` was also checked directly:
missing `ROBINHOOD_RPC_URL` exits 1 with the message, a set one is used, and `ethereum-*` still
falls back to `RPC_URL`.

## Note for review

Both `resolve_base` tables in `run.Dockerfile` carry the comment *"Keep this in sync with
`CLONE_TO_BASE_PROTOCOL` in `protocols/testing/src/test_runner.rs`"*, and both had silently drifted —
this PR restores the sync by hand a third time. Generating the shell tables from the Rust map, or
having the image read the mapping at build time, would remove the copy; I left that out of scope
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
