### PR TITLE
fix(token-analyzer): compute transfer fee without intermediate underflow

### DIFF
--- a/crates/tycho-ethereum/src/services/token_analyzer/common.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/common.rs
@@ -1,3 +1,5 @@
+use std::cmp;
+
 use alloy::{
     primitives::{keccak256, Address, U256},
     rpc::types::{BlockNumberOrTag, TransactionInput, TransactionRequest},
@@ -14,8 +16,9 @@ pub(crate) fn arbitrary_recipient() -> Address {
 
 /// Computes the transfer fee in basis points (0–10_000) from observed balance deltas.
 ///
-/// Returns the higher of the inbound and outbound fee rates. Returns zero if neither transfer
-/// shows a fee. Errors only on arithmetic overflow, which is not expected in practice.
+/// Returns the higher of the inbound and outbound fee rates. A transfer that credits the
+/// receiver with at least the amount sent has no fee. Errors only if a balance plus the amount
+/// sent overflows U256.
 pub(crate) fn calculate_fee(
     amount: U256,
     middle_amount: U256,
@@ -24,55 +27,26 @@ pub(crate) fn calculate_fee(
     balance_recipient_before: U256,
     balance_recipient_after: U256,
 ) -> Result<U256, String> {
-    Ok(
-        match (
-            balance_after_in != error_add(balance_before_in, amount)?,
-            balance_recipient_after != error_add(balance_recipient_before, middle_amount)?,
-        ) {
-            (true, true) => {
-                let first_transfer_fees = error_div(
-                    error_mul(
-                        error_add(balance_before_in, error_sub(amount, balance_after_in)?)?,
-                        U256::from(10_000),
-                    )?,
-                    amount,
-                )?;
-                let second_transfer_fees = error_div(
-                    error_mul(
-                        error_add(
-                            balance_recipient_before,
-                            error_sub(middle_amount, balance_recipient_after)?,
-                        )?,
-                        U256::from(10_000),
-                    )?,
-                    middle_amount,
-                )?;
-                if first_transfer_fees >= second_transfer_fees {
-                    first_transfer_fees
-                } else {
-                    second_transfer_fees
-                }
-            }
-            (true, false) => error_div(
-                error_mul(
-                    error_add(balance_before_in, error_sub(amount, balance_after_in)?)?,
-                    U256::from(10_000),
-                )?,
-                amount,
-            )?,
-            (false, true) => error_div(
-                error_mul(
-                    error_add(
-                        balance_recipient_before,
-                        error_sub(middle_amount, balance_recipient_after)?,
-                    )?,
-                    U256::from(10_000),
-                )?,
-                middle_amount,
-            )?,
-            (false, false) => U256::ZERO,
-        },
-    )
+    let fee_in = transfer_fee_bps(amount, balance_before_in, balance_after_in)?;
+    let fee_out =
+        transfer_fee_bps(middle_amount, balance_recipient_before, balance_recipient_after)?;
+    Ok(cmp::max(fee_in, fee_out))
+}
+
+/// Fee in basis points that one transfer of `sent` took, from the receiver's balance before
+/// and after. Zero when nothing was sent or the receiver got at least `sent`.
+fn transfer_fee_bps(sent: U256, before: U256, after: U256) -> Result<U256, String> {
+    let expected = before
+        .checked_add(sent)
+        .ok_or_else(|| format!("balance {before} + {sent} overflows"))?;
+    if sent.is_zero() || after >= expected {
+        return Ok(U256::ZERO);
+    }
+    let shortfall = expected - after;
+    let scaled = shortfall
+        .checked_mul(U256::from(10_000))
+        .ok_or_else(|| format!("shortfall {shortfall} * 10_000 overflows"))?;
+    Ok(scaled / sent)
 }
 
 /// Converts a tycho BlockTag to an alloy BlockNumberOrTag.
@@ -104,32 +78,79 @@ pub(crate) fn call_request(
     req
 }
 
-fn error_add(a: U256, b: U256) -> Result<U256, String> {
-    a.checked_add(b)
-        .ok_or_else(|| "overflow".to_string())
-}
-
-fn error_sub(a: U256, b: U256) -> Result<U256, String> {
-    a.checked_sub(b)
-        .ok_or_else(|| "overflow".to_string())
-}
-
-fn error_div(a: U256, b: U256) -> Result<U256, String> {
-    a.checked_div(b)
-        .ok_or_else(|| "overflow".to_string())
-}
-
-fn error_mul(a: U256, b: U256) -> Result<U256, String> {
-    a.checked_mul(b)
-        .ok_or_else(|| "overflow".to_string())
-}
-
 #[cfg(test)]
 mod tests {
-    use alloy::rpc::types::BlockNumberOrTag;
+    use alloy::{primitives::U256, rpc::types::BlockNumberOrTag};
     use tycho_common::models::blockchain::BlockTag;
 
-    use super::map_block_tag;
+    use super::{calculate_fee, map_block_tag};
+
+    fn fee(
+        amount: u64,
+        before_in: u64,
+        after_in: u64,
+        recipient_before: u64,
+        recipient_after: u64,
+    ) -> Result<U256, String> {
+        let after_in = U256::from(after_in);
+        let before_in = U256::from(before_in);
+        calculate_fee(
+            U256::from(amount),
+            after_in - before_in,
+            before_in,
+            after_in,
+            U256::from(recipient_before),
+            U256::from(recipient_after),
+        )
+    }
+
+    #[test]
+    fn calculate_fee_no_fee() {
+        assert_eq!(fee(1_000_000, 0, 1_000_000, 0, 1_000_000), Ok(U256::ZERO));
+    }
+
+    #[test]
+    fn calculate_fee_one_percent() {
+        assert_eq!(fee(1_000_000, 0, 990_000, 0, 980_100), Ok(U256::from(100)));
+    }
+
+    #[test]
+    fn calculate_fee_settlement_dust_above_fee() {
+        assert_eq!(fee(1_000_000, 50_000, 1_040_000, 0, 990_000), Ok(U256::from(100)));
+    }
+
+    #[test]
+    fn calculate_fee_rounding_token_with_settlement_dust() {
+        assert_eq!(fee(1_000_000, 2, 1_000_001, 0, 999_999), Ok(U256::ZERO));
+    }
+
+    #[test]
+    fn calculate_fee_bonus_token() {
+        assert_eq!(fee(1_000_000, 0, 1_000_001, 0, 1_000_001), Ok(U256::ZERO));
+    }
+
+    #[test]
+    fn calculate_fee_takes_the_higher_leg() {
+        assert_eq!(fee(1_000_000, 0, 990_000, 0, 792_000), Ok(U256::from(2_000)));
+    }
+
+    #[test]
+    fn calculate_fee_full_fee() {
+        assert_eq!(fee(1_000_000, 7, 7, 0, 0), Ok(U256::from(10_000)));
+    }
+
+    #[test]
+    fn calculate_fee_balance_near_max_errors() {
+        let result = calculate_fee(
+            U256::from(1_000_000),
+            U256::ZERO,
+            U256::MAX,
+            U256::MAX,
+            U256::ZERO,
+            U256::ZERO,
+        );
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_map_block_tag() {

--- a/crates/tycho-ethereum/src/services/token_analyzer/common.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/common.rs
@@ -171,7 +171,28 @@ mod tests {
                 balance_after: U256::ZERO,
             },
         );
-        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .ends_with("+ 1000000 overflows"));
+    }
+
+    #[test]
+    fn calculate_fee_bps_shortfall_near_max_errors() {
+        let result = calculate_fee_bps(
+            ObservedTransfer {
+                sent: U256::MAX,
+                balance_before: U256::ZERO,
+                balance_after: U256::ZERO,
+            },
+            ObservedTransfer {
+                sent: U256::ZERO,
+                balance_before: U256::ZERO,
+                balance_after: U256::ZERO,
+            },
+        );
+        assert!(result
+            .unwrap_err()
+            .ends_with("* 10_000 overflows"));
     }
 
     #[test]

--- a/crates/tycho-ethereum/src/services/token_analyzer/common.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/common.rs
@@ -35,6 +35,7 @@ impl ObservedTransfer {
         if self.sent.is_zero() || self.balance_after >= expected_after {
             return Ok(U256::ZERO);
         }
+        // Safe: the guard above returned unless balance_after < expected_after.
         let shortfall = expected_after - self.balance_after;
         Ok(shortfall
             .checked_mul(U256::from(10_000))

--- a/crates/tycho-ethereum/src/services/token_analyzer/common.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/common.rs
@@ -121,42 +121,44 @@ mod tests {
     }
 
     #[test]
-    fn calculate_fee_no_fee() {
+    fn calculate_fee_bps_no_fee() {
         assert_eq!(fee(1_000_000, 0, 1_000_000, 0, 1_000_000), Ok(U256::ZERO));
     }
 
     #[test]
-    fn calculate_fee_one_percent() {
+    fn calculate_fee_bps_one_percent() {
         assert_eq!(fee(1_000_000, 0, 990_000, 0, 980_100), Ok(U256::from(100)));
     }
 
     #[test]
-    fn calculate_fee_settlement_dust_above_fee() {
+    fn calculate_fee_bps_settlement_balance_exceeds_fee() {
         assert_eq!(fee(1_000_000, 50_000, 1_040_000, 0, 990_000), Ok(U256::from(100)));
     }
 
     #[test]
-    fn calculate_fee_rounding_token_with_settlement_dust() {
+    fn calculate_fee_bps_one_wei_short_is_zero() {
         assert_eq!(fee(1_000_000, 2, 1_000_001, 0, 999_999), Ok(U256::ZERO));
     }
 
     #[test]
-    fn calculate_fee_bonus_token() {
+    fn calculate_fee_bps_credits_more_than_sent_is_zero() {
         assert_eq!(fee(1_000_000, 0, 1_000_001, 0, 1_000_001), Ok(U256::ZERO));
     }
 
     #[test]
-    fn calculate_fee_takes_the_higher_leg() {
+    fn calculate_fee_bps_takes_the_higher_rate() {
+        // 1% inbound, 20% outbound of the 990_000 that arrived.
         assert_eq!(fee(1_000_000, 0, 990_000, 0, 792_000), Ok(U256::from(2_000)));
     }
 
     #[test]
-    fn calculate_fee_full_fee() {
+    fn calculate_fee_bps_full_fee() {
+        // Nothing arrived, so nothing is sent on.
         assert_eq!(fee(1_000_000, 7, 7, 0, 0), Ok(U256::from(10_000)));
     }
 
     #[test]
-    fn calculate_fee_balance_near_max_errors() {
+    fn calculate_fee_bps_balance_near_max_errors() {
         let result = calculate_fee_bps(
             ObservedTransfer {
                 sent: U256::from(1_000_000),

--- a/crates/tycho-ethereum/src/services/token_analyzer/common.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/common.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use alloy::{
     primitives::{keccak256, Address, U256},
     rpc::types::{BlockNumberOrTag, TransactionInput, TransactionRequest},
@@ -14,39 +12,51 @@ pub(crate) fn arbitrary_recipient() -> Address {
     Address::from_slice(&hash[..20])
 }
 
-/// Computes the transfer fee in basis points (0–10_000) from observed balance deltas.
-///
-/// Returns the higher of the inbound and outbound fee rates. A transfer that credits the
-/// receiver with at least the amount sent has no fee. Errors only if a balance plus the amount
-/// sent overflows U256.
-pub(crate) fn calculate_fee(
-    amount: U256,
-    middle_amount: U256,
-    balance_before_in: U256,
-    balance_after_in: U256,
-    balance_recipient_before: U256,
-    balance_recipient_after: U256,
-) -> Result<U256, String> {
-    let fee_in = transfer_fee_bps(amount, balance_before_in, balance_after_in)?;
-    let fee_out =
-        transfer_fee_bps(middle_amount, balance_recipient_before, balance_recipient_after)?;
-    Ok(cmp::max(fee_in, fee_out))
+/// One simulated token transfer, seen through the receiver's balance.
+pub(crate) struct ObservedTransfer {
+    /// Amount the sender transferred.
+    pub(crate) sent: U256,
+    /// Receiver balance before the transfer.
+    pub(crate) balance_before: U256,
+    /// Receiver balance after the transfer.
+    pub(crate) balance_after: U256,
 }
 
-/// Fee in basis points that one transfer of `sent` took, from the receiver's balance before
-/// and after. Zero when nothing was sent or the receiver got at least `sent`.
-fn transfer_fee_bps(sent: U256, before: U256, after: U256) -> Result<U256, String> {
-    let expected = before
-        .checked_add(sent)
-        .ok_or_else(|| format!("balance {before} + {sent} overflows"))?;
-    if sent.is_zero() || after >= expected {
-        return Ok(U256::ZERO);
+impl ObservedTransfer {
+    /// Computes the fee in basis points this transfer took from the receiver's balance change.
+    /// Zero when nothing was sent or the receiver got at least `sent`. Above 10_000 when the
+    /// receiver ends with less than it started. Errors if `balance_before + sent` or
+    /// `shortfall * 10_000` overflows U256.
+    fn fee_bps(&self) -> Result<U256, String> {
+        let expected_after = self
+            .balance_before
+            .checked_add(self.sent)
+            .ok_or_else(|| format!("balance {} + {} overflows", self.balance_before, self.sent))?;
+        if self.sent.is_zero() || self.balance_after >= expected_after {
+            return Ok(U256::ZERO);
+        }
+        let shortfall = expected_after - self.balance_after;
+        Ok(shortfall
+            .checked_mul(U256::from(10_000))
+            .ok_or_else(|| format!("shortfall {shortfall} * 10_000 overflows"))? /
+            self.sent)
     }
-    let shortfall = expected - after;
-    let scaled = shortfall
-        .checked_mul(U256::from(10_000))
-        .ok_or_else(|| format!("shortfall {shortfall} * 10_000 overflows"))?;
-    Ok(scaled / sent)
+}
+
+/// Computes the transfer fee in basis points from the two simulated transfers: `inbound` moves
+/// `amount` from a holder into the settlement contract, `outbound` moves what arrived on to the
+/// recipient.
+///
+/// Returns the higher of the two fee rates. A transfer that credits the receiver with at least
+/// the amount sent has no fee. The result exceeds 10_000 when a receiver ends with less than it
+/// started. Errors if `balance_before + sent` or `shortfall * 10_000` overflows U256.
+pub(crate) fn calculate_fee_bps(
+    inbound: ObservedTransfer,
+    outbound: ObservedTransfer,
+) -> Result<U256, String> {
+    Ok(inbound
+        .fee_bps()?
+        .max(outbound.fee_bps()?))
 }
 
 /// Converts a tycho BlockTag to an alloy BlockNumberOrTag.
@@ -83,8 +93,10 @@ mod tests {
     use alloy::{primitives::U256, rpc::types::BlockNumberOrTag};
     use tycho_common::models::blockchain::BlockTag;
 
-    use super::{calculate_fee, map_block_tag};
+    use super::{calculate_fee_bps, map_block_tag, ObservedTransfer};
 
+    // Builds the two transfers the way the detectors do: everything the settlement received
+    // (`after_in - before_in`) is sent on to the recipient.
     fn fee(
         amount: u64,
         before_in: u64,
@@ -92,15 +104,19 @@ mod tests {
         recipient_before: u64,
         recipient_after: u64,
     ) -> Result<U256, String> {
-        let after_in = U256::from(after_in);
         let before_in = U256::from(before_in);
-        calculate_fee(
-            U256::from(amount),
-            after_in - before_in,
-            before_in,
-            after_in,
-            U256::from(recipient_before),
-            U256::from(recipient_after),
+        let after_in = U256::from(after_in);
+        calculate_fee_bps(
+            ObservedTransfer {
+                sent: U256::from(amount),
+                balance_before: before_in,
+                balance_after: after_in,
+            },
+            ObservedTransfer {
+                sent: after_in - before_in,
+                balance_before: U256::from(recipient_before),
+                balance_after: U256::from(recipient_after),
+            },
         )
     }
 
@@ -141,13 +157,17 @@ mod tests {
 
     #[test]
     fn calculate_fee_balance_near_max_errors() {
-        let result = calculate_fee(
-            U256::from(1_000_000),
-            U256::ZERO,
-            U256::MAX,
-            U256::MAX,
-            U256::ZERO,
-            U256::ZERO,
+        let result = calculate_fee_bps(
+            ObservedTransfer {
+                sent: U256::from(1_000_000),
+                balance_before: U256::MAX,
+                balance_after: U256::MAX,
+            },
+            ObservedTransfer {
+                sent: U256::ZERO,
+                balance_before: U256::ZERO,
+                balance_after: U256::ZERO,
+            },
         );
         assert!(result.is_err());
     }

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -206,15 +206,25 @@ impl EthCallDetector {
             .checked_sub(r.balanceBeforeIn)
             .ok_or("settlement balance underflow after successful transfer in")?;
 
-        let fees = calculate_fee(
+        // A balance that overflows U256 when the amount sent is added to it is token behaviour,
+        // not an RPC fault. Both transfers ran, so gas is known and the tax is not.
+        let fees = match calculate_fee(
             amount,
             middle_amount,
             r.balanceBeforeIn,
             r.balanceAfterIn,
             r.recipientBefore,
             r.recipientAfter,
-        )
-        .map_err(|e| format!("Failed to calculate transfer fee: {e}"))?;
+        ) {
+            Ok(fees) => fees,
+            Err(e) => {
+                return Ok((
+                    TokenQuality::bad(format!("Failed to calculate transfer fee: {e}")),
+                    Some(gas_per_transfer),
+                    None,
+                ))
+            }
+        };
 
         let computed_balance_after_in = r
             .balanceBeforeIn
@@ -363,6 +373,35 @@ mod tests {
         assert!(gas.is_some());
         // Fee should be ~100 bps (1%)
         assert_eq!(tax, Some(U256::from(100_u64)));
+    }
+
+    #[test]
+    fn handle_response_fee_on_transfer_with_settlement_dust() {
+        // Settlement already holds 50_000 when the 1% fee token credits it with 990_000.
+        let amount = U256::from(1_000_000_u64);
+        let mut r = good_return(amount);
+        r.balanceBeforeIn = U256::from(50_000_u64);
+        r.balanceAfterIn = U256::from(1_040_000_u64);
+        r.balanceAfterOut = U256::from(50_000_u64);
+        r.recipientAfter = U256::from(990_000_u64);
+        let (quality, gas, tax) =
+            EthCallDetector::handle_response(r, amount, Address::ZERO).unwrap();
+        assert!(matches!(quality, TokenQuality::Bad { .. }));
+        assert!(gas.is_some());
+        assert_eq!(tax, Some(U256::from(100_u64)));
+    }
+
+    #[test]
+    fn handle_response_fee_overflow_is_bad() {
+        let amount = U256::from(1_000_000_u64);
+        let mut r = good_return(amount);
+        r.balanceBeforeIn = U256::MAX;
+        r.balanceAfterIn = U256::MAX;
+        let (quality, gas, tax) = EthCallDetector::handle_response(r, amount, Address::ZERO)
+            .expect("a balance near U256::MAX must yield a Bad verdict, not an error");
+        assert!(matches!(quality, TokenQuality::Bad { .. }));
+        assert_eq!(gas, Some(U256::from(27_500_u64)));
+        assert!(tax.is_none());
     }
 
     impl TestFixture {

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -230,7 +230,7 @@ impl EthCallDetector {
             }
         };
 
-        // calculate_fee_bps already rejected both sums if they overflow.
+        // Safe: calculate_fee_bps already checked this sum for overflow.
         let computed_balance_after_in = r.balanceBeforeIn + amount;
         if r.balanceAfterIn != computed_balance_after_in {
             return Ok((
@@ -257,6 +257,7 @@ impl EthCallDetector {
             ));
         }
 
+        // Safe: calculate_fee_bps already checked this sum for overflow.
         let computed_recipient_after = r.recipientBefore + middle_amount;
         if r.recipientAfter != computed_recipient_after {
             return Ok((

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -408,6 +408,19 @@ mod tests {
         assert!(tax.is_none());
     }
 
+    #[test]
+    fn handle_response_credits_more_than_sent_is_bad() {
+        let amount = U256::from(1_000_000_u64);
+        let mut r = good_return(amount);
+        r.balanceAfterIn = amount + U256::from(1_u64);
+        r.recipientAfter = amount + U256::from(1_u64);
+        let (quality, gas, tax) =
+            EthCallDetector::handle_response(r, amount, Address::ZERO).unwrap();
+        assert!(matches!(quality, TokenQuality::Bad { .. }));
+        assert_eq!(gas, Some(U256::from(27_500_u64)));
+        assert_eq!(tax, Some(U256::ZERO));
+    }
+
     impl TestFixture {
         pub(crate) fn create_ethcall_detector(&self) -> EthCallDetector {
             let rpc = self.create_rpc_client(false);

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -380,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_response_fee_on_transfer_with_settlement_dust() {
+    fn handle_response_fee_on_transfer_with_settlement_balance() {
         // Settlement already holds 50_000 when the 1% fee token credits it with 990_000.
         let amount = U256::from(1_000_000_u64);
         let mut r = good_return(amount);

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -20,7 +20,7 @@ use tycho_common::{
 use super::{
     arbitrary_recipient,
     bytecode::{analyzeCall, ANALYZER_BYTECODE, FORWARDER_BYTECODE},
-    calculate_fee, map_block_tag,
+    calculate_fee_bps, map_block_tag, ObservedTransfer,
 };
 use crate::{rpc::EthereumRpcClient, BytesCodec};
 
@@ -208,13 +208,17 @@ impl EthCallDetector {
 
         // A balance that overflows U256 when the amount sent is added to it is token behaviour,
         // not an RPC fault. Both transfers ran, so gas is known and the tax is not.
-        let fees = match calculate_fee(
-            amount,
-            middle_amount,
-            r.balanceBeforeIn,
-            r.balanceAfterIn,
-            r.recipientBefore,
-            r.recipientAfter,
+        let fees = match calculate_fee_bps(
+            ObservedTransfer {
+                sent: amount,
+                balance_before: r.balanceBeforeIn,
+                balance_after: r.balanceAfterIn,
+            },
+            ObservedTransfer {
+                sent: middle_amount,
+                balance_before: r.recipientBefore,
+                balance_after: r.recipientAfter,
+            },
         ) {
             Ok(fees) => fees,
             Err(e) => {

--- a/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/ethcall_detector.rs
@@ -206,8 +206,8 @@ impl EthCallDetector {
             .checked_sub(r.balanceBeforeIn)
             .ok_or("settlement balance underflow after successful transfer in")?;
 
-        // A balance that overflows U256 when the amount sent is added to it is token behaviour,
-        // not an RPC fault. Both transfers ran, so gas is known and the tax is not.
+        // A U256 overflow in the fee maths is token state (a balance near U256::MAX), not an RPC
+        // fault. Both transfers ran, so gas is known; the fee is not.
         let fees = match calculate_fee_bps(
             ObservedTransfer {
                 sent: amount,
@@ -230,10 +230,8 @@ impl EthCallDetector {
             }
         };
 
-        let computed_balance_after_in = r
-            .balanceBeforeIn
-            .checked_add(amount)
-            .ok_or("settlement balance overflow when checking transfer in")?;
+        // calculate_fee_bps already rejected both sums if they overflow.
+        let computed_balance_after_in = r.balanceBeforeIn + amount;
         if r.balanceAfterIn != computed_balance_after_in {
             return Ok((
                 TokenQuality::bad(format!(
@@ -259,10 +257,7 @@ impl EthCallDetector {
             ));
         }
 
-        let computed_recipient_after = r
-            .recipientBefore
-            .checked_add(middle_amount)
-            .ok_or("recipient balance overflow when checking transfer out")?;
+        let computed_recipient_after = r.recipientBefore + middle_amount;
         if r.recipientAfter != computed_recipient_after {
             return Ok((
                 TokenQuality::bad(format!(

--- a/crates/tycho-ethereum/src/services/token_analyzer/mod.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/mod.rs
@@ -3,7 +3,9 @@ mod common;
 mod ethcall_detector;
 mod trace_detector;
 
-pub(crate) use common::{arbitrary_recipient, calculate_fee, call_request, map_block_tag};
+pub(crate) use common::{
+    arbitrary_recipient, calculate_fee_bps, call_request, map_block_tag, ObservedTransfer,
+};
 pub use ethcall_detector::EthCallDetector;
 #[allow(deprecated)]
 pub use trace_detector::TraceCallDetector;

--- a/crates/tycho-ethereum/src/services/token_analyzer/trace_detector.rs
+++ b/crates/tycho-ethereum/src/services/token_analyzer/trace_detector.rs
@@ -17,7 +17,9 @@ use tycho_common::{
     Bytes,
 };
 
-use super::{arbitrary_recipient, calculate_fee, call_request, map_block_tag};
+use super::{
+    arbitrary_recipient, calculate_fee_bps, call_request, map_block_tag, ObservedTransfer,
+};
 use crate::{
     erc20::{approveCall, balanceOfCall, transferCall},
     rpc::EthereumRpcClient,
@@ -294,13 +296,17 @@ impl TraceCallDetector {
             None => return Ok((bad, Some(gas_per_transfer), None)),
         };
 
-        let fees = calculate_fee(
-            amount,
-            middle_amount,
-            balance_before_in,
-            balance_after_in,
-            balance_recipient_before,
-            balance_recipient_after,
+        let fees = calculate_fee_bps(
+            ObservedTransfer {
+                sent: amount,
+                balance_before: balance_before_in,
+                balance_after: balance_after_in,
+            },
+            ObservedTransfer {
+                sent: middle_amount,
+                balance_before: balance_recipient_before,
+                balance_after: balance_recipient_after,
+            },
         );
 
         tracing::debug!(%amount, %balance_before_in, %balance_after_in, %balance_after_out);

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -229,7 +229,7 @@ async fn analyze_batch(
         {
             Ok(res) => res,
             Err(error) => {
-                warn!(?error, "Token quality detection failed");
+                warn!(?t.address, ?error, "Token quality detection failed");
                 outcome.failed += 1;
                 continue;
             }


### PR DESCRIPTION
## Problem

The nightly `analyze-tokens` job (02:00 UTC) logs this error:

```
WARN Token quality detection failed error="Failed to calculate transfer fee: overflow"
```

In the 2026-09-09 prod run, every failed token hit this line: Base 13 of 13, BSC 257 of 257. The
36 h before that had 1,580 hits across chains.

When the analyzer returns an error, the job skips the token and leaves its quality unchanged. The
token stays in the 6–10 retry window and is retried every night, forever.

## Root cause

`calculate_fee` subtracts the receiver's new balance from the amount sent, then adds the old
balance. The subtraction underflows when the receiver already holds more than the fee. Three token
types hit this:

- a fee-on-transfer token, when settlement already holds dust
- a rounding token that credits 1 wei less than sent
- a bonus token that credits more than sent

Two smaller defects made it worse. The arithmetic helpers reported `"overflow"` for every failure,
so the message misled. And `handle_response` returned the error as `Err`, so the job read a token
defect as an RPC fault.

## Fix

`calculate_fee` now adds first and subtracts second: `(before + sent) - after`. That cannot
underflow. A receiver that gets at least `sent` pays no fee. A zero-amount transfer pays no fee.
Inputs that worked before give the same result. The four `error_*` helpers are gone.

`handle_response` now returns `Bad` instead of `Err`. The warn line now names the token address.

`TraceCallDetector` calls the same function and gets the fix.

## Notes for reviewers

Fee tokens now get a tax value and quality 50. Rounding and bonus tokens report 0 bps and stay
`Bad`, so they fall 1 per night to the floor at 5. The analyzer already treats every token with an
inexact balance move that way.

Check after the first 02:00 UTC run post-deploy: `failed=0` on the Retry pass line for
`base-analyze-tokens` and `bsc-analyze-tokens`.

## Follow-ups

- Two `checked_add` guards after the fee call still return hard errors. `calculate_fee` computes
  the same sums first, so they are unreachable. Left alone.
- BSC demotes ~65,900 tokens per night. That is the revert-cohort drain from 63334ed3f, not this
  bug.
