### PR TITLE
fix(storage): retry write batches on serialization failure

### DIFF
--- a/crates/tycho-common/src/storage.rs
+++ b/crates/tycho-common/src/storage.rs
@@ -68,8 +68,6 @@ pub enum StorageError {
     DecodeError(String),
     #[error("Unexpected storage error: {0}")]
     Unexpected(String),
-    #[error("Transaction aborted by a concurrent transaction: {0}")]
-    TransactionConflict(String),
     #[error("Currently unsupported operation: {0}")]
     Unsupported(String),
     #[error("Write cache unexpectedly dropped notification channel!")]

--- a/crates/tycho-common/src/storage.rs
+++ b/crates/tycho-common/src/storage.rs
@@ -68,6 +68,8 @@ pub enum StorageError {
     DecodeError(String),
     #[error("Unexpected storage error: {0}")]
     Unexpected(String),
+    #[error("Transaction aborted by a concurrent transaction: {0}")]
+    TransactionConflict(String),
     #[error("Currently unsupported operation: {0}")]
     Unsupported(String),
     #[error("Write cache unexpectedly dropped notification channel!")]

--- a/crates/tycho-storage/CLAUDE.md
+++ b/crates/tycho-storage/CLAUDE.md
@@ -28,10 +28,9 @@ All public DB operations go through one of two gateway structs:
 - **`CachedGateway`** (normal path): sends `WriteOp` messages over an async channel to
   `DBCacheWriteExecutor`, which batches by block and flushes in a fixed order when the next
   block arrives. Most reads hit the DB directly; the exceptions are `get_tokens` (served from
-  `token_cache` when enabled) and `get_delta` (small LRU). The executor retries a batch up to
-  three times when Postgres reports a transaction conflict (deadlock or serialization failure,
-  surfaced as `StorageError::TransactionConflict`); the batch re-runs from scratch with a fresh
-  snapshot.
+  `token_cache` when enabled) and `get_delta` (small LRU). The executor runs a batch up to
+  three times when Postgres reports a transaction conflict (deadlock or serialization
+  failure); each attempt re-runs from scratch with a fresh snapshot.
 - **`DirectGateway`** (testing / low-throughput): same trait surface, no buffering.
 
 `GatewayBuilder::build` requires **exactly one** chain (`ensure_chain`) — an instance is

--- a/crates/tycho-storage/CLAUDE.md
+++ b/crates/tycho-storage/CLAUDE.md
@@ -28,7 +28,10 @@ All public DB operations go through one of two gateway structs:
 - **`CachedGateway`** (normal path): sends `WriteOp` messages over an async channel to
   `DBCacheWriteExecutor`, which batches by block and flushes in a fixed order when the next
   block arrives. Most reads hit the DB directly; the exceptions are `get_tokens` (served from
-  `token_cache` when enabled) and `get_delta` (small LRU).
+  `token_cache` when enabled) and `get_delta` (small LRU). The executor retries a batch up to
+  three times when Postgres reports a transaction conflict (deadlock or serialization failure,
+  surfaced as `StorageError::TransactionConflict`); the batch re-runs from scratch with a fresh
+  snapshot.
 - **`DirectGateway`** (testing / low-throughput): same trait surface, no buffering.
 
 `GatewayBuilder::build` requires **exactly one** chain (`ensure_chain`) — an instance is

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -1325,7 +1325,9 @@ mod test_serial_db {
     use tycho_common::models::ChangeType;
 
     use super::*;
-    use crate::postgres::{db_fixtures, db_fixtures::yesterday_one_am, testing::run_against_db};
+    use crate::postgres::{
+        db_fixtures, db_fixtures::yesterday_one_am, orm, testing::run_against_db,
+    };
 
     #[tokio::test]
     async fn test_write_and_flush() {
@@ -1419,6 +1421,12 @@ mod test_serial_db {
                 Chain::Ethereum,
                 100,
             );
+            let next_block_id = sql_query("SELECT nextval('block_id_seq') AS value")
+                .get_result::<BigIntRow>(&mut connection)
+                .await
+                .expect("Failed to read the block id sequence")
+                .value;
+
             let os_rx = send_write_message(
                 &tx,
                 block.clone(),
@@ -1443,16 +1451,19 @@ mod test_serial_db {
 
             handle.abort();
 
-            let block_id = BlockIdentifier::Number((Chain::Ethereum, 1));
-            let fetched_block = gateway
-                .get_block(&block_id, &mut connection)
+            // The sequence does not roll back: the aborted first attempt consumed one value and
+            // the successful re-run the next one.
+            let stored_block = orm::Block::by_hash(&block.hash, &mut connection)
                 .await
-                .expect("Failed to fetch block");
-            assert_eq!(fetched_block, block);
+                .expect("Failed to fetch the block");
+            assert_eq!(stored_block.id, next_block_id + 2, "the batch must run exactly twice");
 
             let stored_token =
                 db_fixtures::get_token_by_symbol(&mut connection, "ETH".to_string()).await;
-            assert_eq!(stored_token.quality, 50);
+            assert_eq!(
+                stored_token.quality, 50,
+                "the re-run must not overwrite the concurrent update"
+            );
         })
         .await;
     }

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -43,7 +43,7 @@ use tycho_common::{
     Bytes,
 };
 
-use super::{PostgresError, PostgresGateway};
+use super::{is_transaction_conflict, PostgresError, PostgresGateway};
 
 /// Represents different types of database write operations.
 #[derive(PartialEq, Clone, Debug)]
@@ -405,7 +405,9 @@ impl DBCacheWriteExecutor {
 
             match res {
                 Ok(_) => break,
-                Err(PostgresError(StorageError::TransactionConflict(ref reason))) => {
+                Err(PostgresError(StorageError::Unexpected(ref e)))
+                    if is_transaction_conflict(e) =>
+                {
                     retry_count += 1;
                     if retry_count < max_retries {
                         let delay = std::time::Duration::from_secs(retry_count);
@@ -414,7 +416,7 @@ impl DBCacheWriteExecutor {
                             delay,
                             retry_count + 1,
                             max_retries,
-                            reason
+                            e
                         );
                         tokio::time::sleep(delay).await;
                         continue;

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -1383,30 +1383,6 @@ mod test_serial_db {
         .await;
     }
 
-    #[derive(QueryableByName)]
-    struct LockWaiters {
-        #[diesel(sql_type = diesel::sql_types::BigInt)]
-        count: i64,
-    }
-
-    /// Waits until a backend of this database blocks on a lock, up to 10 seconds.
-    async fn await_lock_waiter(conn: &mut AsyncPgConnection) {
-        for _ in 0..200 {
-            let waiters = sql_query(
-                "SELECT count(*) AS count FROM pg_stat_activity
-                 WHERE wait_event_type = 'Lock' AND datname = current_database()",
-            )
-            .get_result::<LockWaiters>(conn)
-            .await
-            .expect("Failed to query lock waiters");
-            if waiters.count >= 1 {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-        panic!("No backend blocked on a lock within 10 seconds");
-    }
-
     #[tokio::test]
     async fn test_write_retries_serialization_failure() {
         run_against_db(|connection_pool| async move {
@@ -1431,37 +1407,7 @@ mod test_serial_db {
 
             let handle = write_executor.run();
 
-            // Open a transaction that updates the token row and holds the lock until released.
-            let (ready_tx, ready_rx) = oneshot::channel();
-            let (release_tx, release_rx) = oneshot::channel();
-            let blocker_pool = connection_pool.clone();
-            let blocker = tokio::spawn(async move {
-                let mut conn = blocker_pool
-                    .get()
-                    .await
-                    .expect("Failed to get a connection from the pool");
-                conn.transaction(|conn| {
-                    async move {
-                        sql_query("UPDATE token SET quality = 50")
-                            .execute(conn)
-                            .await
-                            .expect("Failed to update the token quality");
-                        ready_tx
-                            .send(())
-                            .expect("Failed to signal the open update");
-                        release_rx
-                            .await
-                            .expect("Failed to await the release signal");
-                        Ok::<(), diesel::result::Error>(())
-                    }
-                    .scope_boxed()
-                })
-                .await
-                .expect("Blocking transaction failed");
-            });
-            ready_rx
-                .await
-                .expect("Blocking transaction never opened its update");
+            let mut blocker = start_blocking_token_update().await;
 
             let block = get_sample_block(1);
             let token = models::token::Token::new(
@@ -1480,14 +1426,15 @@ mod test_serial_db {
             )
             .await;
 
-            // The block upsert takes the batch snapshot, the token insert waits on the row lock.
+            // The block upsert takes the REPEATABLE READ snapshot, then the token insert waits on
+            // the row the blocker updated. After the commit below that row is newer than the
+            // snapshot, so Postgres raises 40001 and the executor re-runs the batch; the re-run
+            // sees the committed row and the insert is a no-op.
             await_lock_waiter(&mut connection).await;
-            release_tx
-                .send(())
-                .expect("Failed to release the blocking transaction");
-            blocker
+            sql_query("COMMIT")
+                .execute(&mut blocker)
                 .await
-                .expect("Blocking task panicked");
+                .expect("Failed to commit the blocking transaction");
 
             os_rx
                 .await
@@ -1961,6 +1908,57 @@ mod test_serial_db {
             .await
             .expect("Failed to send write message through mpsc channel");
         os_rx
+    }
+
+    #[derive(QueryableByName)]
+    struct BigIntRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        value: i64,
+    }
+
+    /// Waits until a backend of this database blocks on another transaction's row lock.
+    async fn await_lock_waiter(conn: &mut AsyncPgConnection) {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        let deadline = tokio::time::Instant::now() + TIMEOUT;
+        loop {
+            let waiters = sql_query(
+                "SELECT count(*) AS value FROM pg_stat_activity
+                 WHERE wait_event_type = 'Lock' AND wait_event = 'transactionid'
+                 AND datname = current_database()",
+            )
+            .get_result::<BigIntRow>(conn)
+            .await
+            .expect("Failed to query lock waiters");
+            if waiters.value >= 1 {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "No backend blocked on a row lock within {TIMEOUT:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Opens a transaction that updates the ETH token row and leaves it uncommitted. The caller
+    /// releases the row lock with `COMMIT` on the returned connection.
+    async fn start_blocking_token_update() -> AsyncPgConnection {
+        let db_url = std::env::var("DATABASE_URL").expect("Database URL must be set for testing");
+        // A dedicated connection: when the test panics before the commit, dropping it closes the
+        // socket and Postgres rolls the transaction back. A pooled connection would return to the
+        // pool with the transaction open and block the teardown on the row lock.
+        let mut conn = AsyncPgConnection::establish(&db_url)
+            .await
+            .expect("Failed to connect to the database");
+        sql_query("BEGIN")
+            .execute(&mut conn)
+            .await
+            .expect("Failed to begin the blocking transaction");
+        sql_query("UPDATE token SET quality = 50 WHERE symbol = 'ETH'")
+            .execute(&mut conn)
+            .await
+            .expect("Failed to update the token quality");
+        conn
     }
 
     //noinspection SpellCheckingInspection

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -315,6 +315,7 @@ pub(crate) struct DBCacheWriteExecutor {
     state_gateway: PostgresGateway,
     persisted_block: Option<models::blockchain::Block>,
     msg_receiver: mpsc::Receiver<DBCacheMessage>,
+    max_retries: u64,
 }
 
 impl DBCacheWriteExecutor {
@@ -337,7 +338,7 @@ impl DBCacheWriteExecutor {
 
         debug!("Persisted block: {:?}", persisted_block);
 
-        Self { name, chain, pool, state_gateway, persisted_block, msg_receiver }
+        Self { name, chain, pool, state_gateway, persisted_block, msg_receiver, max_retries: 3 }
     }
 
     /// Spawns a task to process incoming database messages (write requests or flush commands).
@@ -370,7 +371,7 @@ impl DBCacheWriteExecutor {
             .expect("pool should be connected");
 
         let mut retry_count = 0;
-        let max_retries = 3;
+        let max_retries = self.max_retries;
         let mut res =
             Err(PostgresError(StorageError::Unexpected("default response error".to_string())));
 
@@ -1463,6 +1464,82 @@ mod test_serial_db {
             assert_eq!(
                 stored_token.quality, 50,
                 "the re-run must not overwrite the concurrent update"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_write_fails_after_exhausted_conflict_retries() {
+        run_against_db(|connection_pool| async move {
+            let mut connection = connection_pool
+                .get()
+                .await
+                .expect("Failed to get a connection from the pool");
+            let chain_id = db_fixtures::insert_chain(&mut connection, "ethereum").await;
+            let eth_address = "0000000000000000000000000000000000000000";
+            db_fixtures::insert_token(&mut connection, chain_id, eth_address, "ETH", 18, Some(100))
+                .await;
+            let gateway: PostgresGateway = PostgresGateway::from_connection(&mut connection).await;
+            let (tx, rx) = mpsc::channel(10);
+            let mut write_executor = DBCacheWriteExecutor::new(
+                "ethereum".to_owned(),
+                Chain::Ethereum,
+                connection_pool.clone(),
+                gateway.clone(),
+                rx,
+            )
+            .await;
+            write_executor.max_retries = 1;
+
+            let handle = write_executor.run();
+
+            let mut blocker = start_blocking_token_update().await;
+
+            let block = get_sample_block(1);
+            let token = models::token::Token::new(
+                &Bytes::from_str(eth_address).expect("Invalid address"),
+                "ETH",
+                18,
+                0,
+                &[Some(100)],
+                Chain::Ethereum,
+                100,
+            );
+            let os_rx = send_write_message(
+                &tx,
+                block.clone(),
+                vec![WriteOp::UpsertBlock(vec![block.clone()]), WriteOp::InsertTokens(vec![token])],
+            )
+            .await;
+
+            await_lock_waiter(&mut connection).await;
+            sql_query("COMMIT")
+                .execute(&mut blocker)
+                .await
+                .expect("Failed to commit the blocking transaction");
+
+            let err = os_rx
+                .await
+                .expect("Response from channel ok")
+                .expect_err("The single attempt must fail on the conflict");
+
+            handle.abort();
+
+            let StorageError::Unexpected(message) = err else {
+                panic!("Expected the conflict as Unexpected, got {err:?}");
+            };
+            assert!(is_transaction_conflict(&message), "{message}");
+
+            let block_id = BlockIdentifier::Number((Chain::Ethereum, 1));
+            assert!(
+                matches!(
+                    gateway
+                        .get_block(&block_id, &mut connection)
+                        .await,
+                    Err(StorageError::NotFound(_, _))
+                ),
+                "the failed batch must not persist the block"
             );
         })
         .await;

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -405,17 +405,16 @@ impl DBCacheWriteExecutor {
 
             match res {
                 Ok(_) => break,
-                Err(PostgresError(StorageError::Unexpected(ref e)))
-                    if e.contains("deadlock detected") =>
-                {
+                Err(PostgresError(StorageError::TransactionConflict(ref reason))) => {
                     retry_count += 1;
                     if retry_count < max_retries {
                         let delay = std::time::Duration::from_secs(retry_count);
                         warn!(
-                            "Deadlock detected, retrying in {:?} (attempt {}/{})",
+                            "Transaction conflict, retrying in {:?} (attempt {}/{}): {}",
                             delay,
                             retry_count + 1,
-                            max_retries
+                            max_retries,
+                            reason
                         );
                         tokio::time::sleep(delay).await;
                         continue;
@@ -1319,6 +1318,8 @@ impl Gateway for CachedGateway {}
 mod test_serial_db {
     use std::{collections::HashSet, slice, str::FromStr, time::Duration};
 
+    use diesel::{sql_query, QueryableByName};
+    use diesel_async::RunQueryDsl;
     use tycho_common::models::ChangeType;
 
     use super::*;
@@ -1376,6 +1377,133 @@ mod test_serial_db {
                 .expect("Failed to fetch extraction state");
 
             assert_eq!(fetched_block, block);
+        })
+        .await;
+    }
+
+    #[derive(QueryableByName)]
+    struct LockWaiters {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        count: i64,
+    }
+
+    /// Waits until a backend of this database blocks on a lock, up to 10 seconds.
+    async fn await_lock_waiter(conn: &mut AsyncPgConnection) {
+        for _ in 0..200 {
+            let waiters = sql_query(
+                "SELECT count(*) AS count FROM pg_stat_activity
+                 WHERE wait_event_type = 'Lock' AND datname = current_database()",
+            )
+            .get_result::<LockWaiters>(conn)
+            .await
+            .expect("Failed to query lock waiters");
+            if waiters.count >= 1 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("No backend blocked on a lock within 10 seconds");
+    }
+
+    #[tokio::test]
+    async fn test_write_retries_serialization_failure() {
+        run_against_db(|connection_pool| async move {
+            let mut connection = connection_pool
+                .get()
+                .await
+                .expect("Failed to get a connection from the pool");
+            let chain_id = db_fixtures::insert_chain(&mut connection, "ethereum").await;
+            let eth_address = "0000000000000000000000000000000000000000";
+            db_fixtures::insert_token(&mut connection, chain_id, eth_address, "ETH", 18, Some(100))
+                .await;
+            let gateway: PostgresGateway = PostgresGateway::from_connection(&mut connection).await;
+            let (tx, rx) = mpsc::channel(10);
+            let write_executor = DBCacheWriteExecutor::new(
+                "ethereum".to_owned(),
+                Chain::Ethereum,
+                connection_pool.clone(),
+                gateway.clone(),
+                rx,
+            )
+            .await;
+
+            let handle = write_executor.run();
+
+            // Open a transaction that updates the token row and holds the lock until released.
+            let (ready_tx, ready_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            let blocker_pool = connection_pool.clone();
+            let blocker = tokio::spawn(async move {
+                let mut conn = blocker_pool
+                    .get()
+                    .await
+                    .expect("Failed to get a connection from the pool");
+                conn.transaction(|conn| {
+                    async move {
+                        sql_query("UPDATE token SET quality = 50")
+                            .execute(conn)
+                            .await
+                            .expect("Failed to update the token quality");
+                        ready_tx
+                            .send(())
+                            .expect("Failed to signal the open update");
+                        release_rx
+                            .await
+                            .expect("Failed to await the release signal");
+                        Ok::<(), diesel::result::Error>(())
+                    }
+                    .scope_boxed()
+                })
+                .await
+                .expect("Blocking transaction failed");
+            });
+            ready_rx
+                .await
+                .expect("Blocking transaction never opened its update");
+
+            let block = get_sample_block(1);
+            let token = models::token::Token::new(
+                &Bytes::from_str(eth_address).expect("Invalid address"),
+                "ETH",
+                18,
+                0,
+                &[Some(100)],
+                Chain::Ethereum,
+                100,
+            );
+            let os_rx = send_write_message(
+                &tx,
+                block.clone(),
+                vec![WriteOp::UpsertBlock(vec![block.clone()]), WriteOp::InsertTokens(vec![token])],
+            )
+            .await;
+
+            // The block upsert takes the batch snapshot, the token insert waits on the row lock.
+            await_lock_waiter(&mut connection).await;
+            release_tx
+                .send(())
+                .expect("Failed to release the blocking transaction");
+            blocker
+                .await
+                .expect("Blocking task panicked");
+
+            os_rx
+                .await
+                .expect("Response from channel ok")
+                .expect("Transaction cached");
+
+            handle.abort();
+
+            let block_id = BlockIdentifier::Number((Chain::Ethereum, 1));
+            let fetched_block = gateway
+                .get_block(&block_id, &mut connection)
+                .await
+                .expect("Failed to fetch block");
+            assert_eq!(fetched_block, block);
+
+            let stored_token =
+                db_fixtures::get_token_by_symbol(&mut connection, "ETH".to_string()).await;
+            assert_eq!(stored_token.quality, 50);
         })
         .await;
     }

--- a/crates/tycho-storage/src/postgres/mod.rs
+++ b/crates/tycho-storage/src/postgres/mod.rs
@@ -339,8 +339,22 @@ impl<T, O> WithOrdinal<T, O> {
 #[derive(Debug)]
 struct PostgresError(StorageError);
 
+/// Returns the Postgres message if the error aborted the transaction because it conflicted with a
+/// concurrent one (SQLSTATE class 40): a serialization failure or a deadlock.
+///
+/// Diesel maps 40001 to `SerializationFailure` but 40P01 to `Unknown`, hence the message check.
+fn transaction_conflict(err: &diesel::result::Error) -> Option<String> {
+    let diesel::result::Error::DatabaseError(kind, info) = err else { return None };
+    let is_conflict = matches!(kind, diesel::result::DatabaseErrorKind::SerializationFailure) ||
+        info.message() == "deadlock detected";
+    is_conflict.then(|| info.message().to_owned())
+}
+
 impl From<diesel::result::Error> for PostgresError {
     fn from(value: diesel::result::Error) -> Self {
+        if let Some(reason) = transaction_conflict(&value) {
+            return PostgresError(StorageError::TransactionConflict(reason));
+        }
         PostgresError(StorageError::Unexpected(format!("DieselError: {value}")))
     }
 }
@@ -379,6 +393,9 @@ fn storage_error_from_diesel(
     id: &str,
     fetch_args: Option<String>,
 ) -> PostgresError {
+    if let Some(reason) = transaction_conflict(&err) {
+        return PostgresError(StorageError::TransactionConflict(reason));
+    }
     let err_string = err.to_string();
     match err {
         diesel::result::Error::DatabaseError(
@@ -1475,6 +1492,63 @@ pub mod db_fixtures {
         .execute(conn)
         .await
         .expect("calculating fixture component tvl failed");
+    }
+}
+
+#[cfg(test)]
+mod tests_error_mapping {
+    use diesel::result::{DatabaseErrorKind, Error};
+
+    use super::*;
+
+    fn db_error(kind: DatabaseErrorKind, message: &str) -> Error {
+        Error::DatabaseError(kind, Box::new(message.to_string()))
+    }
+
+    #[test]
+    fn test_serialization_failure_maps_to_conflict() {
+        let message = "could not serialize access due to concurrent update";
+        let err = db_error(DatabaseErrorKind::SerializationFailure, message);
+
+        assert_eq!(
+            PostgresError::from(err).0,
+            StorageError::TransactionConflict(message.to_string())
+        );
+
+        let err = db_error(DatabaseErrorKind::SerializationFailure, message);
+        assert_eq!(
+            storage_error_from_diesel(err, "Token", "batch", None).0,
+            StorageError::TransactionConflict(message.to_string())
+        );
+    }
+
+    #[test]
+    fn test_deadlock_maps_to_conflict() {
+        let message = "deadlock detected";
+        let err = db_error(DatabaseErrorKind::Unknown, message);
+
+        assert_eq!(
+            PostgresError::from(err).0,
+            StorageError::TransactionConflict(message.to_string())
+        );
+
+        let err = db_error(DatabaseErrorKind::Unknown, message);
+        assert_eq!(
+            storage_error_from_diesel(err, "Token", "batch", None).0,
+            StorageError::TransactionConflict(message.to_string())
+        );
+    }
+
+    #[test]
+    fn test_other_database_error_stays_unexpected() {
+        let err = db_error(DatabaseErrorKind::Unknown, "some other error");
+        assert!(matches!(PostgresError::from(err).0, StorageError::Unexpected(_)));
+
+        let err = db_error(DatabaseErrorKind::Unknown, "some other error");
+        assert!(matches!(
+            storage_error_from_diesel(err, "Token", "batch", None).0,
+            StorageError::Unexpected(_)
+        ));
     }
 }
 

--- a/crates/tycho-storage/src/postgres/mod.rs
+++ b/crates/tycho-storage/src/postgres/mod.rs
@@ -339,22 +339,8 @@ impl<T, O> WithOrdinal<T, O> {
 #[derive(Debug)]
 struct PostgresError(StorageError);
 
-/// Returns the Postgres message if the error aborted the transaction because it conflicted with a
-/// concurrent one (SQLSTATE class 40): a serialization failure or a deadlock.
-///
-/// Diesel maps 40001 to `SerializationFailure` but 40P01 to `Unknown`, hence the message check.
-fn transaction_conflict(err: &diesel::result::Error) -> Option<String> {
-    let diesel::result::Error::DatabaseError(kind, info) = err else { return None };
-    let is_conflict = matches!(kind, diesel::result::DatabaseErrorKind::SerializationFailure) ||
-        info.message() == "deadlock detected";
-    is_conflict.then(|| info.message().to_owned())
-}
-
 impl From<diesel::result::Error> for PostgresError {
     fn from(value: diesel::result::Error) -> Self {
-        if let Some(reason) = transaction_conflict(&value) {
-            return PostgresError(StorageError::TransactionConflict(reason));
-        }
         PostgresError(StorageError::Unexpected(format!("DieselError: {value}")))
     }
 }
@@ -369,6 +355,14 @@ impl From<StorageError> for PostgresError {
     fn from(value: StorageError) -> Self {
         PostgresError(value)
     }
+}
+
+/// True if `message` is the Postgres error of a transaction that aborted because it conflicted
+/// with a concurrent one: a serialization failure (SQLSTATE 40001) or a deadlock (40P01). Every
+/// 40001 message starts with "could not serialize access"; the check is a `contains` because one
+/// conversion path prefixes the message with `DieselError: `.
+fn is_transaction_conflict(message: &str) -> bool {
+    message.contains("deadlock detected") || message.contains("could not serialize access")
 }
 
 fn truncate_to_byte_limit(input: &str, limit: usize) -> String {
@@ -393,9 +387,6 @@ fn storage_error_from_diesel(
     id: &str,
     fetch_args: Option<String>,
 ) -> PostgresError {
-    if let Some(reason) = transaction_conflict(&err) {
-        return PostgresError(StorageError::TransactionConflict(reason));
-    }
     let err_string = err.to_string();
     match err {
         diesel::result::Error::DatabaseError(
@@ -1496,59 +1487,23 @@ pub mod db_fixtures {
 }
 
 #[cfg(test)]
-mod tests_error_mapping {
-    use diesel::result::{DatabaseErrorKind, Error};
-
-    use super::*;
-
-    fn db_error(kind: DatabaseErrorKind, message: &str) -> Error {
-        Error::DatabaseError(kind, Box::new(message.to_string()))
-    }
+mod tests_transaction_conflict {
+    use super::is_transaction_conflict;
 
     #[test]
-    fn test_serialization_failure_maps_to_conflict() {
-        let message = "could not serialize access due to concurrent update";
-        let err = db_error(DatabaseErrorKind::SerializationFailure, message);
-
-        assert_eq!(
-            PostgresError::from(err).0,
-            StorageError::TransactionConflict(message.to_string())
-        );
-
-        let err = db_error(DatabaseErrorKind::SerializationFailure, message);
-        assert_eq!(
-            storage_error_from_diesel(err, "Token", "batch", None).0,
-            StorageError::TransactionConflict(message.to_string())
-        );
-    }
-
-    #[test]
-    fn test_deadlock_maps_to_conflict() {
-        let message = "deadlock detected";
-        let err = db_error(DatabaseErrorKind::Unknown, message);
-
-        assert_eq!(
-            PostgresError::from(err).0,
-            StorageError::TransactionConflict(message.to_string())
-        );
-
-        let err = db_error(DatabaseErrorKind::Unknown, message);
-        assert_eq!(
-            storage_error_from_diesel(err, "Token", "batch", None).0,
-            StorageError::TransactionConflict(message.to_string())
-        );
-    }
-
-    #[test]
-    fn test_other_database_error_stays_unexpected() {
-        let err = db_error(DatabaseErrorKind::Unknown, "some other error");
-        assert!(matches!(PostgresError::from(err).0, StorageError::Unexpected(_)));
-
-        let err = db_error(DatabaseErrorKind::Unknown, "some other error");
-        assert!(matches!(
-            storage_error_from_diesel(err, "Token", "batch", None).0,
-            StorageError::Unexpected(_)
-        ));
+    fn test_is_transaction_conflict() {
+        let cases = [
+            ("deadlock detected", true),
+            ("DieselError: deadlock detected", true),
+            ("could not serialize access due to concurrent update", true),
+            ("DieselError: could not serialize access due to concurrent update", true),
+            ("could not serialize access due to read/write dependencies among transactions", true),
+            ("duplicate key value violates unique constraint \"token_pkey\"", false),
+            ("Failed to update tokens: connection reset", false),
+        ];
+        for (message, expected) in cases {
+            assert_eq!(is_transaction_conflict(message), expected, "{message}");
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`bsc-tycho-indexer` (0.376.0) exited with code 1 at 02:16:36 UTC on 2026-09-04. The API was down
3 min 18 s, the auth proxy served ~950 HTTP 502s, and `bsc-fynd` and `bsc-fynd-spot` restarted. The
`uniswap_v4` write path had been stalled since 02:12:54 while the stream looked healthy:

    ERROR db_write: DBTransactionFailed error=PostgresError(Unexpected("could not serialize
    access due to concurrent update")) block_range=[119836433, 119836463] extractor_id="uniswap_v4"

## Root cause

The write executor runs each block batch at REPEATABLE READ and re-inserts every token of every
touched component with `INSERT ... ON CONFLICT DO NOTHING`. When another transaction updates one of
those token rows and commits after the batch snapshot, Postgres raises SQLSTATE 40001 on that
insert. The nightly `analyze-tokens` job is that writer: it updated ~93k BSC token rows in 94
commits during the window, as it does every night. The executor's retry loop matched only
`deadlock detected`, so the 40001 propagated. The error surfaced one commit batch later (512
blocks), and 0.376.0 has no extractor supervisor, so the process exited.

## Fix

The executor retries a batch when the Postgres message inside `StorageError::Unexpected` is a
transaction conflict: `deadlock detected` (40P01) or `could not serialize access …`, the prefix
Postgres uses for every serialization failure (40001). The check is one helper in
`tycho-storage`; no public type changes. Retries stay at three attempts with the existing 1 s and
2 s delays. The re-run gets a fresh snapshot and the token insert becomes a no-op.

A serial DB test holds the token row lock on a dedicated connection, forces a real 40001, and
checks that the block id advanced twice, so it fails when the batch does not run twice. A second
test allows one attempt and checks that the conflict reaches the caller.

## Notes for reviewers

The isolation level is unchanged. Classification is message-based on purpose: a new
`StorageError` variant adds a case to a public enum of a published crate. Postgres messages are
English unless `lc_messages` is changed, which the deadlock check already relied on.
Serialization failures wait through the deadlock backoff; an immediate retry would work but is not
worth a second predicate for a few conflicts per night.

## Follow-ups

- Stop re-inserting known tokens every batch (only the unknown set needs the insert).
- `analyze-tokens`: skip the write for tokens whose fields did not change. Its own write path
  (`update_tokens`) does not retry on conflicts.
