### PR TITLE
fix(router-trades): read the fee bps scale off the calculator

### DIFF
--- a/crates/tycho-execution/substreams/Cargo.lock
+++ b/crates/tycho-execution/substreams/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-router-trades"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/crates/tycho-execution/substreams/README.md
+++ b/crates/tycho-execution/substreams/README.md
@@ -184,6 +184,26 @@ manifests under `tycho-router-trades/chains/`. The FeeCalculator constructor emi
 the initial pairing is a parameter; rotations (`FeeCalculatorActivated` / `FeeCalculatorUpdated`)
 and all fee-rate changes are replayed from events into `store_fee_config`.
 
+#### The bps denominator belongs to the calculator
+
+`trades.router_fee_on_output_bps` is a raw number and only means a rate together with
+`fee_bps_scale`. The scale is a property of the **FeeCalculator**, not of the router: the second
+generation widened the bps arguments from `uint16` to `uint32` and moved the denominator from
+10,000 to 100,000,000, so the same 0.1% reads as `10` on the first and `100000` on the second.
+
+A router can be rotated onto a calculator of the other generation, and five of them are: a v3_0
+router pointed at a `uint32` calculator reports bps on 100,000,000. Taking the scale from the
+router generation therefore made the rate 10,000 times too large on those.
+
+Because the two generations differ in the argument width, they differ in event signature and so
+in topic, and the event that sets a bps value also says which denominator it is on.
+`store_fee_config` keeps that under `fc:<calculator>:scale`, and a trade reads the scale of the
+calculator it resolved to. The router generation is only the fallback for a calculator that no
+observed event gives away. `fee_config_events.bps_scale` carries the same value per event.
+
+An event that carries no bps value has one signature in both generations and identifies neither,
+so it sets nothing.
+
 ### Volume in USD
 
 Pricing is a post-ingestion step, not part of the substreams. Tycho prices every token in the

--- a/crates/tycho-execution/substreams/schema.sql
+++ b/crates/tycho-execution/substreams/schema.sql
@@ -158,7 +158,12 @@ CREATE TABLE IF NOT EXISTS fee_config_events (
     event        TEXT NOT NULL,
     client       TEXT,
     old_value    TEXT,
-    new_value    TEXT
+    new_value    TEXT,
+    -- Denominator the old_value and new_value bps are on, when this event gives its emitter's
+    -- generation away; NULL otherwise. The two FeeCalculator generations widened the bps
+    -- arguments from uint16 to uint32, so an event carrying one has a different topic in each,
+    -- and 10 on the first means the same rate as 100000 on the second.
+    bps_scale    BIGINT
 );
 CREATE INDEX IF NOT EXISTS fee_config_events_emitter_idx ON fee_config_events (chain, emitter, block_number);
 

