### PR TITLE
fix(indexer): recover from a silent substreams endpoint

### DIFF
--- a/crates/tycho-indexer/CLAUDE.md
+++ b/crates/tycho-indexer/CLAUDE.md
@@ -104,8 +104,10 @@ On `BlockUndoSignal(target_hash, target_number)` from Substreams:
    purges from that height inclusive (stale copy). A hash miss is fatal when the
    target is below the buffer, at the buffer's oldest block (no predecessor left to
    anchor the revert), or above the buffer without a pending partial at exactly that height
-   (the flashblocks case — the only legitimate target-ahead shape). Nonfatal hash-miss
-   fallbacks log a warning and increment `extractor_revert_hash_miss`.
+   (the flashblocks case — the only legitimate target-ahead shape). The one unanchorable
+   target that is not fatal is the buffer's own last applied revert target, replayed by an
+   endpoint that resumed from a pre-reorg cursor: that purge already happened. Nonfatal
+   hash-miss fallbacks log a warning and increment `extractor_revert_hash_miss`.
 2. Pending partials are dropped only when above the target height; partials at the target
    height are the still-valid prefix of the last valid block and are kept.
 3. Previous attribute values are restored from the buffer, then the DB. The buffer keeps

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1210,6 +1210,20 @@ where
                 .increment(1);
                 purged
             }
+            PurgeOutcome::AlreadyApplied => {
+                warn!(
+                    target_number = block_ref.number,
+                    "Revert target already purged by an earlier revert; nothing left to purge"
+                );
+                counter!(
+                    "extractor_revert_hash_miss",
+                    "extractor" => self.name.clone(),
+                    "chain" => self.chain.to_string(),
+                    "resolution" => "already_applied",
+                )
+                .increment(1);
+                Vec::new()
+            }
             PurgeOutcome::TargetAhead => {
                 // A target above the sealed buffer is only legitimate when it names the
                 // block currently streaming as partials (flashblocks). Anything else

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -70,6 +70,9 @@ where
     block_messages: VecDeque<B>,
     committing_blocks: VecDeque<Arc<B>>,
     strict: bool,
+    /// Target of the last revert this buffer applied, kept after the target itself has been
+    /// drained so a replay of that same revert can be told apart from a reorg past finality.
+    last_revert_target: Option<Bytes>,
 }
 
 /// Result of a height-aware purge. Hash match is authoritative; height is a fallback.
@@ -83,6 +86,9 @@ pub(crate) enum PurgeOutcome<B> {
     /// Hash not found and the target height is above the newest buffered block (or the
     /// buffer is empty). Nothing sealed is invalid; nothing purged.
     TargetAhead,
+    /// Hash not found because this buffer already purged to that target and has since moved
+    /// past it. The invalidated blocks are long gone; nothing purged.
+    AlreadyApplied,
 }
 
 /// The commitment status of a block or block-scoped data with the DB.
@@ -101,7 +107,12 @@ where
     B: BlockScoped + std::fmt::Debug + DeepSizeOf,
 {
     pub(crate) fn new() -> Self {
-        Self { block_messages: VecDeque::new(), committing_blocks: VecDeque::new(), strict: false }
+        Self {
+            block_messages: VecDeque::new(),
+            committing_blocks: VecDeque::new(),
+            strict: false,
+            last_revert_target: None,
+        }
     }
 
     /// Inserts a new block into the buffer. Ensures the new block is the expected next block,
@@ -264,6 +275,7 @@ where
                 .split_off(idx + 1)
                 .into();
             trace!(?purged, "ReorgBuffer purged blocks");
+            self.last_revert_target = Some(target_hash.clone());
             return Ok(PurgeOutcome::HashMatch(purged));
         }
 
@@ -282,9 +294,18 @@ where
 
         // A height match needs an in-buffer predecessor (idx >= 1) to anchor the revert
         // message. Otherwise the target is at or below the oldest buffered block — a reorg
