### PR TITLE
fix(indexer): base revert attr miss label on component existence

### DIFF
--- a/crates/tycho-indexer/CLAUDE.md
+++ b/crates/tycho-indexer/CLAUDE.md
@@ -117,12 +117,12 @@ On `BlockUndoSignal(target_hash, target_number)` from Substreams:
    created and deleted is malformed module output, so it goes through the lookup like a
    pre-existing attribute. Attributes with no prior value anywhere revert as deletions,
    emit one summary warning, and increment `extractor_revert_attr_miss` per attribute; its
-   `component_found` label says whether the component is known anywhere: a
-   `protocol_components` entry in buffer history or a `protocol_component` row in the DB.
-   `false` means an upstream module emitted state for a component Tycho never saw
-   created. The extractor registers both label sets at zero at startup so the first
-   miss is visible to `increase()`. Any hit means an upstream module emitted an Update
-   or Deletion for an attribute that never had a Creation.
+   `component_known` label says whether the component is known anywhere: a
+   `TxWithChanges.protocol_components` entry in buffer history or a row in the
+   `protocol_component` table. `false` means an upstream module emitted state for a
+   component Tycho never saw created. The extractor registers both label sets at zero at
+   startup so the first miss is visible to `increase()`. Any hit means an upstream module
+   emitted an Update or Deletion for an attribute that never had a Creation.
 4. If nothing was invalidated, only the cursor advances — no message is emitted. Otherwise
    a `BlockAggregatedChanges` with `revert = true` is broadcast.
 5. **No DB rollback is needed** — only finalized blocks ever reach the DB, so the persisted

--- a/crates/tycho-indexer/CLAUDE.md
+++ b/crates/tycho-indexer/CLAUDE.md
@@ -117,8 +117,10 @@ On `BlockUndoSignal(target_hash, target_number)` from Substreams:
    created and deleted is malformed module output, so it goes through the lookup like a
    pre-existing attribute. Attributes with no prior value anywhere revert as deletions,
    emit one summary warning, and increment `extractor_revert_attr_miss` per attribute; its
-   `component_state_found` label says whether the DB returned state rows for the
-   component. The extractor registers both label sets at zero at startup so the first
+   `component_found` label says whether the component is known anywhere: a
+   `protocol_components` entry in buffer history or a `protocol_component` row in the DB.
+   `false` means an upstream module emitted state for a component Tycho never saw
+   created. The extractor registers both label sets at zero at startup so the first
    miss is visible to `increase()`. Any hit means an upstream module emitted an Update
    or Deletion for an attribute that never had a Creation.
 4. If nothing was invalidated, only the cursor advances — no message is emitted. Otherwise

--- a/crates/tycho-indexer/src/extractor/mod.rs
+++ b/crates/tycho-indexer/src/extractor/mod.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use deepsize::DeepSizeOf;
@@ -10,7 +13,7 @@ use tycho_common::{
         blockchain::{Block, BlockAggregatedChanges, BlockScoped},
         contract::AccountBalance,
         protocol::ComponentBalance,
-        Address, BlockHash, ExtractorIdentity, MergeError,
+        Address, BlockHash, ComponentId, ExtractorIdentity, MergeError,
     },
     storage::StorageError,
     Bytes,
@@ -263,5 +266,13 @@ where
     ) -> HashMap<(AccountStateIdType, AccountStateKeyType), AccountStateValueType> {
         self.block_update
             .get_filtered_account_state_update(keys)
+    }
+
+    fn get_filtered_protocol_components(
+        &self,
+        ids: &HashSet<&ComponentId>,
+    ) -> HashSet<ComponentId> {
+        self.block_update
+            .get_filtered_protocol_components(ids)
     }
 }

--- a/crates/tycho-indexer/src/extractor/mod.rs
+++ b/crates/tycho-indexer/src/extractor/mod.rs
@@ -268,10 +268,7 @@ where
             .get_filtered_account_state_update(keys)
     }
 
-    fn get_filtered_protocol_components(
-        &self,
-        ids: &HashSet<&ComponentId>,
-    ) -> HashSet<ComponentId> {
+    fn get_filtered_protocol_components(&self, ids: &HashSet<ComponentId>) -> HashSet<ComponentId> {
         self.block_update
             .get_filtered_protocol_components(ids)
     }

--- a/crates/tycho-indexer/src/extractor/models.rs
+++ b/crates/tycho-indexer/src/extractor/models.rs
@@ -231,6 +231,23 @@ impl StateUpdateBufferEntry for BlockChanges {
 
         res
     }
+
+    fn get_filtered_protocol_components(
+        &self,
+        ids: &HashSet<&ComponentId>,
+    ) -> HashSet<ComponentId> {
+        let mut res = HashSet::new();
+
+        for update in self.txs_with_update.iter() {
+            for component_id in update.protocol_components.keys() {
+                if ids.contains(component_id) {
+                    res.insert(component_id.clone());
+                }
+            }
+        }
+
+        res
+    }
 }
 
 #[cfg(test)]

--- a/crates/tycho-indexer/src/extractor/models.rs
+++ b/crates/tycho-indexer/src/extractor/models.rs
@@ -232,10 +232,7 @@ impl StateUpdateBufferEntry for BlockChanges {
         res
     }
 
-    fn get_filtered_protocol_components(
-        &self,
-        ids: &HashSet<&ComponentId>,
-    ) -> HashSet<ComponentId> {
+    fn get_filtered_protocol_components(&self, ids: &HashSet<ComponentId>) -> HashSet<ComponentId> {
         let mut res = HashSet::new();
 
         for update in self.txs_with_update.iter() {

--- a/crates/tycho-indexer/src/extractor/models.rs
+++ b/crates/tycho-indexer/src/extractor/models.rs
@@ -512,9 +512,9 @@ mod test {
         models::{
             blockchain::{Block, Transaction, TxWithChanges},
             contract::AccountBalance,
-            protocol::ComponentBalance,
+            protocol::{ComponentBalance, ProtocolComponent},
             token::Token,
-            Address, Chain, MergeError,
+            Address, Chain, ChangeType, MergeError,
         },
         Bytes,
     };
@@ -748,6 +748,36 @@ mod test {
                 ((c_id, attr_fee), Bytes::from(50u64).lpad(32, 0)),
             ])
         );
+    }
+
+    #[test]
+    fn test_block_changes_protocol_components_filter() {
+        // The fixture txs carry `pool_0` as an Update; a third tx adds a Deletion so the filter
+        // is checked across txs and change types.
+        let mut block_changes = block_changes_from_fixtures();
+        block_changes
+            .txs_with_update
+            .push(TxWithChanges {
+                protocol_components: HashMap::from([(
+                    "pool_gone".to_string(),
+                    ProtocolComponent {
+                        id: "pool_gone".to_string(),
+                        change: ChangeType::Deletion,
+                        ..Default::default()
+                    },
+                )]),
+                tx: default_tx(),
+                ..Default::default()
+            });
+
+        let ids: HashSet<ComponentId> = ["pool_0", "pool_gone", "missing"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        let filtered = block_changes.get_filtered_protocol_components(&ids);
+
+        assert_eq!(filtered, HashSet::from(["pool_0".to_string(), "pool_gone".to_string()]));
     }
 
     #[test]

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -231,6 +231,37 @@ where
         Ok(())
     }
 
