### PR TITLE
feat(router-trades): index the vault balances that hold router fees

### DIFF
--- a/crates/tycho-execution/substreams/Makefile
+++ b/crates/tycho-execution/substreams/Makefile
@@ -37,6 +37,8 @@ lint: check-manifests
 fmt:
 	cargo +nightly fmt
 
+# Needs a substreams CLI that bundles the sink-sql descriptors (1.22 does, 1.16 does not:
+# it fails on the manifest's `sink:` block with "could not find protobuf message type").
 protogen:
 	cd tycho-router-trades && substreams protogen chains/ethereum.yaml --output-path src/pb --exclude-paths="sf/substreams,sf/firehose,google,sf/ethereum"
 

--- a/crates/tycho-execution/substreams/README.md
+++ b/crates/tycho-execution/substreams/README.md
@@ -20,8 +20,9 @@ executors per hop, splits, watermark (trailing calldata), revert selector, decod
 gas used.
 
 Related tables: `trade_hops` (one row per executor hop), `fees_taken` (one row per fee
-recipient), `fee_config_events` (FeeCalculator admin events and fee-calculator rotations), and
-`router_call_errors` (selector-matched calls that could not be decoded safely).
+recipient), `fee_config_events` (FeeCalculator admin events and fee-calculator rotations),
+`vault_transfers` (ERC-6909 balance movements inside a router), and `router_call_errors`
+(selector-matched calls that could not be decoded safely).
 
 ### Discarded calls
 
@@ -53,6 +54,46 @@ The other two filters look redundant next to the flag, because a reverted call d
 state and a failed transaction discards all of it. They stay because the view does not lean on
 that: nothing in the Firehose contract promises a call cannot report `status_reverted` with its
 state kept.
+
+### Vault balances
+
+A V3 router holds token balances of its own, ERC-6909 style, and pays a fee recipient into that
+vault instead of transferring the token out. Router revenue therefore sits in the router until
+someone withdraws it, and `vault_balances` is what it looks like.
+
+The balance needs two sources, because the two kinds of movement report themselves differently:
+
+| movement | event | table |
+| --- | --- | --- |
+| fee credit | none, on purpose | `fees_taken` |
+| deposit, withdrawal, move between owners | ERC-6909 `Transfer` | `vault_transfers` |
+| swap funded from the vault, output paid into it | ERC-6909 `Transfer` | `vault_transfers` |
+
+`Vault._creditVaultForFees` mints without an event to save gas; `_takeFees` emits `FeesTaken`
+instead, and that is the only record of the credit. Every other path goes through `Vault._update`
+and does emit `Transfer`. Nothing else writes a vault balance, so the two together are complete.
+
+The credited token comes from the `FeesTaken` event, not from the swap calldata, so a balance
+does not depend on the swap decoder reading `tokenOut` right.
+
+`vault_flows` is the ledger of single movements and `vault_balances` the sum per owner, router
+and token. `balance` is what the router's `balanceOf(owner, uint256(uint160(token)))` returns, so
+it can be checked against the chain. An owner that withdrew everything stays listed on zero, so
+what it collected over time remains visible in `credited_as_fees`.
+
+Balances are per router: each deployment holds its own vault, and a rotation leaves the old
+balance where it was.
+
+Two things to know when reading real data:
+
+* A **negative** balance means credits are missing. Expect one on a chain that still holds trades
+  indexed before `state_committed` existed, because such a row counts a fee credit the chain
+  threw away and no later withdrawal takes it back out. Re-indexing the chain clears it.
+* The **zero token address** is native ETH on the first ethereum router
+  (`0x1f8db310`), which is the convention it was deployed with; later routers use the
+  `0xeeee…eeee` sentinel. Both appear as written, because the id the router credited is what
+  `balanceOf` answers on. On that router, the fee taker has withdrawn zero-address balances as
+  ETH: the debit of 487837220983021421 in block 25144849 moved exactly that many wei.
 
 ### Executor names
 
@@ -382,8 +423,10 @@ Nothing has to be cleared in the database: a chain with no cursor row starts at 
 ## Module graph
 
 ```
-index_router_activity ─┬─▶ map_fee_config_events ─▶ store_fee_config ─▶ map_trades ─▶ db_out
-                       └────────────────────────────────────────────▶            └──▶
+index_router_activity ─┬─▶ map_fee_config_events ─▶ store_fee_config ─▶ map_trades
+                       └─▶ map_vault_transfers
+
+db_out ◀── map_trades, map_fee_config_events, map_vault_transfers
 ```
 
 ### Block index
@@ -394,9 +437,12 @@ frame, and `fee_cfg` for a block that carries a log the fee-config decoders reco
 block that has neither, which is more than 999 blocks in 1000. Everything downstream of a
 filtered module, `store_fee_config` included, only sees the blocks that pass.
 
-`map_trades` filters on the routers of its params. Its filter has to name the same addresses,
-because a filter that is too narrow drops trades and reports nothing;
-`scripts/check_manifests.py` compares the two and runs in CI.
+`map_trades` and `map_vault_transfers` filter on the routers of their params, which are the
+same params. A filter has to name the same addresses, because one that is too narrow drops rows
+and reports nothing; `scripts/check_manifests.py` compares the three and runs in CI.
+
+A vault movement is a call to the router, so the `addr:` keys the index already writes cover it
+and `map_vault_transfers` needs nothing new from the index.
 
 `map_fee_config_events` filters on `fee_cfg` alone. It decodes a FeeCalculator event from any
 emitter, and a list of addresses would not hold: nearly half of the fee-config events stored so

--- a/crates/tycho-execution/substreams/schema.sql
+++ b/crates/tycho-execution/substreams/schema.sql
@@ -112,11 +112,14 @@ CREATE TABLE IF NOT EXISTS trade_hops (
 );
 CREATE INDEX IF NOT EXISTS trade_hops_trade_idx ON trade_hops (trade_id);
 