-        // past the revertable window, which is fatal.
+        // past the revertable window, which is fatal unless we already applied this very
+        // revert.
         let idx = self.find_index(|b| b.block().number == target_number);
         let Some(idx) = idx.filter(|&i| i > 0) else {
+            // An endpoint that replays history after a reconnect re-sends the undo signal it
+            // already sent, and by then the target has aged out of the buffer. The purge it
+            // asks for happened, so repeating it is a no-op rather than a data loss: the
+            // blocks that followed the target were re-delivered and re-buffered after the
+            // first purge.
+            if self.last_revert_target.as_ref() == Some(target_hash) {
+                return Ok(PurgeOutcome::AlreadyApplied);
+            }
             error!(
                 ?target_hash,
                 target_number,
@@ -298,6 +319,7 @@ where
             .split_off(idx)
             .into();
         trace!(?purged, "ReorgBuffer purged blocks from stale height");
+        self.last_revert_target = Some(target_hash.clone());
         Ok(PurgeOutcome::HeightMatch(purged))
     }
 
@@ -1256,6 +1278,53 @@ mod test {
 
         assert!(matches!(result, Err(StorageError::NotFound(_, _))));
         assert_eq!(reorg_buffer.block_messages.len(), 3, "a fatal miss must not mutate");
+    }
+
+    /// Purges to block 2, then moves the buffer past it: block 2 is the last applied revert
+    /// target and is no longer buffered.
+    fn buffer_past_applied_revert() -> (ReorgBuffer<BlockChanges>, Bytes) {
+        let mut reorg_buffer = filled_buffer();
+        let target =
+            Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+
+        reorg_buffer
+            .purge_to(&target, 2)
+            .expect("the target is buffered, so the first revert applies");
+        reorg_buffer
+            .insert_block(get_block_changes(3))
+            .unwrap();
+        reorg_buffer
+            .drain_blocks_until(3)
+            .unwrap();
+
+        (reorg_buffer, target)
+    }
+
+    #[test]
+    fn test_purge_to_replayed_target_is_already_applied() {
+        // An endpoint that replays history after a reconnect re-sends an undo signal whose
+        // target has since aged out of the buffer.
+        let (mut reorg_buffer, target) = buffer_past_applied_revert();
+
+        let outcome = reorg_buffer
+            .purge_to(&target, 2)
+            .expect("a replay of an applied revert is a no-op, not a reorg past finality");
+
+        assert!(matches!(outcome, PurgeOutcome::AlreadyApplied));
+        assert_eq!(reorg_buffer.block_messages.len(), 1, "a replayed revert must not mutate");
+    }
+
+    #[test]
+    fn test_purge_to_stale_target_other_than_the_last_revert_errors() {
+        // Only the target we purged to is safe to skip; any other unanchorable target is
+        // still a reorg past the revertable window.
+        let (mut reorg_buffer, _) = buffer_past_applied_revert();
+
+        let result = reorg_buffer.purge_to(&unknown_hash(), 2);
+
+        assert!(matches!(result, Err(StorageError::NotFound(_, _))));
+        assert_eq!(reorg_buffer.block_messages.len(), 1, "a fatal miss must not mutate");
     }
 
     #[test]

--- a/crates/tycho-indexer/src/substreams/mock.rs
+++ b/crates/tycho-indexer/src/substreams/mock.rs
@@ -41,6 +41,8 @@ pub enum MockResponse {
     Unauthenticated,
     /// One `BlockScopedData` carrying `cursor`, then `grpc-status: 16` trailers.
     BlockThenUnauthenticated { cursor: String },
+    /// One `BlockScopedData` carrying `cursor`, then silence with the stream left open.
+    BlockThenStall { cursor: String },
 }
 
 /// Response body that emits one gRPC data frame and then error trailers.
@@ -71,6 +73,36 @@ impl HttpBody for DataThenTrailers {
         let mut trailers = HeaderMap::new();
         trailers.insert("grpc-status", HeaderValue::from_static(self.grpc_status));
         Poll::Ready(Ok(Some(trailers)))
+    }
+}
+
+/// Response body that emits one gRPC data frame and then never resolves.
+///
+/// Models an endpoint that stops writing without closing the stream: the client keeps a
+/// healthy-looking connection that will never produce another message.
+struct DataThenStall {
+    data: Option<Bytes>,
+}
+
+impl HttpBody for DataThenStall {
+    type Data = Bytes;
+    type Error = Status;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        match self.get_mut().data.take() {
+            Some(data) => Poll::Ready(Some(Ok(data))),
+            None => Poll::Pending,
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Pending
     }
 }
 