+    /// Returns the ids among `ids` with no protocol component entry in the reorg buffer history
+    /// and no component row in the DB.
+    async fn missing_components(
+        &self,
+        reorg_buffer: &ReorgBuffer<BlockUpdateWithCursor<BlockChanges>>,
+        ids: Vec<&ComponentId>,
+    ) -> Result<HashSet<ComponentId>, ExtractionError> {
+        let (_, absent_from_buffer) = reorg_buffer.lookup_components(&ids);
+        if absent_from_buffer.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let in_db: HashSet<ComponentId> = self
+            .gateway
+            .inner
+            .get_protocol_components(
+                &absent_from_buffer
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<&str>>(),
+            )
+            .await
+            .map_err(ExtractionError::Storage)?
+            .into_iter()
+            .map(|component| component.id)
+            .collect();
+        Ok(absent_from_buffer
+            .into_iter()
+            .filter(|id| !in_db.contains(id))
+            .collect())
+    }
+
     async fn is_first_message(&self) -> bool {
         !self
             .inner
@@ -1546,70 +1577,35 @@ where
             }
         }
 
-        // A component with DB state rows is known; the rest need an existence check, first
-        // in the buffer history, then against the component table.
-        let mut unknown_components: HashSet<ComponentId> = HashSet::new();
-        if !not_found.is_empty() {
-            let candidates: Vec<&ComponentId> = not_found
-                .keys()
-                .filter(|id| !states_by_id.contains_key(id.as_str()))
-                .collect();
-            let (_, absent_from_buffer) = reorg_buffer.lookup_components(&candidates);
-            if !absent_from_buffer.is_empty() {
-                let db_components = self
-                    .gateway
-                    .inner
-                    .get_protocol_components(
-                        &absent_from_buffer
-                            .iter()
-                            .map(String::as_str)
-                            .collect::<Vec<&str>>(),
-                    )
-                    .await
-                    .map_err(ExtractionError::Storage)?;
-                let in_db: HashSet<&str> = db_components
-                    .iter()
-                    .map(|component| component.id.as_str())
-                    .collect();
-                unknown_components = absent_from_buffer
-                    .into_iter()
-                    .filter(|id| !in_db.contains(id.as_str()))
-                    .collect();
-            }
-        }
+        let missing_components = self
+            .missing_components(&reorg_buffer, not_found.keys().collect())
+            .await?;
 
-        // Both count per attribute: known misses belong to a component Tycho saw created,
-        // unknown misses to a component that exists nowhere.
-        let mut known_misses = 0_u64;
-        let mut unknown_misses = 0_u64;
-        let mut known: Vec<(&str, usize)> = Vec::new();
-        let mut unknown: Vec<(&str, usize)> = Vec::new();
-        for (component_id, keys) in not_found.iter() {
-            if unknown_components.contains(component_id) {
-                unknown_misses += keys.len() as u64;
-                unknown.push((component_id.as_str(), keys.len()));
-            } else {
-                known_misses += keys.len() as u64;
-                known.push((component_id.as_str(), keys.len()));
-            }
-        }
+        // Per attribute: an attribute miss belongs to a component Tycho knows, a component
+        // miss to one that exists nowhere.
+        let (component_misses, attribute_misses): (Vec<(&str, usize)>, Vec<(&str, usize)>) =
+            not_found
+                .iter()
+                .map(|(id, keys)| (id.as_str(), keys.len()))
+                .partition(|(id, _)| missing_components.contains(*id));
         if !not_found.is_empty() {
             warn!(
-                known = ?known,
-                unknown = ?unknown,
+                ?attribute_misses,
+                ?component_misses,
                 "Attributes with no prior state in buffer or DB during revert; \
                  reverting them as deletions"
             );
         }
-        for (misses, component_found) in [(known_misses, "true"), (unknown_misses, "false")] {
-            if misses > 0 {
+        for (misses, component_found) in [(attribute_misses, "true"), (component_misses, "false")] {
+            let count: usize = misses.iter().map(|(_, n)| n).sum();
+            if count > 0 {
                 counter!(
                     "extractor_revert_attr_miss",
                     "extractor" => self.name.clone(),
                     "chain" => self.chain.to_string(),
                     "component_found" => component_found,
                 )
-                .increment(misses);
+                .increment(count as u64);
             }
         }
 
@@ -4874,17 +4870,20 @@ mod test {
                             HashMap::new(),
                         )])
                     });
-                // pool_y is answered by the buffer and pool_w by its state rows, so only
-                // pool_ghost and pool_z reach the component table.
+                // pool_y is answered by the buffer; the rest reach the component table, where
+                // pool_w and pool_z exist and pool_ghost does not.
                 gw.expect_get_protocol_components()
                     .returning(|component_ids| {
                         let mut ids = component_ids.to_vec();
                         ids.sort();
-                        assert_eq!(ids, vec!["pool_ghost", "pool_z"]);
-                        Ok(vec![ProtocolComponent {
-                            id: "pool_z".to_string(),
-                            ..Default::default()
-                        }])
+                        assert_eq!(ids, vec!["pool_ghost", "pool_w", "pool_z"]);
+                        Ok(["pool_w", "pool_z"]
+                            .into_iter()
+                            .map(|id| ProtocolComponent {
+                                id: id.to_string(),
+                                ..Default::default()
+                            })
+                            .collect())
                     });
                 gw.expect_get_components_balances()
                     .returning(|_| Ok(HashMap::new()));

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1582,32 +1582,33 @@ where
             .find_unknown_components(&reorg_buffer, &not_found.keys().collect::<Vec<_>>())
             .await?;
 
-        // Per attribute: an attribute miss belongs to a component Tycho knows, a component
-        // miss to one that exists nowhere.
-        let (component_misses, attribute_misses): (Vec<(&str, usize)>, Vec<(&str, usize)>) =
-            not_found
-                .iter()
-                .map(|(id, keys)| (id.as_str(), keys.len()))
-                .partition(|(id, _)| unknown_components.contains(*id));
+        // Both count per attribute. An attribute miss belongs to a known component. A
+        // component miss belongs to an unknown component.
+        let (component_misses, attr_misses): (Vec<_>, Vec<_>) = not_found
+            .iter()
+            .map(|(id, keys)| (id.as_str(), keys.len()))
+            .partition(|(id, _)| unknown_components.contains(*id));
         if !not_found.is_empty() {
             warn!(
-                ?attribute_misses,
+                ?attr_misses,
                 ?component_misses,
                 "Attributes with no prior state in buffer or DB during revert; \
                  reverting them as deletions"
             );
         }