--- a/crates/tycho-execution/substreams/tycho-router-trades/Cargo.toml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tycho-router-trades"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/arbitrum.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/arbitrum.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/base.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/base.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/ethereum.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/ethereum.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/plasma.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/plasma.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/polygon.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/polygon.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/unichain.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/unichain.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/proto/tycho/router/v1/trades.proto
+++ b/crates/tycho-execution/substreams/tycho-router-trades/proto/tycho/router/v1/trades.proto
@@ -160,6 +160,10 @@ message FeeConfigEvent {
   // Decimal / hex string representation of the old and new values.
   string old_value = 10;
   string new_value = 11;
+  // Denominator of the bps values this emitter uses, when the event gives its generation away;
+  // 0 otherwise. The two FeeCalculator generations widened the bps arguments from uint16 to
+  // uint32, so an event that carries one has a different topic in each.
+  uint64 bps_scale = 12;
 }
 
 // Every ERC-6909 Transfer a router emitted in one block.

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/db_out.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/db_out.rs
@@ -55,6 +55,9 @@ pub fn db_out(
         if !ev.new_value.is_empty() {
             row.set("new_value", &ev.new_value);
         }
+        if ev.bps_scale != 0 {
+            row.set("bps_scale", ev.bps_scale);
+        }
     }
     for t in &vault.transfers {
         let id = format!("{}:{}:{}", t.chain, hex_addr(&t.tx_hash), t.log_index);

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/fee_config.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/fee_config.rs
@@ -40,7 +40,7 @@ pub fn map_fee_config_events(params: String, block: Block) -> Result<FeeConfigEv
             let is_router = params.router(&log.address).is_some();
             let decoded =
                 if is_router { decode_router_event(log) } else { decode_fee_calculator_event(log) };
-            let Some((event, client, old_value, new_value)) = decoded else {
+            let Some(decoded) = decoded else {
                 continue;
             };
             events.push(FeeConfigEvent {
@@ -51,17 +51,36 @@ pub fn map_fee_config_events(params: String, block: Block) -> Result<FeeConfigEv
                 log_index: log.index,
                 ordinal: log.ordinal,
                 emitter: log.address.clone(),
-                event: event.to_string(),
-                client,
-                old_value,
-                new_value,
+                event: decoded.event.to_string(),
+                client: decoded.client,
+                old_value: decoded.old_value,
+                new_value: decoded.new_value,
+                bps_scale: decoded.bps_scale.unwrap_or_default(),
             });
         }
     }
     Ok(FeeConfigEvents { events })
 }
 
