### PR TITLE
feat(router-trades): start each chain at its first v3 router

### DIFF
--- a/crates/tycho-execution/substreams/Cargo.lock
+++ b/crates/tycho-execution/substreams/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-router-trades"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/crates/tycho-execution/substreams/tycho-router-trades/Cargo.toml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tycho-router-trades"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/arbitrum.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/arbitrum.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/base.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/base.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:
@@ -21,7 +21,7 @@ binaries:
 modules:
   - name: index_router_activity
     kind: blockIndex
-    initialBlock: 30783770
+    initialBlock: 43834007
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:
@@ -29,7 +29,7 @@ modules:
 
   - name: map_fee_config_events
     kind: map
-    initialBlock: 30783770
+    initialBlock: 43834007
     blockFilter:
       module: index_router_activity
       query:
@@ -42,7 +42,7 @@ modules:
 
   - name: store_fee_config
     kind: store
-    initialBlock: 30783770
+    initialBlock: 43834007
     updatePolicy: set
     valueType: string
     inputs:
@@ -50,7 +50,7 @@ modules:
 
   - name: map_trades
     kind: map
-    initialBlock: 30783770
+    initialBlock: 43834007
     blockFilter:
       module: index_router_activity
       query:
@@ -64,7 +64,7 @@ modules:
 
   - name: map_vault_transfers
     kind: map
-    initialBlock: 30783770
+    initialBlock: 43834007
     blockFilter:
       module: index_router_activity
       query:
@@ -77,7 +77,7 @@ modules:
 
   - name: db_out
     kind: map
-    initialBlock: 30783770
+    initialBlock: 43834007
     inputs:
       - map: map_trades
       - map: map_fee_config_events

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/bsc.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/ethereum.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/ethereum.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:
@@ -21,7 +21,7 @@ binaries:
 modules:
   - name: index_router_activity
     kind: blockIndex
-    initialBlock: 22575004
+    initialBlock: 24735864
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:
@@ -29,7 +29,7 @@ modules:
 
   - name: map_fee_config_events
     kind: map
-    initialBlock: 22575004
+    initialBlock: 24735864
     blockFilter:
       module: index_router_activity
       query:
@@ -42,7 +42,7 @@ modules:
 
   - name: store_fee_config
     kind: store
-    initialBlock: 22575004
+    initialBlock: 24735864
     updatePolicy: set
     valueType: string
     inputs:
@@ -50,7 +50,7 @@ modules:
 
   - name: map_trades
     kind: map
-    initialBlock: 22575004
+    initialBlock: 24735864
     blockFilter:
       module: index_router_activity
       query:
@@ -64,7 +64,7 @@ modules:
 
   - name: map_vault_transfers
     kind: map
-    initialBlock: 22575004
+    initialBlock: 24735864
     blockFilter:
       module: index_router_activity
       query:
@@ -77,7 +77,7 @@ modules:
 
   - name: db_out
     kind: map
-    initialBlock: 22575004
+    initialBlock: 24735864
     inputs:
       - map: map_trades
       - map: map_fee_config_events

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/plasma.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/plasma.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/polygon.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/polygon.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/robinhood.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:

--- a/crates/tycho-execution/substreams/tycho-router-trades/chains/unichain.yaml
+++ b/crates/tycho-execution/substreams/tycho-router-trades/chains/unichain.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: tycho_router_trades
-  version: v0.2.0
+  version: v0.3.0
   url: https://github.com/propeller-heads/tycho/tree/main/crates/tycho-execution/substreams
 
 imports:
@@ -21,7 +21,7 @@ binaries:
 modules:
   - name: index_router_activity
     kind: blockIndex
-    initialBlock: 16000000
+    initialBlock: 43709003
     inputs:
       - source: sf.ethereum.type.v2.Block
     output:
@@ -29,7 +29,7 @@ modules:
 
   - name: map_fee_config_events
     kind: map
-    initialBlock: 16000000
+    initialBlock: 43709003
     blockFilter:
       module: index_router_activity
       query:
@@ -42,7 +42,7 @@ modules:
 
   - name: store_fee_config
     kind: store
-    initialBlock: 16000000
+    initialBlock: 43709003
     updatePolicy: set
     valueType: string
     inputs:
@@ -50,7 +50,7 @@ modules:
 
   - name: map_trades
     kind: map
-    initialBlock: 16000000
+    initialBlock: 43709003
     blockFilter:
       module: index_router_activity
       query:
@@ -64,7 +64,7 @@ modules:
 
   - name: map_vault_transfers
     kind: map
-    initialBlock: 16000000
+    initialBlock: 43709003
     blockFilter:
       module: index_router_activity
       query:
@@ -77,7 +77,7 @@ modules:
 
   - name: db_out
     kind: map
-    initialBlock: 16000000
+    initialBlock: 43709003
     inputs:
       - map: map_trades
       - map: map_fee_config_events


### PR DESCRIPTION
Cuts the backfill roughly in half on three chains by skipping the era before any v3 router existed. Nothing else changes, and no v3 data is lost.

## Why

The earliest router on ethereum, unichain and base is a **v2** deployment; the v3 routers came months later. So the sink walks millions of blocks that can only hold v2 trades:

| chain | initialBlock | first v3 router | blocks skipped | share of the range |
| --- | --- | --- | --- | --- |
| ethereum | 22,575,004 | **24,735,864** | 2,160,860 | 64.8% |
| unichain | 16,000,000 | **43,709,003** | 27,709,003 | 66.3% |
| base | 30,783,770 | **43,834,007** | 13,050,237 | 64.9% |

Base is the one that hurts. It spent a day and a half of backfill inside that range and still hadn't reached the v3 era — its newest stored trade is dated 2026-01-29, below the new start block.

arbitrum, bsc, polygon and robinhood are untouched: their earliest router is already a v3 one, so their `initialBlock` doesn't move.

## What is lost

**No v3 data, by construction.** Of the 84,767 stored trades below the new start blocks, every single one is v2:

| chain | dropped | of which v3 | kept |
| --- | --- | --- | --- |
| base | 50,847 | **0** | 0 |
| ethereum | 23,288 | **0** | 109,148 |
| unichain | 10,632 | **0** | 1,504 |

The **v2 routers stay in the params**, so a v2 trade above the new start block is still indexed — only the era below it goes.

## The trap this could have sprung

`map_fee_config_events` builds `store_fee_config`, which every trade reads to resolve its fee rate. If a config event sat below the new start block, trades would resolve their bps against an empty store.

Three do — and all three are `RouterFeeReceiverUpdated`:

```
ethereum 24693010  0xa32ff629…  RouterFeeReceiverUpdated
ethereum 24698766  0xbbd729e9…  RouterFeeReceiverUpdated
unichain 43262143  0x4df554ae…  RouterFeeReceiverUpdated
```

`store_action` maps that event to `StoreAction::Ignore`, so it writes nothing to the store. No store state is lost and no trade resolves its fee differently — only three audit rows in `fee_config_events`. base has no fee-config events at all below its new block.

That is why every module in these manifests moves together rather than splitting the index and the fee modules across two start blocks.

## How the blocks were found

Bisected `eth_getCode` for the earliest v3 router on each chain, and checked the block before it is empty:

```
base      43834006=empty  43834007=code
ethereum  24735863=empty  24735864=code
unichain  43709002=empty  43709003=code
```

Confirmed in the packed spkg that `map_trades` carries the new value.

## Release

Bumped to **0.3.0**. This supersedes 0.2.0, which was released an hour ago but not yet pinned — the sinks are down on a missing `SPKG` (helm-configuration#1026), so pinning 0.3.0 straight away avoids starting a base backfill that would immediately be thrown away.

`plasma` keeps its `initialBlock`: no RPC to bisect against, and it is not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmQJ8ED1jjCXzthvBGPo1