-        for (misses, component_known) in [(attribute_misses, "true"), (component_misses, "false")] {
-            let count: usize = misses.iter().map(|(_, n)| n).sum();
-            if count > 0 {
-                counter!(
-                    "extractor_revert_attr_miss",
-                    "extractor" => self.name.clone(),
-                    "chain" => self.chain.to_string(),
-                    "component_known" => component_known,
-                )
-                .increment(count as u64);
-            }
+        for (misses, component_known) in [(attr_misses, "true"), (component_misses, "false")] {
+            counter!(
+                "extractor_revert_attr_miss",
+                "extractor" => self.name.clone(),
+                "chain" => self.chain.to_string(),
+                "component_known" => component_known,
+            )
+            .increment(
+                misses
+                    .iter()
+                    .map(|(_, n)| *n as u64)
+                    .sum(),
+            );
         }
 
         let empty = HashSet::<String>::new();

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -3303,7 +3303,8 @@ mod test {
         gw.expect_advance()
             .times(0)
             .returning(|_, _, _| Ok(()));
-        // Revert lookups: contracts, protocol states, component balances, account balances.
+        // Revert lookups: contracts, protocol states, protocol components, component
+        // balances, account balances.
         gw.expect_flushed_block_height()
             .returning(|| None);
         gw.expect_get_contracts()
@@ -4616,6 +4617,52 @@ mod test {
                 .updated_attributes
                 .is_empty(),
             "a value must not be both restored and deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_revert_attr_miss_component_lookup_error_fails_revert() {
+        let mut gw = MockExtractorGateway::new();
+        gw.expect_ensure_protocol_types()
+            .times(1)
+            .returning(|_| Ok(()));
+        gw.expect_get_cursor()
+            .times(1)
+            .returning(|| Ok(("cursor".into(), Bytes::default())));
+        gw.expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
+        gw.expect_advance()
+            .times(0)
+            .returning(|_, _, _| Ok(()));
+        gw.expect_flushed_block_height()
+            .returning(|| None);
+        gw.expect_get_contracts()
+            .returning(|_| Ok(Vec::new()));
+        gw.expect_get_protocol_states()
+            .returning(|_| Ok(Vec::new()));
+        // The component table lookup is the only call that fails.
+        gw.expect_get_protocol_components()
+            .returning(|_| Err(StorageError::Unexpected("connection reset".to_string())));
+        let extractor = create_extractor(gw).await;
+
+        full_block(&extractor, 1, 1, vec![]).await;
+        // `pool_ghost` has no creation anywhere, so the revert reaches the component table.
+        full_block(
+            &extractor,
+            2,
+            1,
+            vec![entity_change_tx(2, 0, "pool_ghost", "reserve", 42, PbChangeType::Update)],
+        )
+        .await;
+
+        let err = extractor
+            .handle_revert(undo_to(1))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ExtractionError::Storage(StorageError::Unexpected(_))),
+            "a component table failure must abort the revert, got {err:?}"
         );
     }
 

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -118,12 +118,12 @@ where
 
         // Register both label sets at zero so the first miss registers as a rise for
         // increase(); a series born at a nonzero value looks flat and no alert fires.
-        for state_found in ["true", "false"] {
+        for component_found in ["true", "false"] {
             counter!(
                 "extractor_revert_attr_miss",
                 "extractor" => name.to_string(),
                 "chain" => chain.to_string(),
-                "component_state_found" => state_found,
+                "component_found" => component_found,
             )
             .increment(0);
         }
@@ -1530,10 +1530,6 @@ where
         // both sets and it never existed before the range. Either way no prior value
         // exists and the revert deletes it. Substreams output is external input — a miss
         // is a data-quality signal, not a reason to kill the extractor.
-        // Both count per attribute. attr_misses: the component has state rows in the DB,
-        // just not this attribute. component_misses: no state rows for the component at all.
-        let mut attr_misses = 0_u64;
-        let mut component_misses = 0_u64;
         for (component_id, keys) in missing_map {
             let state = states_by_id
                 .get(component_id.as_str())
@@ -1543,36 +1539,75 @@ where
                     db_states.insert((component_id.clone(), key), value.clone());
                     continue;
                 }
-                if state.is_some() {
-                    attr_misses += 1;
-                } else {
-                    component_misses += 1;
-                }
                 not_found
                     .entry(component_id.clone())
                     .or_default()
                     .insert(key);
             }
         }
+
+        // A component with DB state rows is known; the rest need an existence check, first
+        // in the buffer history, then against the component table.
+        let mut unknown_components: HashSet<ComponentId> = HashSet::new();
         if !not_found.is_empty() {
-            let missed: Vec<(&str, usize)> = not_found
-                .iter()
-                .map(|(id, keys)| (id.as_str(), keys.len()))
+            let candidates: Vec<&ComponentId> = not_found
+                .keys()
+                .filter(|id| !states_by_id.contains_key(id.as_str()))
                 .collect();
+            let (_, absent_from_buffer) = reorg_buffer.lookup_components(&candidates);
+            if !absent_from_buffer.is_empty() {
+                let db_components = self
+                    .gateway
+                    .inner
+                    .get_protocol_components(
+                        &absent_from_buffer
+                            .iter()
+                            .map(String::as_str)
+                            .collect::<Vec<&str>>(),
+                    )
+                    .await
+                    .map_err(ExtractionError::Storage)?;
+                let in_db: HashSet<&str> = db_components
+                    .iter()
+                    .map(|component| component.id.as_str())
+                    .collect();
+                unknown_components = absent_from_buffer
+                    .into_iter()
+                    .filter(|id| !in_db.contains(id.as_str()))
+                    .collect();
+            }
+        }
+
+        // Both count per attribute: known misses belong to a component Tycho saw created,
+        // unknown misses to a component that exists nowhere.
+        let mut known_misses = 0_u64;
+        let mut unknown_misses = 0_u64;
+        let mut known: Vec<(&str, usize)> = Vec::new();
+        let mut unknown: Vec<(&str, usize)> = Vec::new();
+        for (component_id, keys) in not_found.iter() {
+            if unknown_components.contains(component_id) {
+                unknown_misses += keys.len() as u64;
+                unknown.push((component_id.as_str(), keys.len()));
+            } else {
+                known_misses += keys.len() as u64;
+                known.push((component_id.as_str(), keys.len()));
+            }
+        }
+        if !not_found.is_empty() {
             warn!(
-                components = ?missed,
-                total = attr_misses + component_misses,
+                known = ?known,
+                unknown = ?unknown,
                 "Attributes with no prior state in buffer or DB during revert; \
                  reverting them as deletions"
             );
         }
