### PR TITLE
feat(integration-test): wire up Robinhood Chain protocols

### DIFF
--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -266,6 +266,16 @@ impl ProtocolStreamProcessor {
                     "ramses_v3".to_string(),
                 ]
             }
+            Chain::Robinhood => {
+                vec![
+                    "uniswap_v2".to_string(),
+                    "uniswap_v3".to_string(),
+                    "uniswap_v4".to_string(),
+                    "sushiswap_v3".to_string(),
+                    "robinswap_v3".to_string(),
+                    "ramses_v3".to_string(),
+                ]
+            }
             Chain::Arbitrum => {
                 vec![
                     "uniswap_v2".to_string(),
@@ -302,6 +312,14 @@ impl ProtocolStreamProcessor {
             }
             "uniswap_v3" => {
                 stream = stream.exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None);
+            }
+            "sushiswap_v3" => {
+                stream =
+                    stream.exchange::<UniswapV3State>("sushiswap_v3", tvl_filter.clone(), None);
+            }
+            "robinswap_v3" => {
+                stream =
+                    stream.exchange::<UniswapV3State>("robinswap_v3", tvl_filter.clone(), None);
             }
             "pancakeswap_v3" => {
                 stream =


### PR DESCRIPTION
## What

`tycho-integration-test` could not run the Robinhood Chain protocols:

- `add_protocol_to_stream` had no arm for `sushiswap_v3` or `robinswap_v3`, so passing either to `--protocols` returned `Unknown protocol`. Both are Uniswap V3 forks indexed via the `ethereum-uniswap-v3-logs-only` substreams package, so they map to `UniswapV3State` — the same wiring `crates/tycho-simulation/examples/quickstart/main.rs` already uses.
- `get_default_protocols_for_chain` had no `Chain::Robinhood` arm, so the chain fell through to `_ => vec![]`.

This adds the two match arms and a `Chain::Robinhood` default list covering the six protocol systems the Robinhood instance serves: `uniswap_v2`, `uniswap_v3`, `uniswap_v4`, `sushiswap_v3`, `robinswap_v3`, `ramses_v3`. All six already have executors in `crates/tycho-execution/config/executor_addresses.json`, and `swap_encoder_registry.rs` already groups `sushiswap_v3 | robinswap_v3` with `uniswap_v3`.

## Results

Against `tycho-robinhood-dev.propellerheads.xyz`, 20 sampled blocks per run, `--test-every-n-blocks 50`:

| Protocol | Pools | get_limits | get_amount_out | Reverted | Slippage |
|---|---|---|---|---|---|
| `ramses_v3` | 7 (TVL ≥ 100 ETH) | 280 / 0 | 280 / 0 | 0 | avg −0.0014%, min −0.07% |
| `sushiswap_v3` | 3 (TVL ≥ 100 ETH) | 120 / 0 | 120 / 0 | 0 | avg −0.0005%, min −0.04% |
| `robinswap_v3` | 2 (TVL ≥ 2 ETH) | 80 / 0 | 80 / 0 | 0 | 0.0000% (72/72 executions) |

`robinswap_v3` needs `--tvl-threshold` lowered to appear at all — its largest pool holds 5.86 ETH, and only 3 of its 31 pools hold more than 1 ETH, so nothing clears the 100 ETH default.

`uniswap_v2`, `uniswap_v3` and `uniswap_v4` are in the default list because the Robinhood instance serves them and they already have both a match arm and an executor. Their pricing and execution were not measured in these runs.

## Notes for reviewers

Two environment findings, neither addressed here:

1. **Runs on Robinhood require `--test-every-n-blocks`.** The chain produces roughly 11 blocks per second (measured: 57 blocks in 5 s). The default mode requires `rpc_latest == update_block` before it will call `debug_traceCall`, and the consumer cannot hold that alignment — a run without sampling skipped all 356 updates as stale, ran zero simulations, and drifted from 8 to 575 blocks behind while logging `tycho_client::deltas: Buffer full, unsubscribing!`. Note also that `Chain::Robinhood::block_time_secs()` returns `1`, about an order of magnitude off the measured rate.

2. **Execution validation is bottlenecked by the RPC, not by these protocols.** All observed failures were `Setup Failures` carrying `Couldn't find storage slots for token …`, and they arrive per block in all-or-nothing batches. `RPCTools` sets `with_max_token_batch_size(5)`, so each chunk is one HTTP batch of 10 `debug_traceCall`/`eth_call` requests against a 30 s client timeout; a `TimedOut` transport error is classified non-retryable, so the chunk dies without a retry and every token in it loses its slots. The same config produced 87.5% success on one run and 0% on a later one as the endpoint degraded under repeated runs, so the failure rate tracks the endpoint's state rather than anything protocol-specific. Reproducing the execution leg reliably needs an endpoint that can serve batched `debug_traceCall`.

Separately, slot detection always queries `BlockId::latest()` while sampled mode tests an older block number — harmless for slot layout, but inconsistent with the intent of `--test-every-n-blocks`.

## Testing

`cargo +nightly fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean. The test suite was not run for this change.

Reproduce:

```bash
TYCHO_URL=tycho-robinhood-dev.propellerheads.xyz RPC_URL=$RPC_ROBINHOOD \
  cargo run --release -p tycho-integration-test -- \
  --chain robinhood --disable-rfq --disable-price-level-stream \
  --test-every-n-blocks 50 --max-blocks 20
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)