+-- One recipient of a FeesTaken event. The router pays a fee into its own vault instead of
+-- transferring it, so a row here is a vault credit; read `vault_balances` for the balance.
 CREATE TABLE IF NOT EXISTS fees_taken (
     id           TEXT PRIMARY KEY, -- {trade_id}:{index}
     trade_id     TEXT NOT NULL,
     chain        TEXT NOT NULL,
     block_number BIGINT NOT NULL,
+    -- From the event, so it is the token the router credited, not the decoded tokenOut.
     token        TEXT NOT NULL,
     recipient    TEXT NOT NULL,
     amount       NUMERIC(78, 0) NOT NULL,
@@ -158,3 +161,31 @@ CREATE TABLE IF NOT EXISTS fee_config_events (
     new_value    TEXT
 );
 CREATE INDEX IF NOT EXISTS fee_config_events_emitter_idx ON fee_config_events (chain, emitter, block_number);
+
+-- ERC-6909 vault balance movements on a router.
+--
+-- Fee credits are absent by design: the router mints those without an event and reports them
+-- through FeesTaken, so they arrive in `fees_taken`. Read the `vault_balances` view, which
+-- takes both sources; a sum over this table alone runs negative.
+CREATE TABLE IF NOT EXISTS vault_transfers (
+    id           TEXT PRIMARY KEY, -- {chain}:{tx_hash}:{log_index}
+    chain        TEXT NOT NULL,
+    block_number BIGINT NOT NULL,
+    block_time   TIMESTAMPTZ NOT NULL,
+    tx_hash      TEXT NOT NULL,
+    log_index    INTEGER NOT NULL,
+    -- Each router holds its own vault, so an owner has one balance per router.
+    router       TEXT NOT NULL,
+    -- msg.sender of the call that moved the balance, which an operator-driven move needs.
+    caller       TEXT NOT NULL,
+    -- Debited owner, or the zero address on a credit.
+    sender       TEXT NOT NULL,
+    -- Credited owner, or the zero address on a debit.
+    receiver     TEXT NOT NULL,
+    token        TEXT NOT NULL,
+    amount       NUMERIC(78, 0) NOT NULL,
+    kind         TEXT NOT NULL CHECK (kind IN ('credit', 'debit', 'transfer'))
+);
+CREATE INDEX IF NOT EXISTS vault_transfers_owner_idx
+    ON vault_transfers (chain, router, token);
+CREATE INDEX IF NOT EXISTS vault_transfers_block_idx ON vault_transfers (chain, block_number);

--- a/crates/tycho-execution/substreams/scripts/check_manifests.py
+++ b/crates/tycho-execution/substreams/scripts/check_manifests.py
@@ -2,9 +2,10 @@
 """Check that every chain manifest filters on the addresses its params configure.
 
 `map_trades` selects on the routers in its params, and its block filter has to name the same
-addresses. `map_fee_config_events` decodes from any emitter, so it filters on `fee_cfg`, a key
-the index sets from the same decoders. A filter that is too narrow drops rows without an error,
-so this runs in CI.
+addresses. `map_vault_transfers` reads logs from the same routers, so it carries the same params
+and the same filter. `map_fee_config_events` decodes from any emitter, so it filters on
+`fee_cfg`, a key the index sets from the same decoders. A filter that is too narrow drops rows
+without an error, so this runs in CI.
 
 Run from anywhere: python3 crates/tycho-execution/substreams/scripts/check_manifests.py
 """
@@ -48,6 +49,17 @@ def main() -> int:
         if actual != routers:
             failures.append(
                 f"{path.name} map_trades: filter has {sorted(actual)}, params say {sorted(routers)}"
+            )
+        vault_params = re.search(r"^  map_vault_transfers: (.+)$", manifest, re.M)
+        if vault_params is None:
+            failures.append(f"{path.name}: no map_vault_transfers params")
+        elif vault_params.group(1) != params:
+            failures.append(f"{path.name} map_vault_transfers: params differ from map_trades")
+        vault_filter = filtered(manifest, "map_vault_transfers")
+        if vault_filter != routers:
+            failures.append(
+                f"{path.name} map_vault_transfers: filter has {sorted(vault_filter)}, "
+                f"params say {sorted(routers)}"
             )
         fee_query = query(manifest, "map_fee_config_events")
         if fee_query != "fee_cfg":

--- a/crates/tycho-execution/substreams/test_views.sql
+++ b/crates/tycho-execution/substreams/test_views.sql
@@ -70,5 +70,101 @@ BEGIN
     END IF;
 END $$;
 
+-- Vault balances come from two sources, so the fixtures below feed both: `fees_taken` for the
+-- credit the router mints without an event, `vault_transfers` for everything that logs one.
+CREATE OR REPLACE FUNCTION add_fee(
+    p_trade TEXT, p_token TEXT, p_recipient TEXT, p_amount NUMERIC, p_role TEXT DEFAULT 'router'
+) RETURNS VOID AS $$
+    INSERT INTO fees_taken (id, trade_id, chain, block_number, token, recipient, amount, role)
+    VALUES (p_trade || ':' || p_recipient || ':' || p_token, p_trade, 'robinhood', 1,
+            p_token, p_recipient, p_amount, p_role);
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION add_vault(
+    p_id TEXT, p_sender TEXT, p_receiver TEXT, p_token TEXT, p_amount NUMERIC, p_kind TEXT
+) RETURNS VOID AS $$
+    INSERT INTO vault_transfers (
+        id, chain, block_number, block_time, tx_hash, log_index, router, caller, sender,
+        receiver, token, amount, kind
+    ) VALUES (
+        p_id, 'robinhood', 2, '2026-09-01T00:00:00Z', '0x' || p_id, 0, '0xr', '0xcaller',
+        p_sender, p_receiver, p_token, p_amount, p_kind
+    );
+$$ LANGUAGE sql;
+
+DO $$
+DECLARE
+    zero TEXT := '0x0000000000000000000000000000000000000000';
+BEGIN
+    -- Fees on two calls the chain kept.
+    PERFORM add_fee('committed', '0xusdc', '0xfeetaker', 300);
+    PERFORM add_fee('fill', '0xusdc', '0xfeetaker', 200);
+
+    -- A fee on a call the chain threw away. The credit never happened on chain.
+    PERFORM add_fee('discarded', '0xusdc', '0xfeetaker', 999);
+    -- A fee on a reverted call and on a failed transaction. Neither reached the vault, and both
+    -- of those trades carry the flag, so only tx_success and call_success keep them out.
+    PERFORM add_fee('reverted', '0xusdc', '0xfeetaker', 888);
+    PERFORM add_fee('tx-failed', '0xusdc', '0xfeetaker', 777);
+
+    -- A fee on a row indexed before the flag existed. Nothing says the chain kept the call.
+    PERFORM add_fee('legacy', '0xusdc', '0xfeetaker', 666);
+
+    -- A client on zero bps. The row exists but moved nothing, so no owner appears for it.
+    PERFORM add_fee('committed', '0xusdc', '0xclient', 0, 'client');
+
+    -- The fee taker withdraws 120 of the 500 it holds.
+    PERFORM add_vault('w1', '0xfeetaker', zero, '0xusdc', 120, 'debit');
+
+    -- Someone deposits, moves it on, and the second owner takes it all out again.
+    PERFORM add_vault('d1', zero, '0xalice', '0xweth', 70, 'credit');
+    PERFORM add_vault('t1', '0xalice', '0xbob', '0xweth', 70, 'transfer');
+    PERFORM add_vault('w2', '0xbob', zero, '0xweth', 70, 'debit');
+END $$;
+
+DO $$
+DECLARE
+    balance NUMERIC;
+    fees NUMERIC;
+    owners TEXT[];
+BEGIN
+    -- 300 + 200 credited by fees, 120 withdrawn. The discarded, reverted and failed fees are out.
+    SELECT b.balance, b.credited_as_fees INTO balance, fees
+    FROM vault_balances b
+    WHERE b.owner = '0xfeetaker' AND b.token = '0xusdc';
+    IF balance IS DISTINCT FROM 380 OR fees IS DISTINCT FROM 500 THEN
+        RAISE EXCEPTION 'fee taker holds % of % credited, expected 380 of 500', balance, fees;
+    END IF;
+
+    -- A zero-amount fee row puts nobody in the vault.
+    IF EXISTS (SELECT 1 FROM vault_balances b WHERE b.owner = '0xclient') THEN
+        RAISE EXCEPTION 'a zero fee created a vault owner';
+    END IF;
+
+    -- The deposit reached alice, the move took it away again, and bob withdrew it. Both stay
+    -- listed on zero so the flow through them is still visible.
+    SELECT array_agg(b.owner || '=' || b.balance ORDER BY b.owner) INTO owners
+    FROM vault_balances b WHERE b.token = '0xweth';
+    IF owners IS DISTINCT FROM ARRAY['0xalice=0', '0xbob=0'] THEN
+        RAISE EXCEPTION 'weth balances are %', owners;
+    END IF;
+
+    -- The zero address is a mint and burn marker, not an owner.
+    IF EXISTS (
+        SELECT 1 FROM vault_balances b
+        WHERE b.owner = '0x0000000000000000000000000000000000000000'
+    ) THEN
+        RAISE EXCEPTION 'the zero address became a vault owner';
+    END IF;
+
+    -- Nothing here withdraws more than it was credited, so no balance may go negative. A
+    -- negative one on real data means a credit source is missing.
+    IF EXISTS (SELECT 1 FROM vault_balances b WHERE b.balance < 0) THEN
+        RAISE EXCEPTION 'a balance went negative';
+    END IF;
+END $$;
+
+DROP FUNCTION add_fee(TEXT, TEXT, TEXT, NUMERIC, TEXT);
+DROP FUNCTION add_vault(TEXT, TEXT, TEXT, TEXT, NUMERIC, TEXT);
 DROP FUNCTION add_trade(TEXT, TEXT, INTEGER, TEXT, TEXT, NUMERIC, BOOLEAN, BOOLEAN, BOOLEAN);
 COMMIT;

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/arbitrum.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/arbitrum.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 463130033
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34 || addr:0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658 || addr:0x924f147c50ea59f5180a26031a8b65b2aa1e81cd"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 463130033
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: arbitrum-one
 params:
   map_fee_config_events: chain=arbitrum&routers=0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34:v3_0,0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658:v3_1,0x924f147c50ea59f5180a26031a8b65b2aa1e81cd:v3_1&fee_calculators=0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34:0x8265ef25cda2b34968e1a47e54fa5fa01ca1a598,0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658:0x3a61c2a6ee1a752800a561435bf362bbaf25aa00,0x924f147c50ea59f5180a26031a8b65b2aa1e81cd:0x9ca59bd78aab97db9692e43684b12072e910f0b7
   map_trades: chain=arbitrum&routers=0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34:v3_0,0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658:v3_1,0x924f147c50ea59f5180a26031a8b65b2aa1e81cd:v3_1&fee_calculators=0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34:0x8265ef25cda2b34968e1a47e54fa5fa01ca1a598,0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658:0x3a61c2a6ee1a752800a561435bf362bbaf25aa00,0x924f147c50ea59f5180a26031a8b65b2aa1e81cd:0x9ca59bd78aab97db9692e43684b12072e910f0b7
+  map_vault_transfers: chain=arbitrum&routers=0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34:v3_0,0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658:v3_1,0x924f147c50ea59f5180a26031a8b65b2aa1e81cd:v3_1&fee_calculators=0xc1f838a5382bbb5729a0801c8ba73dfc861c4d34:0x8265ef25cda2b34968e1a47e54fa5fa01ca1a598,0x8a8ba3973c84252bf7d357e4c0244b7eedb8b658:0x3a61c2a6ee1a752800a561435bf362bbaf25aa00,0x924f147c50ea59f5180a26031a8b65b2aa1e81cd:0x9ca59bd78aab97db9692e43684b12072e910f0b7
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/base.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/base.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 30783770
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0xea3207778e39eb02d72c9d3c4eac7e224ac5d369 || addr:0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e || addr:0x2d3524b9b5dae34b646614eebb1e038d403e4cac || addr:0x9ba632d83e9ef57571256cf4cc951b8af1158e9c || addr:0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 30783770
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: base
 params:
   map_fee_config_events: chain=base&routers=0xea3207778e39eb02d72c9d3c4eac7e224ac5d369:v2,0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e:v3_0,0x2d3524b9b5dae34b646614eebb1e038d403e4cac:v3_0,0x9ba632d83e9ef57571256cf4cc951b8af1158e9c:v3_1,0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67:v3_1&fee_calculators=0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e:0x8cfea5cc589155c0128267e8d2b027362b661b14,0x2d3524b9b5dae34b646614eebb1e038d403e4cac:0x8cfea5cc589155c0128267e8d2b027362b661b14,0x9ba632d83e9ef57571256cf4cc951b8af1158e9c:0xb6e39a6ce7224fbc73eb24b10a1d3443ff7fbfc1,0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67:0x4c95d7678be1668fca8205f0d076b5e872b715e1
   map_trades: chain=base&routers=0xea3207778e39eb02d72c9d3c4eac7e224ac5d369:v2,0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e:v3_0,0x2d3524b9b5dae34b646614eebb1e038d403e4cac:v3_0,0x9ba632d83e9ef57571256cf4cc951b8af1158e9c:v3_1,0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67:v3_1&fee_calculators=0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e:0x8cfea5cc589155c0128267e8d2b027362b661b14,0x2d3524b9b5dae34b646614eebb1e038d403e4cac:0x8cfea5cc589155c0128267e8d2b027362b661b14,0x9ba632d83e9ef57571256cf4cc951b8af1158e9c:0xb6e39a6ce7224fbc73eb24b10a1d3443ff7fbfc1,0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67:0x4c95d7678be1668fca8205f0d076b5e872b715e1
+  map_vault_transfers: chain=base&routers=0xea3207778e39eb02d72c9d3c4eac7e224ac5d369:v2,0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e:v3_0,0x2d3524b9b5dae34b646614eebb1e038d403e4cac:v3_0,0x9ba632d83e9ef57571256cf4cc951b8af1158e9c:v3_1,0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67:v3_1&fee_calculators=0x06dd6a2e78c757be63bc47daa841cf1a8b50ee5e:0x8cfea5cc589155c0128267e8d2b027362b661b14,0x2d3524b9b5dae34b646614eebb1e038d403e4cac:0x8cfea5cc589155c0128267e8d2b027362b661b14,0x9ba632d83e9ef57571256cf4cc951b8af1158e9c:0xb6e39a6ce7224fbc73eb24b10a1d3443ff7fbfc1,0xaba5b53b03eafad1c5fc8bd5fc765fc85bb3de67:0x4c95d7678be1668fca8205f0d076b5e872b715e1
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 98458505
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0x99748cbd931cb367dad265c5b2b4bd306d448e99 || addr:0x712d0213439d99e56efe5453253c12131c4019c9 || addr:0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 98458505
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: bsc
 params:
   map_fee_config_events: chain=bsc&routers=0x99748cbd931cb367dad265c5b2b4bd306d448e99:v3_0,0x712d0213439d99e56efe5453253c12131c4019c9:v3_1,0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e:v3_1&fee_calculators=0x99748cbd931cb367dad265c5b2b4bd306d448e99:0x890f267d89017e5a76d7213458c4cd755a1119da,0x712d0213439d99e56efe5453253c12131c4019c9:0x12d75cc114c6a3216562fe345bcc19b6c78cec72,0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e:0x6c62645e52d40a700f8219f18cd92ce8a668c8ea
   map_trades: chain=bsc&routers=0x99748cbd931cb367dad265c5b2b4bd306d448e99:v3_0,0x712d0213439d99e56efe5453253c12131c4019c9:v3_1,0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e:v3_1&fee_calculators=0x99748cbd931cb367dad265c5b2b4bd306d448e99:0x890f267d89017e5a76d7213458c4cd755a1119da,0x712d0213439d99e56efe5453253c12131c4019c9:0x12d75cc114c6a3216562fe345bcc19b6c78cec72,0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e:0x6c62645e52d40a700f8219f18cd92ce8a668c8ea
+  map_vault_transfers: chain=bsc&routers=0x99748cbd931cb367dad265c5b2b4bd306d448e99:v3_0,0x712d0213439d99e56efe5453253c12131c4019c9:v3_1,0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e:v3_1&fee_calculators=0x99748cbd931cb367dad265c5b2b4bd306d448e99:0x890f267d89017e5a76d7213458c4cd755a1119da,0x712d0213439d99e56efe5453253c12131c4019c9:0x12d75cc114c6a3216562fe345bcc19b6c78cec72,0x7f3d12bbafb8955e51b3ab9588b34c8ad95bda4e:0x6c62645e52d40a700f8219f18cd92ce8a668c8ea
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/ethereum.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/ethereum.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 22575004
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0xfd0b31d2e955fa55e3fa641fe90e08b677188d35 || addr:0x1f8db310f32d48b6180ff902ec60c586128cef47 || addr:0xda892c989d07a18b5dd3f392d949f00df15c5736 || addr:0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614 || addr:0x1644d2477f809cc2c71bccfd6dc9497e3f83210d"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 22575004
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: mainnet
 params:
   map_fee_config_events: chain=ethereum&routers=0xfd0b31d2e955fa55e3fa641fe90e08b677188d35:v2,0x1f8db310f32d48b6180ff902ec60c586128cef47:v3_0,0xda892c989d07a18b5dd3f392d949f00df15c5736:v3_0,0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614:v3_1,0x1644d2477f809cc2c71bccfd6dc9497e3f83210d:v3_1&fee_calculators=0x1f8db310f32d48b6180ff902ec60c586128cef47:0x24ad1d4a2666a99ef46ada68999a89e324cd914c,0xda892c989d07a18b5dd3f392d949f00df15c5736:0x24ad1d4a2666a99ef46ada68999a89e324cd914c,0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614:0xa236e1f03e18d5f0ad2c7fd1a94d32b459f06a85,0x1644d2477f809cc2c71bccfd6dc9497e3f83210d:0x2930cb02f8293a684981ef7fb63c160329c410f1
   map_trades: chain=ethereum&routers=0xfd0b31d2e955fa55e3fa641fe90e08b677188d35:v2,0x1f8db310f32d48b6180ff902ec60c586128cef47:v3_0,0xda892c989d07a18b5dd3f392d949f00df15c5736:v3_0,0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614:v3_1,0x1644d2477f809cc2c71bccfd6dc9497e3f83210d:v3_1&fee_calculators=0x1f8db310f32d48b6180ff902ec60c586128cef47:0x24ad1d4a2666a99ef46ada68999a89e324cd914c,0xda892c989d07a18b5dd3f392d949f00df15c5736:0x24ad1d4a2666a99ef46ada68999a89e324cd914c,0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614:0xa236e1f03e18d5f0ad2c7fd1a94d32b459f06a85,0x1644d2477f809cc2c71bccfd6dc9497e3f83210d:0x2930cb02f8293a684981ef7fb63c160329c410f1
+  map_vault_transfers: chain=ethereum&routers=0xfd0b31d2e955fa55e3fa641fe90e08b677188d35:v2,0x1f8db310f32d48b6180ff902ec60c586128cef47:v3_0,0xda892c989d07a18b5dd3f392d949f00df15c5736:v3_0,0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614:v3_1,0x1644d2477f809cc2c71bccfd6dc9497e3f83210d:v3_1&fee_calculators=0x1f8db310f32d48b6180ff902ec60c586128cef47:0x24ad1d4a2666a99ef46ada68999a89e324cd914c,0xda892c989d07a18b5dd3f392d949f00df15c5736:0x24ad1d4a2666a99ef46ada68999a89e324cd914c,0xea290ce3eae57bdb37e57872a5a14dc0d2f6e614:0xa236e1f03e18d5f0ad2c7fd1a94d32b459f06a85,0x1644d2477f809cc2c71bccfd6dc9497e3f83210d:0x2930cb02f8293a684981ef7fb63c160329c410f1
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/plasma.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/plasma.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 27191979
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769 || addr:0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18 || addr:0x0953c7e23b44259e5e5630e9b97c31d7278c4c85"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 27191979
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: plasma
 params:
   map_fee_config_events: chain=plasma&routers=0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769:v3_0,0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18:v3_1,0x0953c7e23b44259e5e5630e9b97c31d7278c4c85:v3_1&fee_calculators=0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769:0x9c45a5421f299ff110ad334413d62934f3d9e941,0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18:0xe9f440e025b8b871fce9f9255eab7cea30f5e946,0x0953c7e23b44259e5e5630e9b97c31d7278c4c85:0x8b9918adcb59234fb9f3e7594cf972e3edbb93f1
   map_trades: chain=plasma&routers=0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769:v3_0,0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18:v3_1,0x0953c7e23b44259e5e5630e9b97c31d7278c4c85:v3_1&fee_calculators=0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769:0x9c45a5421f299ff110ad334413d62934f3d9e941,0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18:0xe9f440e025b8b871fce9f9255eab7cea30f5e946,0x0953c7e23b44259e5e5630e9b97c31d7278c4c85:0x8b9918adcb59234fb9f3e7594cf972e3edbb93f1
+  map_vault_transfers: chain=plasma&routers=0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769:v3_0,0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18:v3_1,0x0953c7e23b44259e5e5630e9b97c31d7278c4c85:v3_1&fee_calculators=0x8f9b3b0451efff0ae8100428aee35fa3cbc0b769:0x9c45a5421f299ff110ad334413d62934f3d9e941,0xa7df4a8eeca477c8a869fb5a6578a3d39abe9a18:0xe9f440e025b8b871fce9f9255eab7cea30f5e946,0x0953c7e23b44259e5e5630e9b97c31d7278c4c85:0x8b9918adcb59234fb9f3e7594cf972e3edbb93f1
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/polygon.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/polygon.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 86935804
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0x7cb3e87095f6cf95982dc6f57445171a6d3b511c || addr:0x0c85409014d6c8caef60c837198c931246bd6296 || addr:0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 86935804
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: polygon
 params:
   map_fee_config_events: chain=polygon&routers=0x7cb3e87095f6cf95982dc6f57445171a6d3b511c:v3_0,0x0c85409014d6c8caef60c837198c931246bd6296:v3_1,0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1:v3_1&fee_calculators=0x7cb3e87095f6cf95982dc6f57445171a6d3b511c:0xae1367cda31829d76fb7cf8202272dbc2050995b,0x0c85409014d6c8caef60c837198c931246bd6296:0x64a487c26c39f7bcfdb04b60e906715f5b8ac5f2,0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1:0x3970230eaac99d1c1880c04fcec069e61da823dc
   map_trades: chain=polygon&routers=0x7cb3e87095f6cf95982dc6f57445171a6d3b511c:v3_0,0x0c85409014d6c8caef60c837198c931246bd6296:v3_1,0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1:v3_1&fee_calculators=0x7cb3e87095f6cf95982dc6f57445171a6d3b511c:0xae1367cda31829d76fb7cf8202272dbc2050995b,0x0c85409014d6c8caef60c837198c931246bd6296:0x64a487c26c39f7bcfdb04b60e906715f5b8ac5f2,0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1:0x3970230eaac99d1c1880c04fcec069e61da823dc
+  map_vault_transfers: chain=polygon&routers=0x7cb3e87095f6cf95982dc6f57445171a6d3b511c:v3_0,0x0c85409014d6c8caef60c837198c931246bd6296:v3_1,0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1:v3_1&fee_calculators=0x7cb3e87095f6cf95982dc6f57445171a6d3b511c:0xae1367cda31829d76fb7cf8202272dbc2050995b,0x0c85409014d6c8caef60c837198c931246bd6296:0x64a487c26c39f7bcfdb04b60e906715f5b8ac5f2,0xbd4e6011f03355c2a377fd9af939322a7d0a1bc1:0x3970230eaac99d1c1880c04fcec069e61da823dc
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 24417223
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0x345e48768a65ae596ac6a2aee71202753c4866f5 || addr:0x09215a470bd585e59eb3f4b612fbd2678131ff9e"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 24417223
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: robinhood
 params:
   map_fee_config_events: chain=robinhood&routers=0x345e48768a65ae596ac6a2aee71202753c4866f5:v3_1,0x09215a470bd585e59eb3f4b612fbd2678131ff9e:v3_1&fee_calculators=0x345e48768a65ae596ac6a2aee71202753c4866f5:0xd16dbe64e5688c5771e52d530e0c21b32901f141,0x09215a470bd585e59eb3f4b612fbd2678131ff9e:0x0dd35e98aa40b4b75a8aa4950fd761b23de12854
   map_trades: chain=robinhood&routers=0x345e48768a65ae596ac6a2aee71202753c4866f5:v3_1,0x09215a470bd585e59eb3f4b612fbd2678131ff9e:v3_1&fee_calculators=0x345e48768a65ae596ac6a2aee71202753c4866f5:0xd16dbe64e5688c5771e52d530e0c21b32901f141,0x09215a470bd585e59eb3f4b612fbd2678131ff9e:0x0dd35e98aa40b4b75a8aa4950fd761b23de12854
+  map_vault_transfers: chain=robinhood&routers=0x345e48768a65ae596ac6a2aee71202753c4866f5:v3_1,0x09215a470bd585e59eb3f4b612fbd2678131ff9e:v3_1&fee_calculators=0x345e48768a65ae596ac6a2aee71202753c4866f5:0xd16dbe64e5688c5771e52d530e0c21b32901f141,0x09215a470bd585e59eb3f4b612fbd2678131ff9e:0x0dd35e98aa40b4b75a8aa4950fd761b23de12854
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/unichain.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/unichain.yaml
@@ -62,12 +62,26 @@ modules:
     output:
       type: proto:tycho.router.v1.Trades
 
+  - name: map_vault_transfers
+    kind: map
+    initialBlock: 16000000
+    blockFilter:
+      module: index_router_activity
+      query:
+        string: "addr:0xffa5ec2e444e4285108e4a17b82da495c178427b || addr:0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74 || addr:0x764bc67b1036b00bc91221e988261f971a1c7ce4 || addr:0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc || addr:0xcba5574597ad00ea250fd106dab4fc7461949635"
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.router.v1.VaultTransfers
+
   - name: db_out
     kind: map
     initialBlock: 16000000
     inputs:
       - map: map_trades
       - map: map_fee_config_events
+      - map: map_vault_transfers
     output:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
@@ -76,6 +90,7 @@ network: unichain
 params:
   map_fee_config_events: chain=unichain&routers=0xffa5ec2e444e4285108e4a17b82da495c178427b:v2,0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74:v3_0,0x764bc67b1036b00bc91221e988261f971a1c7ce4:v3_0,0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc:v3_1,0xcba5574597ad00ea250fd106dab4fc7461949635:v3_1&fee_calculators=0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74:0x957ea7a45a29f8d02485f3e08e47b540d3be93ab,0x764bc67b1036b00bc91221e988261f971a1c7ce4:0x957ea7a45a29f8d02485f3e08e47b540d3be93ab,0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc:0xfd1b57e41fe4b2bb48e288f8e68f3bc4aefb7b40,0xcba5574597ad00ea250fd106dab4fc7461949635:0x3a20aded2bacfab637dfda86543eb8e832402417
   map_trades: chain=unichain&routers=0xffa5ec2e444e4285108e4a17b82da495c178427b:v2,0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74:v3_0,0x764bc67b1036b00bc91221e988261f971a1c7ce4:v3_0,0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc:v3_1,0xcba5574597ad00ea250fd106dab4fc7461949635:v3_1&fee_calculators=0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74:0x957ea7a45a29f8d02485f3e08e47b540d3be93ab,0x764bc67b1036b00bc91221e988261f971a1c7ce4:0x957ea7a45a29f8d02485f3e08e47b540d3be93ab,0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc:0xfd1b57e41fe4b2bb48e288f8e68f3bc4aefb7b40,0xcba5574597ad00ea250fd106dab4fc7461949635:0x3a20aded2bacfab637dfda86543eb8e832402417
+  map_vault_transfers: chain=unichain&routers=0xffa5ec2e444e4285108e4a17b82da495c178427b:v2,0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74:v3_0,0x764bc67b1036b00bc91221e988261f971a1c7ce4:v3_0,0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc:v3_1,0xcba5574597ad00ea250fd106dab4fc7461949635:v3_1&fee_calculators=0x1d8dfe01731fcd0ac9b2fe4d0fb238c42d71cf74:0x957ea7a45a29f8d02485f3e08e47b540d3be93ab,0x764bc67b1036b00bc91221e988261f971a1c7ce4:0x957ea7a45a29f8d02485f3e08e47b540d3be93ab,0xa0498d0fa4081c9a735b137a2e6a1910faa0e0bc:0xfd1b57e41fe4b2bb48e288f8e68f3bc4aefb7b40,0xcba5574597ad00ea250fd106dab4fc7461949635:0x3a20aded2bacfab637dfda86543eb8e832402417
 
 sink:
   module: db_out

--- a/crates/tycho-execution/substreams/tycho-router-trades/proto/tycho/router/v1/trades.proto
+++ b/crates/tycho-execution/substreams/tycho-router-trades/proto/tycho/router/v1/trades.proto
@@ -134,6 +134,9 @@ message FeeTaken {
   string amount = 2;
   // Contract array position: "router" first, then "client".
   string role = 3;
+  // The credited token, from the event rather than the calldata, so a vault balance built on
+  // this does not depend on the swap decoder.
+  bytes token = 4;
 }
 
 // Fee configuration changes found in one block.
@@ -157,4 +160,37 @@ message FeeConfigEvent {
   // Decimal / hex string representation of the old and new values.
   string old_value = 10;
   string new_value = 11;
+}
+
+// Every ERC-6909 Transfer a router emitted in one block.
+//
+// The router keeps a vault of internal token balances. It credits a fee recipient there instead
+// of transferring, so router revenue accrues as a vault balance until someone withdraws it.
+//
+// Fee credits are NOT in here: the router mints those without an event to save gas, and reports
+// them through FeesTaken instead (see FeeTaken). A balance therefore needs both sources.
+message VaultTransfers {
+  repeated VaultTransfer transfers = 1;
+}
+
+// One ERC-6909 Transfer: a deposit, a withdrawal, or a move between two owners.
+message VaultTransfer {
+  string chain = 1;
+  uint64 block_number = 2;
+  uint64 block_timestamp = 3;
+  bytes tx_hash = 4;
+  uint32 log_index = 5;
+  // The router holding the vault. Each router has its own, so a balance is per router.
+  bytes router = 6;
+  // msg.sender of the call that moved the balance. The owner of an operator-driven move.
+  bytes caller = 7;
+  // Debited owner; empty on a credit (mint).
+  bytes sender = 8;
+  // Credited owner; empty on a debit (burn).
+  bytes receiver = 9;
+  // The ERC-6909 id, which the router derives from the token address.
+  bytes token = 10;
+  string amount = 11;
+  // "credit" (minted), "debit" (burned) or "transfer" (between two owners).
+  string kind = 12;
 }

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/db_out.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/db_out.rs
@@ -6,10 +6,14 @@ use substreams_database_change::{
 };
 
 use super::hex_addr;
-use crate::pb::tycho::router::v1::{FeeConfigEvents, Trade, Trades};
+use crate::pb::tycho::router::v1::{FeeConfigEvents, Trade, Trades, VaultTransfers};
 
 #[substreams::handlers::map]
-pub fn db_out(trades: Trades, fee_events: FeeConfigEvents) -> Result<DatabaseChanges> {
+pub fn db_out(
+    trades: Trades,
+    fee_events: FeeConfigEvents,
+    vault: VaultTransfers,
+) -> Result<DatabaseChanges> {
     let mut tables = Tables::new();
     for trade in &trades.trades {
         insert_trade(&mut tables, trade)?;
@@ -51,6 +55,23 @@ pub fn db_out(trades: Trades, fee_events: FeeConfigEvents) -> Result<DatabaseCha
         if !ev.new_value.is_empty() {
             row.set("new_value", &ev.new_value);
         }
+    }
+    for t in &vault.transfers {
+        let id = format!("{}:{}:{}", t.chain, hex_addr(&t.tx_hash), t.log_index);
+        tables
+            .create_row("vault_transfers", id)
+            .set("chain", &t.chain)
+            .set("block_number", t.block_number)
+            .set("block_time", rfc3339(t.block_timestamp))
+            .set("tx_hash", hex_addr(&t.tx_hash))
+            .set("log_index", t.log_index)
+            .set("router", hex_addr(&t.router))
+            .set("caller", hex_addr(&t.caller))
+            .set("sender", hex_addr(&t.sender))
+            .set("receiver", hex_addr(&t.receiver))
+            .set("token", hex_addr(&t.token))
+            .set("amount", &t.amount)
+            .set("kind", &t.kind);
     }
     Ok(tables.to_database_changes())
 }
@@ -160,7 +181,7 @@ fn insert_trade(tables: &mut Tables, t: &Trade) -> Result<()> {
         row.set("trade_id", &trade_id)
             .set("chain", &t.chain)
             .set("block_number", t.block_number)
-            .set("token", hex_addr(&t.token_out))
+            .set("token", hex_addr(&fee.token))
             .set("recipient", hex_addr(&fee.recipient))
             .set("amount", &fee.amount)
             .set("role", &fee.role);
@@ -308,8 +329,18 @@ mod tests {
         use crate::pb::tycho::router::v1::FeeTaken;
         let t = Trade {
             fees_taken: vec![
-                FeeTaken { recipient: vec![0xaa; 20], amount: "10".into(), role: "router".into() },
-                FeeTaken { recipient: vec![0xcc; 20], amount: "5".into(), role: "client".into() },
+                FeeTaken {
+                    recipient: vec![0xaa; 20],
+                    amount: "10".into(),
+                    role: "router".into(),
+                    token: vec![0x11; 20],
+                },
+                FeeTaken {
+                    recipient: vec![0xcc; 20],
+                    amount: "5".into(),
+                    role: "client".into(),
+                    token: vec![0x11; 20],
+                },
             ],
             ..Default::default()
         };
@@ -323,8 +354,18 @@ mod tests {
         use crate::pb::tycho::router::v1::FeeTaken;
         let t = Trade {
             fees_taken: vec![
-                FeeTaken { recipient: vec![0xee; 20], amount: "7".into(), role: "router".into() },
-                FeeTaken { recipient: vec![0xee; 20], amount: "3".into(), role: "client".into() },
+                FeeTaken {
+                    recipient: vec![0xee; 20],
+                    amount: "7".into(),
+                    role: "router".into(),
+                    token: vec![0x11; 20],
+                },
+                FeeTaken {
+                    recipient: vec![0xee; 20],
+                    amount: "3".into(),
+                    role: "client".into(),
+                    token: vec![0x11; 20],
+                },
             ],
             ..Default::default()
         };
@@ -341,6 +382,7 @@ mod tests {
                 recipient: vec![0xee; 20],
                 amount: "7".into(),
                 role: "unknown".into(),
+                token: vec![0x11; 20],
             }],
             ..Default::default()
         };

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/mod.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/mod.rs
@@ -2,11 +2,13 @@ mod db_out;
 mod fee_config;
 mod index;
 mod trades;
+mod vault;
 
 pub use db_out::db_out;
 pub use fee_config::{map_fee_config_events, store_fee_config};
 pub use index::index_router_activity;
 pub use trades::map_trades;
+pub use vault::map_vault_transfers;
 
 /// Store key prefixes shared between the fee-config store writer and the trades reader.
 pub(crate) mod keys {

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/trades.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/trades.rs
@@ -176,9 +176,14 @@ fn build_trade(
         .logs
         .iter()
         .filter_map(FeesTaken::match_and_decode)
-        .flat_map(|ev| ev.fees.into_iter())
+        .flat_map(|ev| {
+            let token = ev.token;
+            ev.fees
+                .into_iter()
+                .map(move |fee| (token.clone(), fee))
+        })
         .enumerate()
-        .map(|(index, (recipient, amount))| FeeTaken {
+        .map(|(index, (token, (recipient, amount)))| FeeTaken {
             recipient,
             amount: amount.to_string(),
             role: match index {
@@ -187,6 +192,7 @@ fn build_trade(
                 _ => "unknown",
             }
             .to_string(),
+            token,
         })
         .collect();
 

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/vault.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/vault.rs
@@ -1,0 +1,265 @@
+//! ERC-6909 vault balance movements on the routers.
+//!
+//! A router credits a fee recipient inside its own vault rather than transferring the token
+//! out, so router revenue accrues there. The credit itself carries no ERC-6909 `Transfer`
+//! (`Vault._creditVaultForFees` mints without an event to save gas, and `_takeFees` emits
+//! `FeesTaken` instead), which is why this module covers only the movements that do emit one:
+//! deposits, withdrawals, and moves between two owners.
+use anyhow::Result;
+use substreams::scalar::BigInt;
+use substreams_ethereum::{pb::eth::v2::Block, Event};
+
+use super::block_timestamp;
+use crate::{
+    abi::tycho_router_v3_1::events::Transfer,
+    params::{Params, RouterVersion},
+    pb::tycho::router::v1::{VaultTransfer, VaultTransfers},
+};
+
+/// Emits every ERC-6909 `Transfer` a configured router logged in a committed transaction.
+#[substreams::handlers::map]
+pub fn map_vault_transfers(params: String, block: Block) -> Result<VaultTransfers> {
+    let params = Params::parse(&params)?;
+    Ok(VaultTransfers { transfers: vault_transfers(&params, &block) })
+}
+
+/// The vault movements of one block, reading only the receipts of successful transactions so a
+/// log the chain threw away never becomes a balance.
+fn vault_transfers(params: &Params, block: &Block) -> Vec<VaultTransfer> {
+    let timestamp = block_timestamp(block);
+    let mut transfers = Vec::new();
+    for tx in block.transactions() {
+        for log in tx
+            .receipt
+            .as_ref()
+            .map(|r| r.logs.as_slice())
+            .unwrap_or_default()
+        {
+            // V2 has no vault, so a matching topic from one is a collision, not a movement.
+            let Some(router) = params
+                .router(&log.address)
+                .filter(|r| r.version != RouterVersion::V2)
+            else {
+                continue;
+            };
+            let Some(ev) = Transfer::match_and_decode(log) else {
+                continue;
+            };
+            let Some(token) = token_of(&ev.id) else {
+                substreams::log::info!(
+                    "vault id {} is not a token address, tx 0x{} log {}",
+                    ev.id,
+                    hex::encode(&tx.hash),
+                    log.index
+                );
+                continue;
+            };
+            transfers.push(VaultTransfer {
+                chain: params.chain.clone(),
+                block_number: block.number,
+                block_timestamp: timestamp,
+                tx_hash: tx.hash.clone(),
+                log_index: log.index,
+                router: router.address.clone(),
+                caller: ev.caller,
+                sender: ev.sender.clone(),
+                receiver: ev.receiver.clone(),
+                token,
+                amount: ev.amount.to_string(),
+                kind: kind_of(&ev.sender, &ev.receiver).to_string(),
+            });
+        }
+    }
+    transfers
+}
+
+/// The token an ERC-6909 id stands for, or `None` when the id is not one.
+///
+/// `Vault._toId` casts the token address to `uint256`, so every id a router mints fits in 20
+/// bytes and converts straight back.
+fn token_of(id: &BigInt) -> Option<Vec<u8>> {
+    let bytes = id.to_bytes_be().1;
+    if bytes.len() > 20 {
+        return None;
+    }
+    let mut token = vec![0u8; 20 - bytes.len()];
+    token.extend_from_slice(&bytes);
+    Some(token)
+}
+
+/// Which side of the balance the movement is on, read from the zero address a mint or a burn
+/// puts in place of an owner.
+fn kind_of(sender: &[u8], receiver: &[u8]) -> &'static str {
+    match (sender.iter().all(|b| *b == 0), receiver.iter().all(|b| *b == 0)) {
+        (true, _) => "credit",
+        (false, true) => "debit",
+        (false, false) => "transfer",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use substreams_ethereum::pb::eth::v2::{Log, TransactionReceipt, TransactionTrace};
+
+    use super::*;
+
+    const V3_ROUTER: &str = "1111111111111111111111111111111111111111";
+    const V2_ROUTER: &str = "2222222222222222222222222222222222222222";
+    // keccak256("Transfer(address,address,address,uint256,uint256)")
+    const TRANSFER: &str = "1b3d7edb2e9c0b0e7c525b20aaaef0f5940d2ed71663c7d39266ecafac728859";
+    const USDC: &str = "a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+    fn params() -> Params {
+        Params::parse(&format!("chain=ethereum&routers=0x{V3_ROUTER}:v3_1,0x{V2_ROUTER}:v2"))
+            .unwrap()
+    }
+
+    fn word(hex_tail: &str) -> Vec<u8> {
+        hex::decode(format!("{:0>64}", hex_tail)).unwrap()
+    }
+
+    /// A `Transfer` log: sender, receiver and id are indexed, caller and amount are in the data.
+    fn transfer_log(emitter: &str, sender: &str, receiver: &str, id: &str, amount: u64) -> Log {
+        let mut data = word("9999999999999999999999999999999999999999");
+        data.extend_from_slice(&word(&format!("{amount:x}")));
+        Log {
+            address: hex::decode(emitter).unwrap(),
+            topics: vec![word(TRANSFER), word(sender), word(receiver), word(id)],
+            data,
+            index: 7,
+            ..Default::default()
+        }
+    }
+
+    fn block(status: i32, logs: Vec<Log>) -> Block {
+        Block {
+            number: 42,
+            transaction_traces: vec![TransactionTrace {
+                status,
+                receipt: Some(TransactionReceipt { logs, ..Default::default() }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn succeeded(logs: Vec<Log>) -> Block {
+        block(1, logs)
+    }
+
+    #[test]
+    fn a_mint_on_a_v3_router_is_a_credit() {
+        let owner = "3333333333333333333333333333333333333333";
+        let log = transfer_log(V3_ROUTER, "0", owner, USDC, 250);
+        let transfers = vault_transfers(&params(), &succeeded(vec![log]));
+        assert_eq!(transfers.len(), 1);
+        let t = &transfers[0];
+        assert_eq!(t.kind, "credit");
+        assert_eq!(t.amount, "250");
+        assert_eq!(hex::encode(&t.token), USDC);
+        assert_eq!(hex::encode(&t.receiver), owner);
+        assert_eq!(hex::encode(&t.router), V3_ROUTER);
+        assert_eq!(t.block_number, 42);
+        assert_eq!(t.log_index, 7);
+    }
+
+    #[test]
+    fn a_burn_is_a_debit_and_a_move_is_a_transfer() {
+        let a = "3333333333333333333333333333333333333333";
+        let b = "4444444444444444444444444444444444444444";
+        let kinds: Vec<String> = vault_transfers(
+            &params(),
+            &succeeded(vec![
+                transfer_log(V3_ROUTER, a, "0", USDC, 1),
+                transfer_log(V3_ROUTER, a, b, USDC, 2),
+            ]),
+        )
+        .into_iter()
+        .map(|t| t.kind)
+        .collect();
+        assert_eq!(kinds, ["debit", "transfer"]);
+    }
+
+    #[test]
+    fn a_v2_router_has_no_vault() {
+        let log = transfer_log(V2_ROUTER, "0", "3333333333333333333333333333333333333333", USDC, 1);
+        assert!(vault_transfers(&params(), &succeeded(vec![log])).is_empty());
+    }
+
+    #[test]
+    fn an_unconfigured_emitter_is_ignored() {
+        let other = "5555555555555555555555555555555555555555";
+        let log = transfer_log(other, "0", "3333333333333333333333333333333333333333", USDC, 1);
+        assert!(vault_transfers(&params(), &succeeded(vec![log])).is_empty());
+    }
+
+    #[test]
+    fn a_failed_transaction_moves_nothing() {
+        let log = transfer_log(V3_ROUTER, "0", "3333333333333333333333333333333333333333", USDC, 1);
+        assert!(vault_transfers(&params(), &block(2, vec![log])).is_empty());
+    }
+
+    #[test]
+    fn an_id_wider_than_an_address_is_skipped() {
+        let wide = "ff".repeat(21);
+        let log =
+            transfer_log(V3_ROUTER, "0", "3333333333333333333333333333333333333333", &wide, 1);
+        assert!(vault_transfers(&params(), &succeeded(vec![log])).is_empty());
+    }
+
+    /// Two logs taken off ethereum mainnet, so the topic order and the data layout are checked
+    /// against what the routers really emit rather than against this module's own idea of it.
+    ///
+    /// The withdrawal is the zero-address balance the fee taker took out of the first router in
+    /// block 25144849. It moved 487837220983021421 wei of ETH to that address, which is how the
+    /// zero id on that router is known to be native ETH.
+    #[test]
+    fn decodes_logs_taken_off_mainnet() {
+        let v3_0 = "1f8db310f32d48b6180ff902ec60c586128cef47";
+        let v3_1 = "ea290ce3eae57bdb37e57872a5a14dc0d2f6e614";
+        let fee_taker = "a5503d92ee16a78e602996ad362674dc49034a14";
+        let depositor = "85957b990db8b266bc03fb0cfe295a060ebbf6e1";
+        let params =
+            Params::parse(&format!("chain=ethereum&routers=0x{v3_0}:v3_0,0x{v3_1}:v3_1")).unwrap();
+
+        let withdrawal = Log {
+            address: hex::decode(v3_0).unwrap(),
+            topics: vec![word(TRANSFER), word(fee_taker), word("0"), word("0")],
+            data: hex::decode(format!("{:0>64}{:0>64}", fee_taker, "6c5255e28e81f6d")).unwrap(),
+            index: 332,
+            ..Default::default()
+        };
+        let deposit = Log {
+            address: hex::decode(v3_1).unwrap(),
+            topics: vec![word(TRANSFER), word("0"), word(depositor), word(USDC)],
+            data: hex::decode(format!("{:0>64}{:0>64}", depositor, "f4240")).unwrap(),
+            index: 963,
+            ..Default::default()
+        };
+
+        let transfers = vault_transfers(&params, &succeeded(vec![withdrawal, deposit]));
+        assert_eq!(transfers.len(), 2);
+
+        assert_eq!(transfers[0].kind, "debit");
+        assert_eq!(transfers[0].amount, "487837220983021421");
+        assert_eq!(hex::encode(&transfers[0].sender), fee_taker);
+        assert_eq!(hex::encode(&transfers[0].caller), fee_taker);
+        assert_eq!(transfers[0].token, vec![0u8; 20]);
+
+        assert_eq!(transfers[1].kind, "credit");
+        assert_eq!(transfers[1].amount, "1000000");
+        assert_eq!(hex::encode(&transfers[1].receiver), depositor);
+        assert_eq!(hex::encode(&transfers[1].token), USDC);
+    }
+
+    #[test]
+    fn zero_id_is_the_zero_address() {
+        assert_eq!(token_of(&BigInt::zero()), Some(vec![0u8; 20]));
+    }
+
+    #[test]
+    fn id_converts_back_to_the_token_address() {
+        let token = hex::decode(USDC).unwrap();
+        assert_eq!(token_of(&BigInt::from_unsigned_bytes_be(&token)), Some(token));
+    }
+}

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/pb/tycho.router.v1.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/pb/tycho.router.v1.rs
@@ -203,6 +203,10 @@ pub struct FeeTaken {
     /// Contract array position: "router" first, then "client".
     #[prost(string, tag="3")]
     pub role: ::prost::alloc::string::String,
+    /// The credited token, from the event rather than the calldata, so a vault balance built on
+    /// this does not depend on the swap decoder.
+    #[prost(bytes="vec", tag="4")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
 }
 /// Fee configuration changes found in one block.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -240,5 +244,53 @@ pub struct FeeConfigEvent {
     pub old_value: ::prost::alloc::string::String,
     #[prost(string, tag="11")]
     pub new_value: ::prost::alloc::string::String,
+}
+/// Every ERC-6909 Transfer a router emitted in one block.
+///
+/// The router keeps a vault of internal token balances. It credits a fee recipient there instead
+/// of transferring, so router revenue accrues as a vault balance until someone withdraws it.
+///
+/// Fee credits are NOT in here: the router mints those without an event to save gas, and reports
+/// them through FeesTaken instead (see FeeTaken). A balance therefore needs both sources.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VaultTransfers {
+    #[prost(message, repeated, tag="1")]
+    pub transfers: ::prost::alloc::vec::Vec<VaultTransfer>,
+}
+/// One ERC-6909 Transfer: a deposit, a withdrawal, or a move between two owners.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VaultTransfer {
+    #[prost(string, tag="1")]
+    pub chain: ::prost::alloc::string::String,
+    #[prost(uint64, tag="2")]
+    pub block_number: u64,
+    #[prost(uint64, tag="3")]
+    pub block_timestamp: u64,
+    #[prost(bytes="vec", tag="4")]
+    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag="5")]
+    pub log_index: u32,
+    /// The router holding the vault. Each router has its own, so a balance is per router.
+    #[prost(bytes="vec", tag="6")]
+    pub router: ::prost::alloc::vec::Vec<u8>,
+    /// msg.sender of the call that moved the balance. The owner of an operator-driven move.
+    #[prost(bytes="vec", tag="7")]
+    pub caller: ::prost::alloc::vec::Vec<u8>,
+    /// Debited owner; empty on a credit (mint).
+    #[prost(bytes="vec", tag="8")]
+    pub sender: ::prost::alloc::vec::Vec<u8>,
+    /// Credited owner; empty on a debit (burn).
+    #[prost(bytes="vec", tag="9")]
+    pub receiver: ::prost::alloc::vec::Vec<u8>,
+    /// The ERC-6909 id, which the router derives from the token address.
+    #[prost(bytes="vec", tag="10")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag="11")]
+    pub amount: ::prost::alloc::string::String,
+    /// "credit" (minted), "debit" (burned) or "transfer" (between two owners).
+    #[prost(string, tag="12")]
+    pub kind: ::prost::alloc::string::String,
 }
 // @@protoc_insertion_point(module)

--- a/crates/tycho-execution/substreams/views.sql
+++ b/crates/tycho-execution/substreams/views.sql
@@ -46,4 +46,66 @@ BEGIN
       AND t.state_committed;
 END $$;
 
+DO $$
+BEGIN
+    IF to_regclass('public.vault_transfers') IS NULL OR to_regclass('public.trades') IS NULL THEN
+        RAISE NOTICE 'vault_transfers or trades does not exist yet, skipping the vault views';
+        RETURN;
+    END IF;
+
+    -- Every movement of a vault balance, one row per owner and side.
+    --
+    -- The router keeps token balances of its own (ERC-6909) and credits a fee recipient there
+    -- instead of transferring, so router revenue accrues in the vault until someone withdraws
+    -- it. Two sources are needed to see a balance, because the two kinds of movement report
+    -- themselves differently:
+    --   * `vault_transfers` holds what the ERC-6909 Transfer event carries: deposits,
+    --     withdrawals, moves between owners, and the balance a swap funded from or paid into
+    --     the vault.
+    --   * the fee credit emits no Transfer, on purpose. `Vault._creditVaultForFees` mints
+    --     without an event to save gas, and `_takeFees` emits FeesTaken instead, which lands in
+    --     `fees_taken`. Those rows are the `fee` source below.
+    DROP VIEW IF EXISTS vault_balances;
+    DROP VIEW IF EXISTS vault_flows;
+    CREATE VIEW vault_flows AS
+    SELECT v.chain, v.router, v.receiver AS owner, v.token, v.block_number, v.block_time,
+           v.tx_hash, v.amount AS delta, v.kind AS source
+    FROM vault_transfers v
+    WHERE v.kind IN ('credit', 'transfer')
+    UNION ALL
+    SELECT v.chain, v.router, v.sender, v.token, v.block_number, v.block_time,
+           v.tx_hash, -v.amount, v.kind
+    FROM vault_transfers v
+    WHERE v.kind IN ('debit', 'transfer')
+    UNION ALL
+    SELECT f.chain, t.router, f.recipient, f.token, f.block_number, t.block_time,
+           t.tx_hash, f.amount, 'fee'
+    FROM fees_taken f
+    JOIN trades t ON t.id = f.trade_id
+    WHERE f.amount > 0
+      AND t.tx_success
+      AND t.call_success
+      AND t.state_committed;
+
+    -- What each owner holds in each router's vault, and how much of it fees put there.
+    --
+    -- A balance of zero means the owner withdrew everything, and stays in so the fees an owner
+    -- collected over time remain visible. `balance` is what the router's balanceOf returns, so
+    -- it can be checked against the chain.
+    --
+    -- A negative balance is impossible on chain and means rows are missing here. Expect one on
+    -- a chain still holding trades indexed before `state_committed` existed: the withdrawal is
+    -- in `vault_transfers`, and the fee credit that paid for it is on a trade this view cannot
+    -- count. Re-indexing the chain clears it.
+    CREATE VIEW vault_balances AS
+    SELECT chain, router, owner, token,
+           sum(delta) AS balance,
+           sum(delta) FILTER (WHERE source = 'fee') AS credited_as_fees,
+           count(*) AS n_flows,
+           max(block_number) AS last_block,
+           max(block_time) AS last_change
+    FROM vault_flows
+    GROUP BY 1, 2, 3, 4;
+END $$;
+
 COMMIT;


### PR DESCRIPTION
Stacked on #1405. Review that one first.

## Why

A V3 router pays a fee into its own ERC-6909 vault instead of transferring the token out, so **router revenue sits in the router** until someone withdraws it. We stored the credits (`fees_taken`) and nothing else, so there was no way to read a balance.

Reading the credits alone does not give one. Comparing the summed credits against the routers' own `balanceOf` at the block each chain is indexed to:

| chain | router | token | credited | on chain |
| --- | --- | --- | --- | --- |
| ethereum | `0x1f8db310` | USDC | 19,588,345,706 | 607,298,513 |
| ethereum | `0xda892c98` | USDC | 56,684,446 | 52,916,199 |
| arbitrum | `0xc1f838a5` | GMX | 8,378,901 | 2,463,180 |
| unichain | `0x1d8dfe01` | USDC | 23,932,789 | 23,827,090 |

22 of the 24 largest positions are lower on chain than in the database, because the balances move and we never saw the movements. A scan of the ethereum routers finds **43 withdrawals and 4 deposits**: the fee taker sweeps in batches across many tokens at once, most recently 8 tokens in one block.

## What moves a vault balance, and what reports it

| movement | event | table |
| --- | --- | --- |
| fee credit | none, on purpose | `fees_taken` |
| deposit, withdrawal, move between owners | ERC-6909 `Transfer` | `vault_transfers` (new) |
| swap funded from the vault, output paid into it | ERC-6909 `Transfer` | `vault_transfers` (new) |

The fee credit is the one that emits nothing: `Vault._creditVaultForFees` calls `_mintWithoutEvent` to save gas, and `_takeFees` emits `FeesTaken` instead. That path has exactly one caller, and every other path goes through `Vault._update`, which does emit `Transfer`. So the two sources together are complete.

## What this adds

- **`map_vault_transfers`** emits every ERC-6909 `Transfer` a configured V3 router logs. It reads the receipts of successful transactions only, so a log the chain threw away never becomes a balance. V2 has no vault and is skipped.
- It reads from the same routers and carries the same block filter as `map_trades`. A vault movement is a call to the router, so the `addr:` keys the index already writes cover it and **the index does not change**.
- **`vault_transfers`** table, and the **`vault_flows`** / **`vault_balances`** views that put both sources together. `balance` is what the router's `balanceOf(owner, uint256(uint160(token)))` answers, so it can be checked against the chain. An owner that withdrew everything stays listed on zero, so what it collected over time stays visible in `credited_as_fees`.
- The credited token now comes from the `FeesTaken` event rather than the decoded `tokenOut`, so a balance does not depend on the swap decoder. The two agree on chain: the router builds `FeeInput.tokenOut` from the same calldata argument.
- `scripts/check_manifests.py` compares the new module's params and filter against `map_trades`.

## Tests

- 8 new unit tests in `vault.rs`, two of them decoding **logs taken off ethereum mainnet** so the topic order and data layout are checked against what the routers really emit. One is the fee taker's zero-address withdrawal in block 25144849, which moved exactly 487837220983021421 wei of ETH to that address.
- `test_views.sql` gains fixtures for both sources: fee credits on kept, discarded, reverted and failed calls, a zero-amount fee, a partial withdrawal, and a deposit moved on and withdrawn by a second owner.
- Mutation tested. Four mutations of the module (drop the V2 guard, swap credit and debit, read every trace instead of the successful ones, drop the id width guard) and five of the views (count a discarded fee, count a zero fee, drop the debited side, treat a mint marker as an owner, count reverted and failed fees) each fail the tests.

## Two things to know when reading the data

- A **negative** balance means credits are missing. Expect one on a chain that still holds trades indexed before `state_committed` existed (#1405), because such a row counts a fee credit the chain discarded and no later withdrawal takes it back out. Re-indexing clears it.
- The **zero token address** is native ETH on the first ethereum router, the convention it was deployed with; later routers use the `0xeeee…eeee` sentinel. Both stay as written, because the id the router credited is what `balanceOf` answers on.

## Deployment

New module and a third `db_out` input, so the module hash changes and the package needs a re-sync. #1405 already forces one, which is why this belongs in the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmQJ8ED1jjCXzthvBGPo1