-        for (misses, state_found) in [(attr_misses, "true"), (component_misses, "false")] {
+        for (misses, component_found) in [(known_misses, "true"), (unknown_misses, "false")] {
             if misses > 0 {
                 counter!(
                     "extractor_revert_attr_miss",
                     "extractor" => self.name.clone(),
                     "chain" => self.chain.to_string(),
-                    "component_state_found" => state_found,
+                    "component_found" => component_found,
                 )
                 .increment(misses);
             }
@@ -1797,6 +1832,19 @@ pub trait ExtractorGateway: Send + Sync {
         &self,
         component_ids: &[&'a str],
     ) -> Result<Vec<ProtocolComponentState>, StorageError>;
+
+    /// Returns the protocol components identified by `component_ids`.
+    ///
+    /// Only components that exist in the store are returned: unknown ids are silently omitted
+    /// rather than producing an error, so the result may be shorter than `component_ids` (and
+    /// empty if none are found).
+    ///
+    /// # Errors
+    /// Returns a [`StorageError`] only on an underlying store failure, never for missing ids.
+    async fn get_protocol_components<'a>(
+        &self,
+        component_ids: &[&'a str],
+    ) -> Result<Vec<ProtocolComponent>, StorageError>;
 
     /// Returns the contracts at the given `addresses`, including their storage slots.
     ///
@@ -2138,6 +2186,17 @@ impl ExtractorGateway for ExtractorPgGateway {
             .get_protocol_states(&self.chain, None, None, Some(component_ids), false, None)
             .await
             .map(|state_data| state_data.entity)
+    }
+
+    /// Component ids are unique per chain, so the protocol system is left unconstrained.
+    async fn get_protocol_components<'a>(
+        &self,
+        component_ids: &[&'a str],
+    ) -> Result<Vec<ProtocolComponent>, StorageError> {
+        self.state_gateway
+            .get_protocol_components(&self.chain, None, Some(component_ids), None, None)
+            .await
+            .map(|component_data| component_data.entity)
     }
 
     async fn get_contracts(&self, addresses: &[Address]) -> Result<Vec<Account>, StorageError> {
@@ -3253,6 +3312,8 @@ mod test {
             .returning(|_| Ok(Vec::new()));
         gw.expect_get_protocol_states()
             .returning(|_| Ok(Vec::new()));
+        gw.expect_get_protocol_components()
+            .returning(|_| Ok(Vec::new()));
         gw.expect_get_components_balances()
             .returning(|_| Ok(HashMap::new()));
         gw.expect_get_account_balances()
@@ -3364,6 +3425,8 @@ mod test {
         gw.expect_get_contracts()
             .returning(|_| Ok(Vec::new()));
         gw.expect_get_protocol_states()
+            .returning(|_| Ok(Vec::new()));
+        gw.expect_get_protocol_components()
             .returning(|_| Ok(Vec::new()));
         gw.expect_get_components_balances()
             .returning(|_| Ok(HashMap::new()));
@@ -3595,6 +3658,8 @@ mod test {
         gw.expect_get_contracts()
             .returning(|_| Ok(Vec::new()));
         gw.expect_get_protocol_states()
+            .returning(|_| Ok(Vec::new()));
+        gw.expect_get_protocol_components()
             .returning(|_| Ok(Vec::new()));
         gw.expect_get_components_balances()
             .returning(|_| Ok(HashMap::new()));
@@ -4585,6 +4650,8 @@ mod test {
                 );
                 Ok(Vec::new())
             });
+        gw.expect_get_protocol_components()
+            .returning(|_| Ok(Vec::new()));
         gw.expect_get_components_balances()
             .returning(|_| Ok(HashMap::new()));
         gw.expect_get_account_balances()
@@ -4807,6 +4874,18 @@ mod test {
                             HashMap::new(),
                         )])
                     });
+                // pool_y is answered by the buffer and pool_w by its state rows, so only
+                // pool_ghost and pool_z reach the component table.
+                gw.expect_get_protocol_components()
+                    .returning(|component_ids| {
+                        let mut ids = component_ids.to_vec();
+                        ids.sort();
+                        assert_eq!(ids, vec!["pool_ghost", "pool_z"]);
+                        Ok(vec![ProtocolComponent {
+                            id: "pool_z".to_string(),
+                            ..Default::default()
+                        }])
+                    });
                 gw.expect_get_components_balances()
                     .returning(|_| Ok(HashMap::new()));
                 gw.expect_get_account_balances()
@@ -4818,9 +4897,10 @@ mod test {
                 full_block(&extractor, 1, 1, vec![]).await;
                 full_block(&extractor, 2, 1, vec![component_creation_tx(2, 0, "pool_y", &[])])
                     .await;
-                // fee: pool_y has a buffered creation but no attrs and no DB rows → "false".
-                // rate: pool_ghost was never created anywhere → "false".
+                // fee: pool_y has a buffered creation but no attrs and no DB rows → "true".
                 // gone: pool_w has DB state rows, but not this attribute → "true".
+                // depth: pool_z has a component row but no state rows → "true".
+                // rate: pool_ghost was never created anywhere → "false".
                 full_block(
                     &extractor,
                     3,
@@ -4829,6 +4909,7 @@ mod test {
                         entity_change_tx(3, 0, "pool_y", "fee", 30, PbChangeType::Update),
                         entity_change_tx(3, 1, "pool_ghost", "rate", 7, PbChangeType::Update),
                         entity_change_tx(3, 2, "pool_w", "gone", 9, PbChangeType::Update),
+                        entity_change_tx(3, 3, "pool_z", "depth", 5, PbChangeType::Update),
                     ],
                 )
                 .await;
@@ -4849,11 +4930,11 @@ mod test {
                 &[
                     ("extractor", EXTRACTOR_NAME),
                     ("chain", "ethereum"),
-                    ("component_state_found", "false")
+                    ("component_found", "false")
                 ],
             ),
-            2,
-            "pool_y (no state rows) and pool_ghost (never created) miss without DB rows"
+            1,
+            "only pool_ghost exists neither in the buffer nor in the DB"
         );
         assert_eq!(
             counter_value(
@@ -4862,11 +4943,116 @@ mod test {
                 &[
                     ("extractor", EXTRACTOR_NAME),
                     ("chain", "ethereum"),
-                    ("component_state_found", "true")
+                    ("component_found", "true")
+                ],
+            ),
+            3,
+            "pool_y (buffered creation), pool_w (state rows) and pool_z (component row) are known"
+        );
+    }
+
+    // `metrics::with_local_recorder` takes a sync closure, so this test cannot use
+    // #[tokio::test]; it drives its own current-thread runtime instead.
+    #[test]
+    fn test_revert_attr_miss_on_retained_creation_is_component_found() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        metrics::with_local_recorder(&recorder, || {
+            rt.block_on(async {
+                let mut gw = MockExtractorGateway::new();
+                gw.expect_ensure_protocol_types()
+                    .times(1)
+                    .returning(|_| Ok(()));
+                gw.expect_get_cursor()
+                    .times(1)
+                    .returning(|| Ok(("cursor".into(), Bytes::default())));
+                gw.expect_get_block()
+                    .times(1)
+                    .returning(|_| Ok(Block::default()));
+                gw.expect_advance()
+                    .returning(|_, _, _| Ok(()));
+                // The write never lands: the creation stays reachable in the committing
+                // section.
+                gw.expect_flushed_block_height()
+                    .returning(|| None);
+                gw.expect_get_contracts()
+                    .returning(|_| Ok(Vec::new()));
+                gw.expect_get_protocol_states()
+                    .returning(|_| Ok(Vec::new()));
+                // The buffer answers the only candidate, so the DB is never asked.
+                gw.expect_get_protocol_components()
+                    .times(0)
+                    .returning(|_| Ok(Vec::new()));
+                gw.expect_get_components_balances()
+                    .returning(|_| Ok(HashMap::new()));
+                gw.expect_get_account_balances()
+                    .returning(|_| Ok(HashMap::new()));
+
+                let extractor = create_extractor(gw).await;
+
+                // Block 1: create `pool_x` without attributes.
+                full_block(&extractor, 1, 1, vec![component_creation_tx(1, 0, "pool_x", &[])])
+                    .await;
+                // Block 2: finality 2 drains block 1 into the committing section.
+                full_block(&extractor, 2, 2, vec![]).await;
+                // Block 3: the attribute gets its first-ever value, mis-marked as an
+                // Update. Finality stays 2, so block 2 stays buffered.
+                full_block(
+                    &extractor,
+                    3,
+                    2,
+                    vec![entity_change_tx(
+                        3,
+                        0,
+                        "pool_x",
+                        "protocol_fees",
+                        500,
+                        PbChangeType::Update,
+                    )],
+                )
+                .await;
+
+                extractor
+                    .handle_revert(undo_to(2))
+                    .await
+                    .unwrap()
+                    .unwrap();
+            })
+        });
+
+        let map = snapshot_to_map(snapshotter.snapshot());
+        assert_eq!(
+            counter_value(
+                &map,
+                "extractor_revert_attr_miss",
+                &[
+                    ("extractor", EXTRACTOR_NAME),
+                    ("chain", "ethereum"),
+                    ("component_found", "true")
                 ],
             ),
             1,
-            "pool_w has state rows but not the reverted attribute"
+            "a creation drained but not yet flushed must count as a known component"
+        );
+        assert_eq!(
+            counter_value(
+                &map,
+                "extractor_revert_attr_miss",
+                &[
+                    ("extractor", EXTRACTOR_NAME),
+                    ("chain", "ethereum"),
+                    ("component_found", "false")
+                ],
+            ),
+            0,
+            "the production shape must not alert"
         );
     }
 