@@ -164,6 +196,15 @@ impl tonic::codegen::Service<http::Request<tonic::transport::Body>> for MockSubs
                         data: Some(grpc_frame(&block)),
                         grpc_status: GRPC_STATUS_UNAUTHENTICATED,
                     }))
+                }
+                MockResponse::BlockThenStall { cursor } => {
+                    let block = Response {
+                        message: Some(ResponseMessage::BlockScopedData(BlockScopedData {
+                            cursor,
+                            ..Default::default()
+                        })),
+                    };
+                    builder.body(BoxBody::new(DataThenStall { data: Some(grpc_frame(&block)) }))
                 }
             };
 

--- a/crates/tycho-indexer/src/substreams/stream.rs
+++ b/crates/tycho-indexer/src/substreams/stream.rs
@@ -11,7 +11,7 @@ use futures03::{Stream, StreamExt};
 use metrics::{counter, gauge};
 use once_cell::sync::Lazy;
 use prost::Message as ProstMessage;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 use tokio_retry::strategy::ExponentialBackoff;
 use tracing::{error, info, trace, warn};
 
@@ -50,6 +50,33 @@ impl SubstreamsStream {
         extractor_id: String,
         partial_blocks: bool,
     ) -> Self {
+        Self::with_idle_timeout(
+            endpoint,
+            cursor,
+            package,
+            output_module_name,
+            start_block,
+            end_block,
+            final_blocks_only,
+            extractor_id,
+            partial_blocks,
+            STREAM_IDLE_TIMEOUT,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn with_idle_timeout(
+        endpoint: Arc<SubstreamsEndpoint>,
+        cursor: Option<String>,
+        package: Option<Package>,
+        output_module_name: String,
+        start_block: i64,
+        end_block: u64,
+        final_blocks_only: bool,
+        extractor_id: String,
+        partial_blocks: bool,
+        idle_timeout: Duration,
+    ) -> Self {
         SubstreamsStream {
             stream: Box::pin(stream_blocks(
                 endpoint,
@@ -61,10 +88,20 @@ impl SubstreamsStream {
                 final_blocks_only,
                 extractor_id,
                 partial_blocks,
+                idle_timeout,
             )),
         }
     }
 }
+
+/// Longest silence tolerated from the endpoint before the connection is dropped and redialled.
+///
+/// A live stream sends a progress message every `progress_messages_interval_ms` (30s), so any
+/// healthy connection speaks at least that often regardless of block time or backfill state.
+/// Waiting for the transport to notice instead can take minutes: a gRPC stream whose server
+/// stopped writing without closing surfaces no error until a keepalive or the peer's TCP stack
+/// gives up, and until then the extractor sits in `substreams.next()` with a stale head.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 static DEFAULT_BACKOFF: Lazy<ExponentialBackoff> =
     Lazy::new(|| ExponentialBackoff::from_millis(500).max_delay(Duration::from_secs(45)));
@@ -118,6 +155,7 @@ fn stream_blocks(
     final_blocks_only: bool,
     extractor_id: String,
     partial_blocks: bool,
+    idle_timeout: Duration,
 ) -> impl Stream<Item = Result<BlockResponse, Error>> {
     let mut latest_cursor = cursor.unwrap_or_default();
     let mut latest_block = start_block_num as u64;
@@ -156,7 +194,19 @@ fn stream_blocks(
 
             match result {
                 Ok(stream) => {
-                    for await response in stream {
+                    let mut stream = Box::pin(stream);
+                    loop {
+                        let response = match timeout(idle_timeout, stream.next()).await {
+                            Ok(Some(response)) => response,
+                            Ok(None) => break,
+                            Err(_) => {
+                                warn!(?idle_timeout, "Endpoint went silent, reconnecting");
+                                counter!("substreams_failure", "extractor" => extractor_id.clone(), "cause" => "idle_timeout").increment(1);
+                                wait_for_next_retry(&mut backoff, &mut retry_count, &extractor_id).await?;
+                                continue 'retry_loop;
+                            }
+                        };
+
                         match process_substreams_response(response).await {
                             BlockProcessedResult::BlockScopedData(block_scoped_data) => {
                                 if let Some(block) = block_scoped_data.clock.clone() {
@@ -362,11 +412,18 @@ mod tests {
     use crate::substreams::mock::{start_scripted_mock_substreams, MockResponse};
 
     async fn stream_against(script: Vec<MockResponse>) -> (SubstreamsStream, MockRequests) {
+        stream_against_with_idle_timeout(script, STREAM_IDLE_TIMEOUT).await
+    }
+
+    async fn stream_against_with_idle_timeout(
+        script: Vec<MockResponse>,
+        idle_timeout: Duration,
+    ) -> (SubstreamsStream, MockRequests) {
         let (captured, addr) = start_scripted_mock_substreams(script).await;
         let endpoint = SubstreamsEndpoint::new(format!("http://{addr}"), Some("token".to_string()))
             .await
             .expect("endpoint");
-        let stream = SubstreamsStream::new(
+        let stream = SubstreamsStream::with_idle_timeout(
             Arc::new(endpoint),
             None,
             None,
@@ -376,6 +433,7 @@ mod tests {
             false,
             "test_extractor".to_string(),
             false,
+            idle_timeout,
         );
         (stream, captured)
     }
@@ -426,6 +484,36 @@ mod tests {
 
         let requests = captured.lock().unwrap();
         assert_eq!(requests.len(), 2, "the stream should have reconnected once");
+        assert_eq!(
+            requests[1].start_cursor, "cursor-1",
+            "the reconnect should resume from the last cursor"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_silent_endpoint_reconnects_from_last_cursor() {
+        let (mut stream, captured) = stream_against_with_idle_timeout(
+            vec![MockResponse::BlockThenStall { cursor: "cursor-1".to_string() }, MockResponse::Ok],
+            Duration::from_millis(100),
+        )
+        .await;
+
+        let block = stream
+            .next()
+            .await
+            .expect("stream should yield a block")
+            .expect("first block should not error");
+        assert!(matches!(block, BlockResponse::New(_)));
+
+        let ended = stream
+            .next()
+            .await
+            .expect("stream should yield an item")
+            .expect("a silent endpoint must be reconnected, not surfaced as an error");
+        assert!(matches!(ended, BlockResponse::Ended));
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2, "the silent stream should have been redialled once");
         assert_eq!(
             requests[1].start_cursor, "cursor-1",
             "the reconnect should resume from the last cursor"

--- a/crates/tycho-indexer/src/substreams/stream.rs
+++ b/crates/tycho-indexer/src/substreams/stream.rs
@@ -103,11 +103,20 @@ impl SubstreamsStream {
 /// gives up, and until then the extractor sits in `substreams.next()` with a stale head.
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-static DEFAULT_BACKOFF: Lazy<ExponentialBackoff> =
-    Lazy::new(|| ExponentialBackoff::from_millis(500).max_delay(Duration::from_secs(45)));
+/// Delay between reconnect attempts: 1s, 2s, 4s, ... capped at 45s. Reset by any message
+/// from the endpoint.
+///
+/// The ramp matters because most reconnects follow a transient rejection — an endpoint
+/// shutting down a node, a broken pipe mid-stream — and clear on the next attempt. A ladder
+/// that reaches its cap in one step makes the common case wait the worst case out.
+static DEFAULT_BACKOFF: Lazy<ExponentialBackoff> = Lazy::new(|| {
+    ExponentialBackoff::from_millis(2)
+        .factor(500)
+        .max_delay(Duration::from_secs(45))
+});
 
 /// Consecutive `Unauthenticated` retries allowed once the endpoint has proven the credential by
-/// delivering a block. With `DEFAULT_BACKOFF` these span about three minutes.
+/// delivering a block. With `DEFAULT_BACKOFF` these span about half a minute.
 const MAX_UNAUTHENTICATED_RETRIES: u32 = 5;
 
 /// Whether an `Unauthenticated` status from the endpoint should be retried.
@@ -532,6 +541,27 @@ mod tests {
         assert_eq!(
             requests[1].start_cursor, "cursor-1",
             "the reconnect should resume from the last cursor"
+        );
+    }
+
+    #[test]
+    fn test_reconnect_backoff_ramps_up_to_the_cap() {
+        let delays: Vec<Duration> = DEFAULT_BACKOFF
+            .clone()
+            .take(7)
+            .collect();
+
+        assert_eq!(
+            delays,
+            vec![
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+                Duration::from_secs(8),
+                Duration::from_secs(16),
+                Duration::from_secs(32),
+                Duration::from_secs(45),
+            ]
         );
     }
 

--- a/crates/tycho-indexer/src/substreams/stream.rs
+++ b/crates/tycho-indexer/src/substreams/stream.rs
@@ -121,6 +121,14 @@ fn should_retry_unauthenticated(block_received: bool, retries_used: u32) -> bool
     block_received && retries_used < MAX_UNAUTHENTICATED_RETRIES
 }
 
+/// Seconds since the unix epoch, as a gauge value.
+fn unix_timestamp_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards!?")
+        .as_secs_f64()
+}
+
 async fn wait_for_next_retry(
     backoff: &mut ExponentialBackoff,
     retry_count: &mut u32,
@@ -197,7 +205,14 @@ fn stream_blocks(
                     let mut stream = Box::pin(stream);
                     loop {
                         let response = match timeout(idle_timeout, stream.next()).await {
-                            Ok(Some(response)) => response,
+                            Ok(Some(response)) => {
+                                // Every other stream gauge is written per block, so a stalled
+                                // endpoint leaves them all at their last healthy value and
+                                // indistinguishable from a live stream. This one ages instead.
+                                gauge!("substreams_last_message_timestamp_seconds", "extractor" => extractor_id.clone())
+                                    .set(unix_timestamp_seconds());
+                                response
+                            },
                             Ok(None) => break,
                             Err(_) => {
                                 warn!(?idle_timeout, "Endpoint went silent, reconnecting");


### PR DESCRIPTION
On 2026-09-08 the BSC indexer stopped at block 120653743 for 7 minutes and then exited, which crash-looped both prod bsc-fynd pods (7 and 6 restarts) and left BSC quotes unavailable for ~10 minutes. The endpoint stopped delivering without closing the stream; tonic surfaced the error 5m38s later, and the reconnect replayed an undo signal the extractor had already applied.

Four independent changes, one commit each:

**Reconnect the stream when it goes silent.** The extractor awaited the next message with no deadline. It now redials after 60s without a message. A live stream sends a progress message every 30s, so silence past that means the connection is gone regardless of block time or backfill state. Resumes from the last cursor, the same path a stream error already takes.

**Treat a replayed revert target as already applied.** An endpoint resuming from a pre-reorg cursor re-sends the undo it already sent, by which point the target has aged out of the reorg buffer, so `purge_to` returned `NotFound` and failed the extractor. The buffer now remembers the last target it purged to and answers a repeat with `PurgeOutcome::AlreadyApplied`. Any other unanchorable target stays fatal.

**Report stream liveness as a metric.** `extractor_current_block_number` and `substreams_lag_millis` are written per block, so a stalled stream holds them at their last healthy value — which is why `absent_over_time` alerts saw nothing during the stall. `substreams_last_message_timestamp_seconds` is set on every message from the endpoint, so `time() - substreams_last_message_timestamp_seconds` is alertable.

**Ramp the reconnect backoff.** `from_millis(500)` squares its base, giving 500ms then the 45s cap. Now 1s, 2s, 4s, 8s, 16s, 32s, 45s, matching the supervisor's restart ladder.

## Testing

- `cargo nextest run -p tycho-indexer` — 243 non-DB tests pass, including three new ones: a silent endpoint reconnects from its last cursor (using a new `MockResponse::BlockThenStall`), a replayed revert target is a no-op, and any other stale target still errors. Each was checked against the unfixed code first.
- `cargo clippy -p tycho-indexer --all-targets` clean.
- The `test_serial_db` tests need a database and were not run locally.

## Notes

Prod BSC runs 0.376.0, which predates the supervisor, so the extractor error killed the process. On main the same error restarts only that extractor, with a 60s backoff — the second commit removes the error itself.

Alerting still needs a change on the helm side: every chain's `Substreams Delay` rule is `absent_over_time(extractor_current_block_number[1m])`, which cannot see a stuck value. BSC additionally uses a 5m window.