-type Decoded = (&'static str, Vec<u8>, String, String);
+/// Bps denominators of the two FeeCalculator generations.
+const BPS_SCALE_UINT16: u64 = 10_000;
+const BPS_SCALE_UINT32: u64 = 100_000_000;
+
+/// One decoded fee-config event.
+struct Decoded {
+    event: &'static str,
+    client: Vec<u8>,
+    old_value: String,
+    new_value: String,
+    /// Denominator of the bps values the emitting calculator uses, when the event gives its
+    /// generation away.
+    ///
+    /// The two generations widened the bps arguments from `uint16` to `uint32`, so an event that
+    /// carries one has a different signature, and a different topic, in each. An event that
+    /// carries no bps value has the same signature in both and identifies nothing, and a router
+    /// event says nothing about a calculator at all; both leave this `None`.
+    bps_scale: Option<u64>,
+}
 
 /// Whether the log is one the fee-config decoders recognise, from any emitter.
 ///
@@ -72,93 +91,129 @@ pub(crate) fn is_fee_config_log(log: &Log) -> bool {
 }
 
 fn decode_router_event(log: &Log) -> Option<Decoded> {
+    // A router event names a calculator; it says nothing about that calculator's generation.
+    let rotation = |event, old_value, new_value| {
+        Some(Decoded { event, client: Vec::new(), old_value, new_value, bps_scale: None })
+    };
     if let Some(ev) = router_v3_1::FeeCalculatorActivated::match_and_decode(log) {
-        return Some((
+        return rotation(
             events::FEE_CALCULATOR_ACTIVATED,
-            Vec::new(),
             hex_addr(&ev.old_calculator),
             hex_addr(&ev.new_calculator),
-        ));
+        );
     }
     if let Some(ev) = router_v3_1::FeeCalculatorSet::match_and_decode(log) {
-        return Some((
+        return rotation(
             events::FEE_CALCULATOR_SET,
-            Vec::new(),
             ev.timelock_expires_at.to_string(),
             hex_addr(&ev.fee_calculator),
-        ));
+        );
     }
     if let Some(ev) = router_v3_0::FeeCalculatorUpdated::match_and_decode(log) {
-        return Some((
+        return rotation(
             events::FEE_CALCULATOR_UPDATED,
-            Vec::new(),
             hex_addr(&ev.old_calculator),
             hex_addr(&ev.new_calculator),
-        ));
+        );
     }
     None
 }
 
 fn decode_fee_calculator_event(log: &Log) -> Option<Decoded> {
+    // Both ABIs are tried because the argument width puts each generation's events on their
+    // own topics. That same difference is what names the denominator.
     macro_rules! bps_event {
-        ($ty:ty, $name:expr) => {
+        ($ty:ty, $name:expr, $scale:expr) => {
             if let Some(ev) = <$ty>::match_and_decode(log) {
-                return Some((
-                    $name,
-                    Vec::new(),
-                    ev.old_fee_bps.to_string(),
-                    ev.new_fee_bps.to_string(),
-                ));
+                return Some(Decoded {
+                    event: $name,
+                    client: Vec::new(),
+                    old_value: ev.old_fee_bps.to_string(),
+                    new_value: ev.new_fee_bps.to_string(),
+                    bps_scale: Some($scale),
+                });
             }
         };
     }
     macro_rules! custom_bps_event {
-        ($ty:ty, $name:expr) => {
+        ($ty:ty, $name:expr, $scale:expr) => {
             if let Some(ev) = <$ty>::match_and_decode(log) {
-                return Some((
-                    $name,
-                    ev.client,
-                    ev.old_fee_bps.to_string(),
-                    ev.new_fee_bps.to_string(),
-                ));
+                return Some(Decoded {
+                    event: $name,
+                    client: ev.client,
+                    old_value: ev.old_fee_bps.to_string(),
+                    new_value: ev.new_fee_bps.to_string(),
+                    bps_scale: Some($scale),
+                });
             }
         };
     }
+    // Carries no bps value, so it has one signature in both generations and names neither.
     macro_rules! removed_event {
         ($ty:ty, $name:expr) => {
             if let Some(ev) = <$ty>::match_and_decode(log) {
-                return Some(($name, ev.client, String::new(), String::new()));
+                return Some(Decoded {
+                    event: $name,
+                    client: ev.client,
+                    old_value: String::new(),
+                    new_value: String::new(),
+                    bps_scale: None,
+                });
             }
         };
     }
     macro_rules! receiver_event {
         ($ty:ty) => {
             if let Some(ev) = <$ty>::match_and_decode(log) {
-                return Some((
-                    events::ROUTER_FEE_RECEIVER_UPDATED,
-                    Vec::new(),
-                    hex_addr(&ev.old_receiver),
-                    hex_addr(&ev.new_receiver),
-                ));
+                return Some(Decoded {
+                    event: events::ROUTER_FEE_RECEIVER_UPDATED,
+                    client: Vec::new(),
+                    old_value: hex_addr(&ev.old_receiver),
+                    new_value: hex_addr(&ev.new_receiver),
+                    bps_scale: None,
+                });
             }
         };
     }
-    bps_event!(fc::RouterFeeOnOutputUpdated, events::ROUTER_FEE_ON_OUTPUT_UPDATED);
-    bps_event!(fc_v3_0::RouterFeeOnOutputUpdated, events::ROUTER_FEE_ON_OUTPUT_UPDATED);
-    bps_event!(fc::RouterFeeOnClientFeeUpdated, events::ROUTER_FEE_ON_CLIENT_FEE_UPDATED);
-    bps_event!(fc_v3_0::RouterFeeOnClientFeeUpdated, events::ROUTER_FEE_ON_CLIENT_FEE_UPDATED);
-    custom_bps_event!(fc::CustomRouterFeeOnOutputUpdated, events::CUSTOM_FEE_ON_OUTPUT_UPDATED);
+    bps_event!(
+        fc::RouterFeeOnOutputUpdated,
+        events::ROUTER_FEE_ON_OUTPUT_UPDATED,
+        BPS_SCALE_UINT32
+    );
+    bps_event!(
+        fc_v3_0::RouterFeeOnOutputUpdated,
+        events::ROUTER_FEE_ON_OUTPUT_UPDATED,
+        BPS_SCALE_UINT16
+    );
+    bps_event!(
+        fc::RouterFeeOnClientFeeUpdated,
+        events::ROUTER_FEE_ON_CLIENT_FEE_UPDATED,
+        BPS_SCALE_UINT32
+    );
+    bps_event!(
+        fc_v3_0::RouterFeeOnClientFeeUpdated,
+        events::ROUTER_FEE_ON_CLIENT_FEE_UPDATED,
+        BPS_SCALE_UINT16
+    );
+    custom_bps_event!(
+        fc::CustomRouterFeeOnOutputUpdated,
+        events::CUSTOM_FEE_ON_OUTPUT_UPDATED,
+        BPS_SCALE_UINT32
+    );
     custom_bps_event!(
         fc_v3_0::CustomRouterFeeOnOutputUpdated,
-        events::CUSTOM_FEE_ON_OUTPUT_UPDATED
+        events::CUSTOM_FEE_ON_OUTPUT_UPDATED,
+        BPS_SCALE_UINT16
     );
     custom_bps_event!(
         fc::CustomRouterFeeOnClientFeeUpdated,
-        events::CUSTOM_FEE_ON_CLIENT_FEE_UPDATED
+        events::CUSTOM_FEE_ON_CLIENT_FEE_UPDATED,
+        BPS_SCALE_UINT32
     );
     custom_bps_event!(
         fc_v3_0::CustomRouterFeeOnClientFeeUpdated,
-        events::CUSTOM_FEE_ON_CLIENT_FEE_UPDATED
+        events::CUSTOM_FEE_ON_CLIENT_FEE_UPDATED,
+        BPS_SCALE_UINT16
     );
     removed_event!(fc::CustomRouterFeeOnOutputRemoved, events::CUSTOM_FEE_ON_OUTPUT_REMOVED);
     removed_event!(fc_v3_0::CustomRouterFeeOnOutputRemoved, events::CUSTOM_FEE_ON_OUTPUT_REMOVED);
@@ -169,21 +224,24 @@ fn decode_fee_calculator_event(log: &Log) -> Option<Decoded> {
     );
     receiver_event!(fc::RouterFeeReceiverUpdated);
     receiver_event!(fc_v3_0::RouterFeeReceiverUpdated);
+    // Positive slippage arrived with the newer generation, so either event names it.
     if let Some(ev) = fc_exempt::PositiveSlippageExemptionSet::match_and_decode(log) {
-        return Some((
-            events::POSITIVE_SLIPPAGE_EXEMPTION_SET,
-            ev.client,
-            String::new(),
-            if ev.exempt { "1".to_string() } else { "0".to_string() },
-        ));
+        return Some(Decoded {
+            event: events::POSITIVE_SLIPPAGE_EXEMPTION_SET,
+            client: ev.client,
+            old_value: String::new(),
+            new_value: if ev.exempt { "1".to_string() } else { "0".to_string() },
+            bps_scale: Some(BPS_SCALE_UINT32),
+        });
     }
     if let Some(ev) = fc::PositiveSlippageToggled::match_and_decode(log) {
-        return Some((
-            events::POSITIVE_SLIPPAGE_TOGGLED,
-            Vec::new(),
-            String::new(),
-            if ev.enabled { "1".to_string() } else { "0".to_string() },
-        ));
+        return Some(Decoded {
+            event: events::POSITIVE_SLIPPAGE_TOGGLED,
+            client: Vec::new(),
+            old_value: String::new(),
+            new_value: if ev.enabled { "1".to_string() } else { "0".to_string() },
+            bps_scale: Some(BPS_SCALE_UINT32),
+        });
     }
     None
 }
@@ -192,10 +250,15 @@ fn decode_fee_calculator_event(log: &Log) -> Option<Decoded> {
 #[substreams::handlers::store]
 pub fn store_fee_config(events: FeeConfigEvents, store: StoreSetString) {
     for ev in &events.events {
-        match store_action(ev) {
-            StoreAction::Set { key, value } => store.set(ev.ordinal, key, &value),
-            StoreAction::DeletePrefix(key) => store.delete_prefix(ev.ordinal as i64, &key),
-            StoreAction::Ignore => {}
+        for action in scale_action(ev)
+            .into_iter()
+            .chain(std::iter::once(store_action(ev)))
+        {
+            match action {
+                StoreAction::Set { key, value } => store.set(ev.ordinal, key, &value),
+                StoreAction::DeletePrefix(key) => store.delete_prefix(ev.ordinal as i64, &key),
+                StoreAction::Ignore => {}
+            }
         }
     }
 }
@@ -205,6 +268,20 @@ enum StoreAction {
     Set { key: String, value: String },
     DeletePrefix(String),
     Ignore,
+}
+
+/// The scale an event gives away about its emitter, as a store write.
+///
+/// A router can be rotated onto a calculator of another generation, so the scale belongs to the
+/// calculator that emitted the event, not to the router that resolves to it.
+fn scale_action(ev: &FeeConfigEvent) -> Option<StoreAction> {
+    if ev.bps_scale == 0 {
+        return None;
+    }
+    Some(StoreAction::Set {
+        key: keys::fee_bps_scale(&ev.emitter),
+        value: ev.bps_scale.to_string(),
+    })
 }
 
 fn store_action(ev: &FeeConfigEvent) -> StoreAction {
@@ -278,6 +355,80 @@ mod tests {
         );
     }
 
+    /// keccak256("RouterFeeOnOutputUpdated(uint16,uint16)"), the first generation.
+    const FEE_ON_OUTPUT_UINT16: &str =
+        "050cb5c90bbab79023a902aac364bc8e45cca66341fa7800d99e2590f8c1e85d";
+    /// keccak256("RouterFeeOnOutputUpdated(uint32,uint32)"), the generation after it.
+    const FEE_ON_OUTPUT_UINT32: &str =
+        "c7592fa0fb5814aa63c60ac263038cefb86531a5d16bbf3c5e9ef59eb6087059";
+    /// keccak256("CustomRouterFeeOnOutputRemoved(address)"), which both generations share.
+    const CUSTOM_REMOVED: &str = "9dbcfb046701dc2252b780788e18747ee949d31085c2836c2332c1a067d5b0e2";
+
+    fn bps_log(topic: &str, old: u64, new: u64) -> Log {
+        let mut data = Vec::with_capacity(64);
+        for value in [old, new] {
+            data.extend_from_slice(&[0u8; 24]);
+            data.extend_from_slice(&value.to_be_bytes());
+        }
+        Log { topics: vec![hex::decode(topic).unwrap()], data, ..Default::default() }
+    }
+
+    /// The rate 0.1% as each generation writes it: 10 of 10000, then 100000 of 100000000. Both
+    /// numbers are what the deployed calculators really emitted.
+    #[test]
+    fn a_bps_event_names_the_generation_that_emitted_it() {
+        let first = decode_fee_calculator_event(&bps_log(FEE_ON_OUTPUT_UINT16, 0, 10)).unwrap();
+        assert_eq!(first.event, events::ROUTER_FEE_ON_OUTPUT_UPDATED);
+        assert_eq!(first.new_value, "10");
+        assert_eq!(first.bps_scale, Some(BPS_SCALE_UINT16));
+
+        let next = decode_fee_calculator_event(&bps_log(FEE_ON_OUTPUT_UINT32, 0, 100_000)).unwrap();
+        assert_eq!(next.event, events::ROUTER_FEE_ON_OUTPUT_UPDATED);
+        assert_eq!(next.new_value, "100000");
+        assert_eq!(next.bps_scale, Some(BPS_SCALE_UINT32));
+    }
+
+    #[test]
+    fn an_event_carrying_no_bps_names_no_generation() {
+        let mut client_topic = vec![0u8; 12];
+        client_topic.extend_from_slice(&[0xcc; 20]);
+        let log = Log {
+            topics: vec![hex::decode(CUSTOM_REMOVED).unwrap(), client_topic],
+            ..Default::default()
+        };
+        let decoded = decode_fee_calculator_event(&log).unwrap();
+        assert_eq!(decoded.event, events::CUSTOM_FEE_ON_OUTPUT_REMOVED);
+        assert_eq!(decoded.bps_scale, None);
+    }
+
+    #[test]
+    fn stores_the_scale_against_the_emitter() {
+        let mut ev = event(events::ROUTER_FEE_ON_OUTPUT_UPDATED);
+        ev.bps_scale = BPS_SCALE_UINT32;
+        assert_eq!(
+            scale_action(&ev),
+            Some(StoreAction::Set {
+                key: keys::fee_bps_scale(&[0xaa; 20]),
+                value: "100000000".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn stores_no_scale_for_an_event_that_names_none() {
+        assert_eq!(scale_action(&event(events::CUSTOM_FEE_ON_OUTPUT_REMOVED)), None);
+    }
+
+    /// The fallback for a calculator no observed event gives away is the generation the router
+    /// shipped with, and V2 has no calculator at all.
+    #[test]
+    fn a_router_generation_still_offers_a_default_scale() {
+        use crate::params::RouterVersion;
+        assert_eq!(RouterVersion::V2.default_bps_scale(), None);
+        assert_eq!(RouterVersion::V3_0.default_bps_scale(), Some(BPS_SCALE_UINT16));
+        assert_eq!(RouterVersion::V3_1.default_bps_scale(), Some(BPS_SCALE_UINT32));
+    }
+
     /// keccak256("PositiveSlippageExemptionSet(address,bool)").
     const EXEMPTION_TOPIC: &str =
         "a6baebb00b4a9c84cac5db0f46f5d661a368efaf0577353494dd33083ec5979a";
@@ -296,22 +447,19 @@ mod tests {
 
     #[test]
     fn decodes_positive_slippage_exemption() {
-        let decoded = decode_fee_calculator_event(&exemption_log([0xcc; 20], true));
-        assert_eq!(
-            decoded,
-            Some((
-                events::POSITIVE_SLIPPAGE_EXEMPTION_SET,
-                vec![0xcc; 20],
-                String::new(),
-                "1".to_string()
-            ))
-        );
+        let decoded = decode_fee_calculator_event(&exemption_log([0xcc; 20], true)).unwrap();
+        assert_eq!(decoded.event, events::POSITIVE_SLIPPAGE_EXEMPTION_SET);
+        assert_eq!(decoded.client, vec![0xcc; 20]);
+        assert_eq!(decoded.old_value, String::new());
+        assert_eq!(decoded.new_value, "1");
+        // Positive slippage only exists on the newer generation, so the event names its scale.
+        assert_eq!(decoded.bps_scale, Some(BPS_SCALE_UINT32));
     }
 
     #[test]
     fn decodes_positive_slippage_exemption_removal() {
         let decoded = decode_fee_calculator_event(&exemption_log([0xcc; 20], false));
-        assert_eq!(decoded.map(|d| d.3), Some("0".to_string()));
+        assert_eq!(decoded.map(|d| d.new_value), Some("0".to_string()));
     }
 
     #[test]

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/mod.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/mod.rs
@@ -30,6 +30,9 @@ pub(crate) mod keys {
     pub fn positive_slippage(fc: &[u8]) -> String {
         format!("fc:{}:pos_slip", hex::encode(fc))
     }
+    pub fn fee_bps_scale(fc: &[u8]) -> String {
+        format!("fc:{}:scale", hex::encode(fc))
+    }
     pub fn positive_slippage_exempt(fc: &[u8], client: &[u8]) -> String {
         format!("fc:{}:ps_exempt:{}", hex::encode(fc), hex::encode(client))
     }

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/modules/trades.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/modules/trades.rs
@@ -261,6 +261,16 @@ fn build_trade(
     })
 }
 
+/// The denominator the fee bps of a calculator are on.
+///
+/// The scale belongs to the calculator, not to the router that resolves to it: a router rotated
+/// onto a calculator of another generation reports bps on that generation's denominator. So an
+/// observed scale wins, and the generation the router shipped with is only the fallback for a
+/// calculator no observed event gives away.
+fn bps_scale(observed: Option<u64>, router: RouterVersion) -> Option<u64> {
+    observed.or_else(|| router.default_bps_scale())
+}
+
 /// Resolves the router fee configuration in effect at `ordinal`, applying per-client overrides
 /// the same way `FeeCalculator._resolveClient` does (zero client falls back to `tx.origin`).
 fn resolve_fee_config(
@@ -270,11 +280,17 @@ fn resolve_fee_config(
     tx_origin: &[u8],
     client: Option<&[u8]>,
 ) -> Option<RouterFeeConfig> {
-    let bps_scale = router.version.bps_scale()?;
+    if router.version == RouterVersion::V2 {
+        return None;
+    }
     let fee_calculator = store
         .get_at(ordinal, keys::router_fee_calculator(&router.address))
         .and_then(|v| hex::decode(v.trim_start_matches("0x")).ok())
         .or_else(|| router.fee_calculator.clone())?;
+    let observed_scale = store
+        .get_at(ordinal, keys::fee_bps_scale(&fee_calculator))
+        .and_then(|v| v.parse::<u64>().ok());
+    let bps_scale = bps_scale(observed_scale, router.version)?;
     let client = match client {
         Some(c) if c != ZERO_ADDRESS => c,
         _ => tx_origin,
@@ -313,4 +329,29 @@ fn resolve_fee_config(
         positive_slippage_exempt,
         bps_scale,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rotation this fixes: a v3_0 router pointed at a calculator of the next generation
+    /// reports its bps on 100000000, and reading 10000 off the router makes the rate 10000 times
+    /// too large.
+    #[test]
+    fn an_observed_scale_beats_the_router_generation() {
+        assert_eq!(bps_scale(Some(100_000_000), RouterVersion::V3_0), Some(100_000_000));
+        assert_eq!(bps_scale(Some(10_000), RouterVersion::V3_1), Some(10_000));
+    }
+
+    #[test]
+    fn without_one_the_router_generation_answers() {
+        assert_eq!(bps_scale(None, RouterVersion::V3_0), Some(10_000));
+        assert_eq!(bps_scale(None, RouterVersion::V3_1), Some(100_000_000));
+    }
+
+    #[test]
+    fn v2_has_no_scale_either_way() {
+        assert_eq!(bps_scale(None, RouterVersion::V2), None);
+    }
 }

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/params.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/params.rs
@@ -30,8 +30,13 @@ impl RouterVersion {
         }
     }
 
-    /// Denominator of the fee bps values stored in the FeeCalculator of this generation.
-    pub fn bps_scale(self) -> Option<u64> {
+    /// Denominator of the fee bps values of the FeeCalculator this router generation shipped
+    /// with, or `None` for a generation that has no FeeCalculator.
+    ///
+    /// A router can be rotated onto a calculator of another generation, which changes the
+    /// denominator without changing the router. This is only the fallback for a calculator whose
+    /// generation no observed event gives away; `keys::fee_bps_scale` holds the observed one.
+    pub fn default_bps_scale(self) -> Option<u64> {
         match self {
             RouterVersion::V2 => None,
             RouterVersion::V3_0 => Some(10_000),

--- a/crates/tycho-execution/substreams/tycho-router-trades/src/pb/tycho.router.v1.rs
+++ b/crates/tycho-execution/substreams/tycho-router-trades/src/pb/tycho.router.v1.rs
@@ -244,6 +244,11 @@ pub struct FeeConfigEvent {
     pub old_value: ::prost::alloc::string::String,
     #[prost(string, tag="11")]
     pub new_value: ::prost::alloc::string::String,
+    /// Denominator of the bps values this emitter uses, when the event gives its generation away;
+    /// 0 otherwise. The two FeeCalculator generations widened the bps arguments from uint16 to
+    /// uint32, so an event that carries one has a different topic in each.
+    #[prost(uint64, tag="12")]
+    pub bps_scale: u64,
 }
 /// Every ERC-6909 Transfer a router emitted in one block.
 ///


### PR DESCRIPTION
Stacked on #1411. Found while checking whether CoW settlements dodge positive slippage capture — they don't, but the fee columns on their trades were wrong.

## Why

`trades.router_fee_on_output_bps` is a raw number. It only means a rate together with `fee_bps_scale`, and the scale was taken from the **router** generation. It belongs to the **FeeCalculator**: the second generation widened the bps arguments from `uint16` to `uint32` and moved the denominator from 10,000 to 100,000,000, so the same 0.1% is written `10` on the first and `100000` on the second.

Five v3_0 routers are rotated onto a `uint32` calculator, so their trades carry a denominator 10,000× too small:

| chain | router | calculator | stored `bps` | stored `scale` | reads as | router actually took |
| --- | --- | --- | --- | --- | --- | --- |
| ethereum | `0xda892c98` | `0xc78e92de` | 1000 | 10,000 | **10%** | 0.1 bps |
| bsc | `0x99748cbd` | `0xb3408552` | 1000 | 10,000 | **10%** | 0.1 bps |
| polygon | `0x7cb3e870` | `0xcd8ebf80` | 1000 | 10,000 | **10%** | 0.1 bps |
| arbitrum | `0xc1f838a5` | `0x27e28f38` | 1000 | 10,000 | **10%** | 0.1 bps |
| unichain | `0x764bc67b` | `0xa8138d0a` | 1000 | 10,000 | **10%** | 0.1 bps |

**54,818 stored trades.** The routers still on their original calculator (ethereum `0x24ad1d4a`, unichain `0x957ea7a4`, and two with one trade each) are correct at 10,000.

Confirmed against the chain — the same rate, two generations, verified by topic:

```
0x24ad1d4a  RouterFeeOnOutputUpdated(uint16,uint16)  data 0x…000a    =     10 / 10,000      = 0.1%
0xc78e92de  RouterFeeOnOutputUpdated(uint32,uint32)  data 0x…186a0   = 100,000 / 100,000,000 = 0.1%
```

And measured end to end: for the `0x1f8db310` router (original calculator) `router_fee_amount / gross_amount_out` averages 9.98 bps against a configured 10 — right. For `0xda892c98` it averages 0.1 bps against a configured 10% — wrong by 10,000×.

## How

The two generations differ in argument width, so their events differ in signature and therefore in **topic**. The event that sets a bps value already tells you which denominator it is on — the decoders just threw that away.

- The decoded event now carries the denominator of the calculator that emitted it.
- `store_fee_config` keeps it under `fc:<calculator>:scale`, keyed by the emitter, so a rotation cannot move a scale onto the wrong calculator.
- A trade resolves the scale of the calculator it resolved to; the router generation is only the fallback. **All 14 calculators the stored trades resolve to emit such an event**, so the fallback is unused today.
- The V2 case is now an explicit early return. The old code relied on the missing scale as the gate, which is what tangled the two concerns in the first place.
- `fee_config_events.bps_scale` carries the same value per event, as the evidence for the stored one.

The 4-tuple the decoders returned became a named struct — a fifth positional field would have been unreadable.

## Tests

65 pass. New: a `uint16` and a `uint32` event decoded from their **real topics** with the values the deployed calculators really emitted (`10` and `100000`), an event carrying no bps identifying neither generation, the store write keyed by emitter, and the precedence itself (observed scale beats router generation).

Four mutations each fail the suite: router generation wins over the observed scale, the two denominators swapped, never store the observed scale, and the `uint16` ABI arm labelled `uint32`.

## Deployment

`router_fee_amount` was never affected — it comes from the `FeesTaken` event, not from the bps. Only the rate columns were wrong. Stored rows keep the wrong scale until the chain is re-indexed, which #1405 already requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmQJ8ED1jjCXzthvBGPo1