@@ -4901,11 +5087,11 @@ mod test {
         });
 
         let map = snapshot_to_map(snapshotter.snapshot());
-        for state_found in ["true", "false"] {
+        for component_found in ["true", "false"] {
             let labels = std::collections::BTreeMap::from([
                 ("extractor".to_string(), EXTRACTOR_NAME.to_string()),
                 ("chain".to_string(), "ethereum".to_string()),
-                ("component_state_found".to_string(), state_found.to_string()),
+                ("component_found".to_string(), component_found.to_string()),
             ]);
             assert!(
                 map.contains_key(&(
@@ -4913,7 +5099,7 @@ mod test {
                     "extractor_revert_attr_miss".to_string(),
                     labels,
                 )),
-                "series with component_state_found={state_found} must exist at startup; \
+                "series with component_found={component_found} must exist at startup; \
                  a series born on the first miss looks flat to increase() and no alert fires"
             );
         }

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -233,20 +233,23 @@ where
 
     /// Returns the ids among `ids` with no protocol component entry in the reorg buffer history
     /// and no component row in the DB.
-    async fn missing_components(
+    ///
+    /// The protocol cache is not consulted: it keeps creations that a revert undid, so it would
+    /// label a reverted ghost as known.
+    async fn find_unknown_components(
         &self,
         reorg_buffer: &ReorgBuffer<BlockUpdateWithCursor<BlockChanges>>,
-        ids: Vec<&ComponentId>,
+        ids: &[&ComponentId],
     ) -> Result<HashSet<ComponentId>, ExtractionError> {
-        let (_, absent_from_buffer) = reorg_buffer.lookup_components(&ids);
-        if absent_from_buffer.is_empty() {
-            return Ok(HashSet::new());
+        let mut unknown = reorg_buffer.missing_components(ids);
+        if unknown.is_empty() {
+            return Ok(unknown);
         }
         let in_db: HashSet<ComponentId> = self
             .gateway
             .inner
             .get_protocol_components(
-                &absent_from_buffer
+                &unknown
                     .iter()
                     .map(String::as_str)
                     .collect::<Vec<&str>>(),
@@ -256,10 +259,8 @@ where
             .into_iter()
             .map(|component| component.id)
             .collect();
-        Ok(absent_from_buffer
-            .into_iter()
-            .filter(|id| !in_db.contains(id))
-            .collect())
+        unknown.retain(|id| !in_db.contains(id));
+        Ok(unknown)
     }
 
     async fn is_first_message(&self) -> bool {
@@ -1577,8 +1578,8 @@ where
             }
         }
 
-        let missing_components = self
-            .missing_components(&reorg_buffer, not_found.keys().collect())
+        let unknown_components = self
+            .find_unknown_components(&reorg_buffer, &not_found.keys().collect::<Vec<_>>())
             .await?;
 
         // Per attribute: an attribute miss belongs to a component Tycho knows, a component
@@ -1587,7 +1588,7 @@ where
             not_found
                 .iter()
                 .map(|(id, keys)| (id.as_str(), keys.len()))
-                .partition(|(id, _)| missing_components.contains(*id));
+                .partition(|(id, _)| unknown_components.contains(*id));
         if !not_found.is_empty() {
             warn!(
                 ?attribute_misses,

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -118,12 +118,12 @@ where
 
         // Register both label sets at zero so the first miss registers as a rise for
         // increase(); a series born at a nonzero value looks flat and no alert fires.
-        for component_found in ["true", "false"] {
+        for component_known in ["true", "false"] {
             counter!(
                 "extractor_revert_attr_miss",
                 "extractor" => name.to_string(),
                 "chain" => chain.to_string(),
-                "component_found" => component_found,
+                "component_known" => component_known,
             )
             .increment(0);
         }
@@ -1597,14 +1597,14 @@ where
                  reverting them as deletions"
             );
         }
-        for (misses, component_found) in [(attribute_misses, "true"), (component_misses, "false")] {
+        for (misses, component_known) in [(attribute_misses, "true"), (component_misses, "false")] {
             let count: usize = misses.iter().map(|(_, n)| n).sum();
             if count > 0 {
                 counter!(
                     "extractor_revert_attr_miss",
                     "extractor" => self.name.clone(),
                     "chain" => self.chain.to_string(),
-                    "component_found" => component_found,
+                    "component_known" => component_known,
                 )
                 .increment(count as u64);
             }
@@ -4930,7 +4930,7 @@ mod test {
                 &[
                     ("extractor", EXTRACTOR_NAME),
                     ("chain", "ethereum"),
-                    ("component_found", "false")
+                    ("component_known", "false")
                 ],
             ),
             1,
@@ -4943,7 +4943,7 @@ mod test {
                 &[
                     ("extractor", EXTRACTOR_NAME),
                     ("chain", "ethereum"),
-                    ("component_found", "true")
+                    ("component_known", "true")
                 ],
             ),
             3,
@@ -4954,7 +4954,7 @@ mod test {
     // `metrics::with_local_recorder` takes a sync closure, so this test cannot use
     // #[tokio::test]; it drives its own current-thread runtime instead.
     #[test]
-    fn test_revert_attr_miss_on_retained_creation_is_component_found() {
+    fn test_revert_attr_miss_on_retained_creation_is_component_known() {
         use metrics_util::debugging::DebuggingRecorder;
 
         let recorder = DebuggingRecorder::new();
@@ -5035,7 +5035,7 @@ mod test {
                 &[
                     ("extractor", EXTRACTOR_NAME),
                     ("chain", "ethereum"),
-                    ("component_found", "true")
+                    ("component_known", "true")
                 ],
             ),
             1,
@@ -5048,11 +5048,11 @@ mod test {
                 &[
                     ("extractor", EXTRACTOR_NAME),
                     ("chain", "ethereum"),
-                    ("component_found", "false")
+                    ("component_known", "false")
                 ],
             ),
             0,
-            "the production shape must not alert"
+            "a creation in the committing section is not a component miss"
         );
     }
 
@@ -5087,11 +5087,11 @@ mod test {
         });
 
         let map = snapshot_to_map(snapshotter.snapshot());
-        for component_found in ["true", "false"] {
+        for component_known in ["true", "false"] {
             let labels = std::collections::BTreeMap::from([
                 ("extractor".to_string(), EXTRACTOR_NAME.to_string()),
                 ("chain".to_string(), "ethereum".to_string()),
-                ("component_found".to_string(), component_found.to_string()),
+                ("component_known".to_string(), component_known.to_string()),
             ]);
             assert!(
                 map.contains_key(&(
@@ -5099,7 +5099,7 @@ mod test {
                     "extractor_revert_attr_miss".to_string(),
                     labels,
                 )),
-                "series with component_found={component_found} must exist at startup; \
+                "series with component_known={component_known} must exist at startup; \
                  a series born on the first miss looks flat to increase() and no alert fires"
             );
         }

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -239,7 +239,7 @@ where
     async fn find_unknown_components(
         &self,
         reorg_buffer: &ReorgBuffer<BlockUpdateWithCursor<BlockChanges>>,
-        ids: HashSet<ComponentId>,
+        ids: impl IntoIterator<Item = ComponentId>,
     ) -> Result<HashSet<ComponentId>, ExtractionError> {
         let mut unknown = reorg_buffer.missing_components(ids);
         if unknown.is_empty() {
@@ -1579,7 +1579,7 @@ where
         }
 
         let unknown_components = self
-            .find_unknown_components(&reorg_buffer, not_found.keys().cloned().collect())
+            .find_unknown_components(&reorg_buffer, not_found.keys().cloned())
             .await?;
 
         // Both count per attribute. An attribute miss belongs to a known component. A

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -241,7 +241,7 @@ where
         reorg_buffer: &ReorgBuffer<BlockUpdateWithCursor<BlockChanges>>,
         ids: impl IntoIterator<Item = ComponentId>,
     ) -> Result<HashSet<ComponentId>, ExtractionError> {
-        let mut unknown = reorg_buffer.missing_components(ids);
+        let mut unknown = reorg_buffer.missing_components(ids.into_iter().collect());
         if unknown.is_empty() {
             return Ok(unknown);
         }

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -231,7 +231,7 @@ where
         Ok(())
     }
 
-    /// Returns the ids among `ids` with no protocol component entry in the reorg buffer history
+    /// Returns the ids among `ids` with no component creation in the reorg buffer history
     /// and no component row in the DB.
     ///
     /// The protocol cache is not consulted: it keeps creations that a revert undid, so it would

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -239,7 +239,7 @@ where
     async fn find_unknown_components(
         &self,
         reorg_buffer: &ReorgBuffer<BlockUpdateWithCursor<BlockChanges>>,
-        ids: &[&ComponentId],
+        ids: HashSet<ComponentId>,
     ) -> Result<HashSet<ComponentId>, ExtractionError> {
         let mut unknown = reorg_buffer.missing_components(ids);
         if unknown.is_empty() {
@@ -1579,7 +1579,7 @@ where
         }
 
         let unknown_components = self
-            .find_unknown_components(&reorg_buffer, &not_found.keys().collect::<Vec<_>>())
+            .find_unknown_components(&reorg_buffer, not_found.keys().cloned().collect())
             .await?;
 
         // Both count per attribute. An attribute miss belongs to a known component. A

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -443,8 +443,7 @@ pub(crate) trait StateUpdateBufferEntry: std::fmt::Debug {
 
     /// Returns the ids among `ids` that have a protocol component entry in this block,
     /// whatever the change type.
-    fn get_filtered_protocol_components(&self, ids: &HashSet<&ComponentId>)
-        -> HashSet<ComponentId>;
+    fn get_filtered_protocol_components(&self, ids: &HashSet<ComponentId>) -> HashSet<ComponentId>;
 }
 
 impl<B> ReorgBuffer<B>
@@ -489,33 +488,24 @@ where
         (res, remaining_keys.into_iter().collect())
     }
 
-    /// Looks up buffered protocol component entries for the provided ids. Returns the ids found
-    /// in the buffered blocks and the ids for which no entry was found.
-    pub fn lookup_components(
-        &self,
-        ids: &[&ComponentId],
-    ) -> (HashSet<ComponentId>, Vec<ComponentId>) {
-        let mut found = HashSet::new();
-        let mut remaining_ids: HashSet<ComponentId> = ids
+    /// Returns the ids among `ids` with no protocol component entry in the buffered blocks,
+    /// live and committing sections included.
+    pub fn missing_components(&self, ids: &[&ComponentId]) -> HashSet<ComponentId> {
+        let mut missing: HashSet<ComponentId> = ids
             .iter()
             .map(|&id| id.clone())
             .collect();
 
         for block_message in self.history() {
-            if remaining_ids.is_empty() {
+            if missing.is_empty() {
                 break;
             }
-
-            for id in
-                block_message.get_filtered_protocol_components(&remaining_ids.iter().collect())
-            {
-                if remaining_ids.remove(&id) {
-                    found.insert(id);
-                }
+            for id in block_message.get_filtered_protocol_components(&missing) {
+                missing.remove(&id);
             }
         }
 
-        (found, remaining_ids.into_iter().collect())
+        missing
     }
 
     /// Looks up buffered account state updates for the provided keys. Returns a map of updates and
@@ -640,7 +630,7 @@ mod test {
     use tycho_common::models::{
         blockchain::{Transaction, TxWithChanges},
         protocol::{ProtocolComponent, ProtocolComponentStateDelta},
-        Chain,
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -1112,7 +1102,11 @@ mod test {
             vec![TxWithChanges {
                 protocol_components: HashMap::from([(
                     component_id.to_string(),
-                    ProtocolComponent { id: component_id.to_string(), ..Default::default() },
+                    ProtocolComponent {
+                        id: component_id.to_string(),
+                        change: ChangeType::Creation,
+                        ..Default::default()
+                    },
                 )]),
                 tx: transaction(),
                 ..Default::default()
@@ -1122,7 +1116,7 @@ mod test {
     }
 
     #[test]
-    fn test_lookup_components_reads_live_and_committing_blocks() {
+    fn test_missing_components_reads_live_and_committing_blocks() {
         let mut reorg_buffer = ReorgBuffer::new();
         reorg_buffer
             .insert_block(component_creation_block(1, "c1"))
@@ -1143,16 +1137,13 @@ mod test {
         let c3 = "c3".to_string();
         let ghost = "ghost".to_string();
 
-        let (found, missing) = reorg_buffer.lookup_components(&[&c1, &c3, &ghost]);
-        assert_eq!(found, HashSet::from([c1.clone(), c3.clone()]));
-        assert_eq!(missing, vec![ghost.clone()]);
+        let missing = reorg_buffer.missing_components(&[&c1, &c3, &ghost]);
+        assert_eq!(missing, HashSet::from([ghost.clone()]));
 
         // Releasing block 1 drops its creation from the history.
         reorg_buffer.release_committed(2);
-        let (found, mut missing) = reorg_buffer.lookup_components(&[&c1, &c3, &ghost]);
-        assert_eq!(found, HashSet::from([c3]));
-        missing.sort();
-        assert_eq!(missing, vec![c1, ghost]);
+        let missing = reorg_buffer.missing_components(&[&c1, &c3, &ghost]);
+        assert_eq!(missing, HashSet::from([c1, ghost]));
     }
 
     #[test]

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -440,6 +440,11 @@ pub(crate) trait StateUpdateBufferEntry: std::fmt::Debug {
         &self,
         keys: Vec<(&Address, &Address)>,
     ) -> HashMap<(Address, Address), AccountBalance>;
+
+    /// Returns the ids among `ids` that have a protocol component entry in this block,
+    /// whatever the change type.
+    fn get_filtered_protocol_components(&self, ids: &HashSet<&ComponentId>)
+        -> HashSet<ComponentId>;
 }
 
 impl<B> ReorgBuffer<B>
@@ -482,6 +487,35 @@ where
         }
 
         (res, remaining_keys.into_iter().collect())
+    }
+
+    /// Looks up buffered protocol component entries for the provided ids. Returns the ids found
+    /// in the buffered blocks and the ids for which no entry was found.
+    pub fn lookup_components(
+        &self,
+        ids: &[&ComponentId],
+    ) -> (HashSet<ComponentId>, Vec<ComponentId>) {
+        let mut found = HashSet::new();
+        let mut remaining_ids: HashSet<ComponentId> = ids
+            .iter()
+            .map(|&id| id.clone())
+            .collect();
+
+        for block_message in self.history() {
+            if remaining_ids.is_empty() {
+                break;
+            }
+
+            for id in
+                block_message.get_filtered_protocol_components(&remaining_ids.iter().collect())
+            {
+                if remaining_ids.remove(&id) {
+                    found.insert(id);
+                }
+            }
+        }
+
+        (found, remaining_ids.into_iter().collect())
     }
 
     /// Looks up buffered account state updates for the provided keys. Returns a map of updates and
@@ -605,7 +639,7 @@ mod test {
     use rstest::rstest;
     use tycho_common::models::{
         blockchain::{Transaction, TxWithChanges},
-        protocol::ProtocolComponentStateDelta,
+        protocol::{ProtocolComponent, ProtocolComponentStateDelta},
         Chain,
     };
 
@@ -1064,6 +1098,61 @@ mod test {
             reorg_buffer.lookup_protocol_state(&[(&state1, &new), (&state1, &reserve)]);
         assert!(res.is_empty());
         assert_eq!(missing.len(), 2);
+    }
+
+    /// The `get_block_changes` fixtures carry no protocol components, so component lookups
+    /// need blocks built here.
+    fn component_creation_block(number: u64, component_id: &str) -> BlockChanges {
+        BlockChanges::new(
+            "test".to_string(),
+            Chain::Ethereum,
+            testing::block(number),
+            0,
+            false,
+            vec![TxWithChanges {
+                protocol_components: HashMap::from([(
+                    component_id.to_string(),
+                    ProtocolComponent { id: component_id.to_string(), ..Default::default() },
+                )]),
+                tx: transaction(),
+                ..Default::default()
+            }],
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn test_lookup_components_reads_live_and_committing_blocks() {
+        let mut reorg_buffer = ReorgBuffer::new();
+        reorg_buffer
+            .insert_block(component_creation_block(1, "c1"))
+            .unwrap();
+        reorg_buffer
+            .insert_block(get_block_changes(2))
+            .unwrap();
+        reorg_buffer
+            .insert_block(component_creation_block(3, "c3"))
+            .unwrap();
+
+        // Blocks 1 and 2 move to the committing section, block 3 stays live.
+        reorg_buffer
+            .drain_into_committing(3)
+            .unwrap();
+
+        let c1 = "c1".to_string();
+        let c3 = "c3".to_string();
+        let ghost = "ghost".to_string();
+
+        let (found, missing) = reorg_buffer.lookup_components(&[&c1, &c3, &ghost]);
+        assert_eq!(found, HashSet::from([c1.clone(), c3.clone()]));
+        assert_eq!(missing, vec![ghost.clone()]);
+
+        // Releasing block 1 drops its creation from the history.
+        reorg_buffer.release_committed(2);
+        let (found, mut missing) = reorg_buffer.lookup_components(&[&c1, &c3, &ghost]);
+        assert_eq!(found, HashSet::from([c3]));
+        missing.sort();
+        assert_eq!(missing, vec![c1, ghost]);
     }
 
     #[test]

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -488,14 +488,9 @@ where
         (res, remaining_keys.into_iter().collect())
     }
 
-    /// Returns the ids among `ids` with no protocol component entry in the buffered blocks,
+    /// Returns the ids among `missing` with no protocol component entry in the buffered blocks,
     /// live and committing sections included.
-    pub fn missing_components(&self, ids: &[&ComponentId]) -> HashSet<ComponentId> {
-        let mut missing: HashSet<ComponentId> = ids
-            .iter()
-            .map(|&id| id.clone())
-            .collect();
-
+    pub fn missing_components(&self, mut missing: HashSet<ComponentId>) -> HashSet<ComponentId> {
         for block_message in self.history() {
             if missing.is_empty() {
                 break;
@@ -1136,13 +1131,14 @@ mod test {
         let c1 = "c1".to_string();
         let c3 = "c3".to_string();
         let ghost = "ghost".to_string();
+        let ids = HashSet::from([c1.clone(), c3.clone(), ghost.clone()]);
 
-        let missing = reorg_buffer.missing_components(&[&c1, &c3, &ghost]);
+        let missing = reorg_buffer.missing_components(ids.clone());
         assert_eq!(missing, HashSet::from([ghost.clone()]));
 
         // Releasing block 1 drops its creation from the history.
         reorg_buffer.release_committed(2);
-        let missing = reorg_buffer.missing_components(&[&c1, &c3, &ghost]);
+        let missing = reorg_buffer.missing_components(ids);
         assert_eq!(missing, HashSet::from([c1, ghost]));
     }
 

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -489,11 +489,8 @@ where
 
     /// Returns the ids among `ids` with no component creation in the buffered blocks,
     /// live and committing sections included.
-    pub fn missing_components(
-        &self,
-        ids: impl IntoIterator<Item = ComponentId>,
-    ) -> HashSet<ComponentId> {
-        let mut missing: HashSet<ComponentId> = ids.into_iter().collect();
+    pub fn missing_components(&self, ids: HashSet<ComponentId>) -> HashSet<ComponentId> {
+        let mut missing = ids;
 
         for block_message in self.history() {
             if missing.is_empty() {
@@ -1135,9 +1132,9 @@ mod test {
         let c1 = "c1".to_string();
         let c3 = "c3".to_string();
         let ghost = "ghost".to_string();
-        let ids = [c1.clone(), c3.clone(), ghost.clone()];
+        let ids = HashSet::from([c1.clone(), c3.clone(), ghost.clone()]);
 
-        let missing = reorg_buffer.missing_components(ids.iter().cloned());
+        let missing = reorg_buffer.missing_components(ids.clone());
         assert_eq!(missing, HashSet::from([ghost.clone()]));
 
         // Releasing block 1 drops its creation from the history.

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -441,8 +441,7 @@ pub(crate) trait StateUpdateBufferEntry: std::fmt::Debug {
         keys: Vec<(&Address, &Address)>,
     ) -> HashMap<(Address, Address), AccountBalance>;
 
-    /// Returns the ids among `ids` that have a protocol component entry in this block,
-    /// whatever the change type.
+    /// Returns the ids among `ids` whose component creation this block holds.
     fn get_filtered_protocol_components(&self, ids: &HashSet<ComponentId>) -> HashSet<ComponentId>;
 }
 
@@ -488,7 +487,7 @@ where
         (res, remaining_keys.into_iter().collect())
     }
 
-    /// Returns the ids among `ids` with no protocol component entry in the buffered blocks,
+    /// Returns the ids among `ids` with no component creation in the buffered blocks,
     /// live and committing sections included.
     pub fn missing_components(
         &self,

--- a/crates/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/crates/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -488,9 +488,14 @@ where
         (res, remaining_keys.into_iter().collect())
     }
 
-    /// Returns the ids among `missing` with no protocol component entry in the buffered blocks,
+    /// Returns the ids among `ids` with no protocol component entry in the buffered blocks,
     /// live and committing sections included.
-    pub fn missing_components(&self, mut missing: HashSet<ComponentId>) -> HashSet<ComponentId> {
+    pub fn missing_components(
+        &self,
+        ids: impl IntoIterator<Item = ComponentId>,
+    ) -> HashSet<ComponentId> {
+        let mut missing: HashSet<ComponentId> = ids.into_iter().collect();
+
         for block_message in self.history() {
             if missing.is_empty() {
                 break;
@@ -1131,9 +1136,9 @@ mod test {
         let c1 = "c1".to_string();
         let c3 = "c3".to_string();
         let ghost = "ghost".to_string();
-        let ids = HashSet::from([c1.clone(), c3.clone(), ghost.clone()]);
+        let ids = [c1.clone(), c3.clone(), ghost.clone()];
 
-        let missing = reorg_buffer.missing_components(ids.clone());
+        let missing = reorg_buffer.missing_components(ids.iter().cloned());
         assert_eq!(missing, HashSet::from([ghost.clone()]));
 
         // Releasing block 1 drops its creation from the history.


### PR DESCRIPTION
## Problem

`[PROD-BASE] Revert Attribute Miss` fired 4 times between 2026-09-04 and 2026-09-08 with
`component_state_found=false`, always `uniswap_v3`, on both Base indexers in the same minute:

```
Attributes with no prior state in buffer or DB during revert; reverting them as deletions
components=[("0xd3845774…", 2)]
```

No component was lost. All 4 were noise.

## Root cause

The label came from `get_protocol_states`, which returns state rows of flushed blocks only. A pool
created 97 blocks earlier still has its creation in the reorg buffer and no DB rows. When the
Uniswap fee controller set `protocol_fees/token0|1` for the first time and Substreams reverted that
block as flashblock partials, the attribute miss was real but the label called the component absent.

## Fix

For the residual miss ids the extractor now checks component existence: a `protocol_components`
entry anywhere in reorg buffer history, then a `protocol_component` row in the DB. The label is
renamed to `component_known`; `false` now means no creation exists anywhere. Revert behaviour is
unchanged.

The summary warning now lists the misses per label: `attr_misses=[(id, n)]` for known
components and `component_misses=[(id, n)]` for unknown ones. The `components=` and `total=`
fields are gone, so the grep line above no longer matches after release.

## Notes for reviewers

Both lookups run only on the rare miss path. The protocol cache is not used for the check: it
keeps creations that a revert undid, so a second revert would label a reverted ghost as known.
The `component_state_found` series stops increasing on release, so every current alert rule
goes quiet until the rule rename lands.

## Follow-ups

helm-configuration: switch all 19 `Revert Attribute Miss` rules to `component_known`: 10 under
`helmwave/prod/values/tycho/`, 2 under `helmwave/prod/values/tycho-fynd/`, 7 under
`helmwave/dev/values/tycho/`. The tycho-fynd and dev files also embed `component_state_found`
in the alert `description` annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
