### PR TITLE
fix: treat a zero hook address as no hook on uniswap v4 pools

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
@@ -122,10 +122,15 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
             })
             .collect();
 
+        // A pool with no hook still carries the attribute, set to the zero address, so
+        // presence alone does not mean a hook is installed. Reading it that way gives
+        // every hookless pool a hook handler bound to `address(0)`, and `spot_price`
+        // delegates to it unconditionally — the CLMM formula is then never used.
         let hook_address = snapshot
             .component
             .static_attributes
-            .get("hooks");
+            .get("hooks")
+            .filter(|address| address.iter().any(|byte| *byte != 0));
 
         let mut ticks = match ticks {
             Ok(ticks) if !ticks.is_empty() => ticks
@@ -284,6 +289,65 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, expected);
+    }
+
+    /// A hookless pool carries `hooks` set to the zero address, which is how the indexer
+    /// reports "no hook" rather than omitting the attribute. Decoding it must leave the
+    /// state without a hook handler, so `spot_price` keeps using the CLMM formula, and
+    /// must still reject a snapshot that carries no tick liquidities.
+    #[tokio::test]
+    async fn test_usv4_zero_hook_address_is_no_hook() {
+        let mut component = usv4_component();
+        component
+            .static_attributes
+            .insert("hooks".to_string(), Bytes::from([0u8; 20].to_vec()));
+
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes: usv4_attributes(),
+                balances: HashMap::new(),
+            },
+            component: component.clone(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let result = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .unwrap();
+
+        let fees = UniswapV4Fees::new(0, 0, 500);
+        let expected = UniswapV4State::new(
+            100,
+            U256::from(79228162514264337593543950336_u128),
+            fees,
+            300,
+            60,
+            vec![TickInfo::new(60, 400).unwrap()],
+        )
+        .unwrap();
+        assert_eq!(result, expected);
+
+        let mut attributes = usv4_attributes();
+        attributes.remove("ticks/60/net_liquidity");
+        let without_ticks = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component,
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let result = try_decode_snapshot_with_defaults::<UniswapV4State>(without_ticks).await;
+
+        assert!(matches!(
+            result.err().unwrap(),
+            InvalidSnapshotError::MissingAttribute(attr) if attr == "tick_liquidities"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`UniswapV4State`'s decoder reads the `hooks` static attribute for *presence*:

```rust
let hook_address = snapshot.component.static_attributes.get("hooks");
```

The indexer sets that attribute on every UniswapV4 component and uses the **zero address** to mean "no hook", so `is_some()` is true for a hookless pool. Live component from `tycho-base-beta`, a plain FOMO/USDC pool on Base:

```json
{
  "id": "0xb062ff162c89e387608de7755f7787c0061487a5a15a45c016f9dd8b7471d5ef",
  "static_attributes": {
    "hooks": "0x0000000000000000000000000000000000000000",
    "tick_spacing": "0x1770",
    "key_lp_fee": "0x0927c0",
    "pool_id": "0xb062ff162c89e387608de7755f7787c0061487a5a15a45c016f9dd8b7471d5ef"
  }
}
```

Two things follow.

**A snapshot with no tick liquidities is accepted instead of rejected.** The branch right below reads `if hook_address.is_some() { Vec::new() } else { return Err(MissingAttribute("tick_liquidities")) }`, and the `else` is unreachable in practice — a pool whose liquidity is genuinely hook-managed is indistinguishable from one whose ticks failed to decode.

**Every hookless pool gets a generic VM hook handler bound to `address(0)`.** `instantiate_hook_handler` finds no creator registered for the zero address and falls through to `DEFAULT_HANDLER`, the `GenericVMHookHandlerCreator`. `UniswapV4State::spot_price` then delegates to that handler *unconditionally*:

```rust
fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
    if let Some(hook) = &self.hook {
        match hook.spot_price(base, quote) {
```

unlike the swap path, which gates hook calls behind `has_permission(hook.address(), …)` and so skips them for the zero address. A vanilla pool's spot price is therefore produced by simulating a contract with no code, and only reaches the CLMM formula if that simulation happens to return `RecoverableError` and the numeric-derivative fallback runs.

## How it was found, and what it did not explain

Chasing a mispricing in a downstream consumer: on Base its USD reference token came out 34,288× off market, which pointed here because the consumer's mid-prices are built from `spot_price` while its per-token native prices, which are not, stayed correct to 0.3%.

For the record, this was **not** the cause. Building that consumer against a 0.371.1 tree carrying only this patch and re-measuring against a warm indexer reproduced the wrong prices unchanged, so the fault there lies in the consumer's own mid-path selection. Filing anyway because the code is wrong on its own terms: nothing intends every hookless V4 pool to be priced by a VM simulation of the zero address, and nothing intends the `MissingAttribute` branch to be dead.

## The change

Filter the attribute on "not all zero", so the zero address reads as no hook:

```rust
.get("hooks")
.filter(|address| address.iter().any(|byte| *byte != 0));
```

## Test

`test_usv4_zero_hook_address_is_no_hook` covers the pair the fix restores: a component whose `hooks` attribute is the zero address decodes to the same state as one with no attribute at all, and a snapshot with no tick liquidities is still refused. It fails on `main` — the decode panics at the `unwrap`, because the phantom hook handler cannot be built without an RPC — and passes with the fix.

`cargo test -p tycho-simulation --lib evm::protocol::uniswap_v4::decoder` → 9 passed. The four pre-existing failures in `uniswap_v4::hooks::generic_vm_hook_handler` need `RPC_URL` and fail on a clean tree too.
