### PR TITLE
feat(indexer): bound token metadata fetch and recover deferred tokens

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -80,7 +80,9 @@ Protocol Substreams modules live under `protocols/` as a separate WASM workspace
 2. `ProtocolExtractor` deserializes into `BlockChanges` (tx-level state/balance/token deltas) via
    `tycho-protobuf`'s `TryFromMessage` conversions
    - `PartialBlockBuffer` accumulates sub-block messages until full-block signal arrives
-   - `TokenPreProcessor` fetches metadata (symbol, decimals) via Ethereum RPC for unknown tokens
+   - `TokenPreProcessor` fetches metadata (symbol, decimals) via Ethereum RPC for unknown tokens;
+     with an enrichment budget set, slow tokens come back `Pending` and are repaired by the
+     indexer's `token_metadata_recovery` worker (`docs/token-metadata-recovery.md`)
 3. `BlockChanges` inserted into `ReorgBuffer` (one per `ProtocolExtractor`)
    - On `BlockUndoSignal`: purge blocks after the reverted hash (falling back to the target height when the hash is unknown), emit revert messages — no DB rollback needed
    - Drain to DB when `count_blocks_before(finalized_block_height) >= commit_batch_size` — only finalized blocks ever reach DB

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9788,6 +9788,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.20",
  "tracing-test",
  "tycho-common",
  "unicode-segmentation",

--- a/crates/tycho-client-py/python/tests/test_decode.py
+++ b/crates/tycho-client-py/python/tests/test_decode.py
@@ -12,7 +12,21 @@ from tycho_indexer_client.dto import (
     SynchronizerState,
     SynchronizerStateEnum,
     Header,
+    ResponseToken,
+    Snapshot,
+    TokenMetadataStatus,
 )
+
+
+def test_token_metadata_readiness_and_recovered_snapshot():
+    token = dict(chain="ethereum", address="0x01", symbol="TEST", decimals=6,
+                 tax=0, gas=[30000], quality=100)
+    assert ResponseToken(**token).metadata_status == TokenMetadataStatus.ready
+    pending = ResponseToken(**{**token, "metadata_status": "pending", "quality": 0})
+    assert pending.metadata_status == TokenMetadataStatus.pending
+    snapshot = Snapshot(states={}, vm_storage={}, tokens={"0x01": token})
+    assert snapshot.tokens[HexBytes("0x01")].decimals == 6
+    assert Snapshot(states={}, vm_storage={}).tokens == {}
 
 
 def test_decode_snapshot(asset_dir):

--- a/crates/tycho-client-py/python/tests/test_decode.py
+++ b/crates/tycho-client-py/python/tests/test_decode.py
@@ -1,7 +1,10 @@
 import json
 
+import pytest
 from hexbytes import HexBytes
+from pydantic import ValidationError
 
+from tycho_indexer_client import TokenMetadataStatus as ExportedTokenMetadataStatus
 from tycho_indexer_client.dto import (
     Chain,
     ContractId,
@@ -22,8 +25,12 @@ def test_token_metadata_readiness_and_recovered_snapshot():
     token = dict(chain="ethereum", address="0x01", symbol="TEST", decimals=6,
                  tax=0, gas=[30000], quality=100)
     assert ResponseToken(**token).metadata_status == TokenMetadataStatus.ready
-    pending = ResponseToken(**{**token, "metadata_status": "pending", "quality": 0})
-    assert pending.metadata_status == TokenMetadataStatus.pending
+    pending = {**token, "metadata_status": "pending", "quality": 0}
+    assert ResponseToken(**pending).metadata_status == TokenMetadataStatus.pending
+    assert ResponseToken(**pending).dict()["metadata_status"] == "pending"
+    with pytest.raises(ValidationError):
+        ResponseToken(**{**token, "metadata_status": "unknown"})
+    assert ExportedTokenMetadataStatus is TokenMetadataStatus
     snapshot = Snapshot(states={}, vm_storage={}, tokens={"0x01": token})
     assert snapshot.tokens[HexBytes("0x01")].decimals == 6
     assert Snapshot(states={}, vm_storage={}).tokens == {}

--- a/crates/tycho-client-py/python/tycho_indexer_client/__init__.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/__init__.py
@@ -16,6 +16,7 @@ from .dto import (
     ResponseProtocolState,
     ResponseAccount,
     ResponseToken,
+    TokenMetadataStatus,
     HexBytes,
     ProtocolSystemsResponse,
     ComponentTvlResponse,

--- a/crates/tycho-client-py/python/tycho_indexer_client/dto.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/dto.py
@@ -165,7 +165,13 @@ class ProtocolComponent(BaseModel):
     created_at: datetime
 
 
+class TokenMetadataStatus(str, Enum):
+    ready = "ready"
+    pending = "pending"
+
+
 class ResponseToken(BaseModel):
+    metadata_status: TokenMetadataStatus = TokenMetadataStatus.ready
     chain: Union[Chain, CustomChain]
     address: HexBytes = Field(..., example="0xc9f2e6ea1637E499406986ac50ddC92401ce1f58")
     symbol: str = Field(..., example="WETH")
@@ -230,6 +236,7 @@ class ResponseAccount(BaseModel):
 
 
 class Snapshot(BaseModel):
+    tokens: Dict[HexBytes, ResponseToken] = Field(default_factory=dict)
     states: Dict[str, ComponentWithState] = Field(default_factory=dict)
     vm_storage: Dict[HexBytes, ResponseAccount] = Field(default_factory=dict)
 

--- a/crates/tycho-client/CLAUDE.md
+++ b/crates/tycho-client/CLAUDE.md
@@ -38,7 +38,9 @@ TychoStreamBuilder (stream.rs)
 2. `HttpRPCClient` fetches initial snapshot at that block synchronously; all subsequent new
    components are fetched via background tasks (`spawn_snapshot_task`) so the delta loop never
    blocks on RPC. Each component moves through `SnapshotStatus` (`Deferred` → `InFlight`
-   → removed on success, or `RetryNext` / `Blacklisted` on failure). When `partial_blocks` is
+   → removed on success, or `RetryNext` / `Blacklisted` on failure; `WaitingForTokens` parks a
+   pool whose token metadata is still pending on the server and re-checks it with exponential
+   backoff). When `partial_blocks` is
    enabled, brand-new components are held in `Deferred` state until the first message of the next
    block, then promoted to `InFlight`.
 3. `BlockSynchronizer` waits for all synchronizers, then emits a `FeedMessage` per block

--- a/crates/tycho-client/src/feed/component_tracker.rs
+++ b/crates/tycho-client/src/feed/component_tracker.rs
@@ -206,7 +206,7 @@ where
     }
 
     /// Initialise the tracked contracts list from tracked components and their entrypoints
-    fn reinitialize_contracts(&mut self) {
+    pub(crate) fn reinitialize_contracts(&mut self) {
         // Add contracts from all tracked components
         self.contracts = self
             .components

--- a/crates/tycho-client/src/feed/dto.rs
+++ b/crates/tycho-client/src/feed/dto.rs
@@ -33,6 +33,12 @@ pub struct ComponentWithState {
 /// Serializable counterpart of [`crate::feed::synchronizer::Snapshot`].
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Snapshot {
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        with = "tycho_common::serde_primitives::hex_hashmap_key"
+    )]
+    pub tokens: HashMap<Bytes, dto::ResponseToken>,
     pub states: HashMap<String, ComponentWithState>,
     #[serde(with = "tycho_common::serde_primitives::hex_hashmap_key")]
     pub vm_storage: HashMap<Bytes, ResponseAccount>,
@@ -74,6 +80,11 @@ impl From<ComponentWithState> for synchronizer::ComponentWithState {
 impl From<Snapshot> for synchronizer::Snapshot {
     fn from(value: Snapshot) -> Self {
         Self {
+            tokens: value
+                .tokens
+                .into_iter()
+                .map(|(address, token)| (address, token.into()))
+                .collect(),
             states: value
                 .states
                 .into_iter()
@@ -136,6 +147,11 @@ impl From<synchronizer::ComponentWithState> for ComponentWithState {
 impl From<synchronizer::Snapshot> for Snapshot {
     fn from(value: synchronizer::Snapshot) -> Self {
         Self {
+            tokens: value
+                .tokens
+                .into_iter()
+                .map(|(address, token)| (address, token.into()))
+                .collect(),
             states: value
                 .states
                 .into_iter()

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    sync::{Arc, RwLock},
     time::Duration,
 };
 
@@ -22,6 +23,7 @@ use tycho_common::{
         },
         contract::Account,
         protocol::{ProtocolComponent, ProtocolComponentState},
+        token::Token,
         Chain, ExtractorIdentity,
     },
     Bytes,
@@ -34,11 +36,18 @@ use crate::{
         BlockHeader, HeaderLike,
     },
     rpc::{
-        RPCClient, RPCError, SnapshotParameters, TracedEntryPointsPaginatedParams,
+        RPCClient, RPCError, SnapshotParameters, TokensParams, TracedEntryPointsPaginatedParams,
         RPC_CLIENT_CONCURRENCY,
     },
     DeltasError,
 };
+
+/// First wait before re-checking a pool parked on pending token metadata. Doubles on every
+/// further miss up to `TOKEN_METADATA_MAX_RETRY_DELAY`, mirroring the indexer's recovery
+/// worker, so a pool the server never repairs costs a bounded number of requests.
+const TOKEN_METADATA_RETRY_DELAY: Duration = Duration::from_secs(5);
+const TOKEN_METADATA_MAX_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
+const SNAPSHOT_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Error, Debug)]
 pub enum SynchronizerError {
@@ -141,6 +150,9 @@ pub struct ProtocolStateSynchronizer<R: RPCClient, D: DeltasClient> {
     /// from the moment it's queued until its snapshot is successfully applied (at which point it
     /// moves into `component_tracker.components`).
     snapshot_queue: HashMap<String, SnapshotStatus>,
+    /// How often each parked pool has been re-checked; drives the retry backoff.
+    token_retry_attempts: HashMap<String, u32>,
+    tokens: Arc<RwLock<HashMap<Bytes, Token>>>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -153,12 +165,15 @@ pub struct ComponentWithState {
 
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct Snapshot {
+    /// Metadata resolved with this snapshot, including tokens recovered after their creation.
+    pub tokens: HashMap<Bytes, Token>,
     pub states: HashMap<String, ComponentWithState>,
     pub vm_storage: HashMap<Bytes, Account>,
 }
 
 impl Snapshot {
     fn extend(&mut self, other: Snapshot) {
+        self.tokens.extend(other.tokens);
         self.states.extend(other.states);
         self.vm_storage.extend(other.vm_storage);
     }
@@ -228,11 +243,15 @@ enum SnapshotStatus {
     InFlight,
     /// The last fetch attempt failed transiently; will be re-queued on the next delta.
     RetryNext,
+    /// A token of this pool is still pending on the server. The instant is the earliest retry
+    /// time; polling the token endpoint on every block during finality would be wasted work.
+    WaitingForTokens(tokio::time::Instant),
     /// The fetch failed permanently; component is excluded until the synchronizer restarts.
     Blacklisted,
 }
 
 struct SnapshotFetchResult {
+    pending_components: Vec<String>,
     components: HashMap<String, ProtocolComponent>,
     contract_ids: HashSet<Bytes>,
     dci_update: DCIUpdate,
@@ -289,6 +308,7 @@ pub trait StateSynchronizer: Send + Sync + 'static {
 }
 
 struct FetchSnapshotParams {
+    tokens: Arc<RwLock<HashMap<Bytes, Token>>>,
     chain: Chain,
     protocol_system: String,
     block_number: u64,
@@ -300,16 +320,78 @@ struct FetchSnapshotParams {
 /// Fetches a snapshot for given components. If DCI is enabled, also traces entry
 /// points and extends `contract_ids` with any contracts they access.
 ///
-/// Returns the snapshot, the DCI update, and the complete set of contract IDs (original +
-/// DCI-discovered).
+/// Returns the ready snapshot, its DCI update and contract IDs, and component IDs waiting
+/// for metadata. Deferred pools must be retried even if their TVL does not change again.
 async fn fetch_snapshot<R: RPCClient>(
     rpc_client: &R,
-    components: HashMap<String, ProtocolComponent>,
+    mut components: HashMap<String, ProtocolComponent>,
     mut contract_ids: HashSet<Bytes>,
     params: &FetchSnapshotParams,
-) -> Result<(Snapshot, DCIUpdate, HashSet<Bytes>), SynchronizerError> {
+) -> Result<(Snapshot, DCIUpdate, HashSet<Bytes>, Vec<String>), SynchronizerError> {
     if components.is_empty() {
-        return Ok((Snapshot::default(), DCIUpdate::default(), contract_ids));
+        return Ok((Snapshot::default(), DCIUpdate::default(), contract_ids, Vec::new()));
+    }
+
+    let addresses: HashSet<_> = components
+        .values()
+        .flat_map(|c| c.tokens.iter().cloned())
+        .collect();
+    let mut tokens: HashMap<_, _> = {
+        let known = params
+            .tokens
+            .read()
+            .expect("token metadata lock poisoned");
+        addresses
+            .iter()
+            .filter_map(|address| {
+                known
+                    .get(address)
+                    .filter(|token| token.metadata_status.is_ready())
+                    .map(|token| (address.clone(), token.clone()))
+            })
+            .collect()
+    };
+    let missing: Vec<_> = addresses
+        .into_iter()
+        .filter(|a| !tokens.contains_key(a))
+        .collect();
+    for chunk in missing.chunks(1000) {
+        let response = rpc_client
+            .get_tokens(
+                TokensParams::new(params.chain)
+                    .with_addresses(chunk.to_vec())
+                    .with_pagination(0, 1000),
+            )
+            .await?;
+        for token in response.into_data() {
+            if token.metadata_status.is_ready() {
+                tokens.insert(token.address.clone(), token);
+            }
+        }
+    }
+    let mut pending = Vec::new();
+    components.retain(|id, component| {
+        let ready = component
+            .tokens
+            .iter()
+            .all(|address| tokens.contains_key(address));
+        if !ready {
+            pending.push(id.clone());
+        }
+        ready
+    });
+    // Snapshot only admitted pools. A pending pool must not install token contracts as ordinary
+    // accounts before the decoder has the metadata needed to create their proxies. Recomputed
+    // only when something was parked: otherwise the caller-supplied set, which may include
+    // entrypoint contracts, is exactly right.
+    if !pending.is_empty() {
+        contract_ids = components
+            .values()
+            .flat_map(|c| c.contract_addresses.iter().cloned())
+            .collect();
+    }
+    if components.is_empty() {
+        return Ok((Snapshot::default(), DCIUpdate::default(), contract_ids, pending));
     }
 
     let component_ids: Vec<String> = components.keys().cloned().collect();
@@ -351,11 +433,12 @@ async fn fetch_snapshot<R: RPCClient>(
     .include_balances(params.retrieve_balances)
     .include_tvl(params.include_tvl);
 
-    let snapshot = rpc_client
+    let mut snapshot = rpc_client
         .get_snapshots(&request, None, RPC_CLIENT_CONCURRENCY)
         .await?;
 
-    Ok((snapshot, dci_update, contract_ids))
+    snapshot.tokens = tokens;
+    Ok((snapshot, dci_update, contract_ids, pending))
 }
 
 /// Fetches a snapshot for new components not yet in the tracker. Calls `get_protocol_components`
@@ -367,6 +450,7 @@ async fn fetch_snapshot_background<R: RPCClient>(
 ) -> Result<SnapshotFetchResult, SynchronizerError> {
     if component_ids.is_empty() {
         return Ok(SnapshotFetchResult {
+            pending_components: Vec::new(),
             components: HashMap::new(),
             contract_ids: HashSet::new(),
             dci_update: DCIUpdate::default(),
@@ -376,8 +460,8 @@ async fn fetch_snapshot_background<R: RPCClient>(
     }
 
     let request = crate::rpc::ProtocolComponentsParams::new(params.chain, &params.protocol_system)
-        .with_component_ids(component_ids);
-    let components: HashMap<String, ProtocolComponent> = rpc_client
+        .with_component_ids(component_ids.clone());
+    let mut components: HashMap<String, ProtocolComponent> = rpc_client
         .get_protocol_components(request)
         .await?
         .into_data()
@@ -391,10 +475,26 @@ async fn fetch_snapshot_background<R: RPCClient>(
         .collect();
 
     let snapshot_block = params.block_number;
-    let (snapshot, dci_update, contract_ids) =
+    let (snapshot, dci_update, contract_ids, mut pending_components) =
         fetch_snapshot(&rpc_client, components.clone(), contract_ids, &params).await?;
 
-    Ok(SnapshotFetchResult { components, contract_ids, dci_update, snapshot, snapshot_block })
+    // Creation can arrive on the stream before its finalized component is visible over RPC.
+    // Keep the request staged so database visibility alone can eventually admit the pool.
+    pending_components.extend(
+        component_ids
+            .into_iter()
+            .filter(|id| !components.contains_key(id)),
+    );
+
+    components.retain(|id, _| !pending_components.contains(id));
+    Ok(SnapshotFetchResult {
+        pending_components,
+        components,
+        contract_ids,
+        dci_update,
+        snapshot,
+        snapshot_block,
+    })
 }
 
 impl<R, D> ProtocolStateSynchronizer<R, D>
@@ -442,6 +542,8 @@ where
             snapshot_tasks: Vec::new(),
             buffered_deltas: Vec::new(),
             snapshot_queue: HashMap::new(),
+            token_retry_attempts: HashMap::new(),
+            tokens: Default::default(),
         }
     }
 
@@ -578,12 +680,13 @@ where
                     break msg;
                 };
 
+                self.remember_tokens(&first_msg.new_tokens);
                 self.filter_deltas(&mut first_msg);
 
                 // initial snapshot
                 info!(height = first_msg.get_block().number, "First deltas received");
                 let header: BlockHeader = (&first_msg).into();
-                let deltas_msg = StateSyncMessage {
+                let mut deltas_msg = StateSyncMessage {
                     header: header.clone(),
                     snapshots: Default::default(),
                     deltas: Some(first_msg),
@@ -625,6 +728,7 @@ where
                             .into_iter()
                             .collect();
                         let fetch_params = FetchSnapshotParams {
+                            tokens: self.tokens.clone(),
                             chain: self.extractor_id.chain,
                             protocol_system: self.extractor_id.name.clone(),
                             block_number: snapshot_header.number,
@@ -640,9 +744,21 @@ where
                         )
                         .await
                         {
-                            Ok((snap, dci_update, _)) => {
+                            Ok((snap, dci_update, _, pending)) => {
+                                self.remember_tokens(&snap.tokens);
+                                for id in pending {
+                                    self.component_tracker.components.remove(&id);
+                                    self.park_for_tokens(id);
+                                }
+                                self.component_tracker.reinitialize_contracts();
                                 self.component_tracker
                                     .process_entrypoints(&dci_update);
+                                // The first message was filtered before any pool was parked;
+                                // drop the deltas of parked pools so consumers never see state
+                                // for a component that has no snapshot.
+                                if let Some(deltas) = deltas_msg.deltas.as_mut() {
+                                    self.filter_deltas(deltas);
+                                }
                                 snap
                             }
                             Err(SynchronizerError::RPCError(
@@ -695,6 +811,8 @@ where
                 select! {
                     deltas_opt = msg_rx.recv() => {
                         if let Some(mut deltas) = deltas_opt {
+                            self.remember_tokens(&deltas.new_tokens);
+                            self.invalidate_pending_snapshots(&deltas);
                             let header: BlockHeader = (&deltas).into();
                             debug!(block_number=?header.number, "Received delta message");
 
@@ -720,23 +838,28 @@ where
                             }
 
                             let (snapshots, removed_components) = {
-                                let (to_add, to_remove) =
+                                let (mut to_add, mut to_remove) =
                                     self.component_tracker.filter_updated_components(&deltas);
+                                // Explicit deletions come as `Deletion` changes; a reverted
+                                // creation comes in `deleted_protocol_components`. Both must
+                                // cancel a pending add and drop a parked or in-flight pool.
+                                let deleted = deltas
+                                    .new_protocol_components
+                                    .iter()
+                                    .filter(|(_, component)| component.change == tycho_common::models::ChangeType::Deletion)
+                                    .map(|(id, _)| id)
+                                    .chain(deltas.deleted_protocol_components.keys());
+                                for id in deleted {
+                                    to_add.retain(|candidate| candidate != id);
+                                    if !to_remove.contains(id) { to_remove.push(id.clone()); }
+                                }
 
                                 // Harvest transient retries now so they feed into truly_new.
                                 // TVL changes are not re-emitted, so without explicit re-queuing
                                 // a transiently failed component would never be retried.
                                 // Remove from the map first so the truly_new filter below treats
                                 // them the same as brand-new components.
-                                let retry_ids: Vec<String> = self
-                                    .snapshot_queue
-                                    .iter()
-                                    .filter(|(_, s)| matches!(s, SnapshotStatus::RetryNext))
-                                    .map(|(id, _)| id.clone())
-                                    .collect();
-                                for id in &retry_ids {
-                                    self.snapshot_queue.remove(id);
-                                }
+                                let retry_ids = self.take_snapshot_retries(tokio::time::Instant::now());
 
                                 // Components not yet tracked and not in the staged state machine
                                 // (not in-flight, not deferred, not blacklisted). Merges
@@ -958,9 +1081,10 @@ where
                 .push(current_delta.clone());
         }
 
-        let (tx, rx) = oneshot::channel();
+        let (mut tx, rx) = oneshot::channel();
         let rpc = self.rpc_client.clone();
         let bg_params = FetchSnapshotParams {
+            tokens: self.tokens.clone(),
             chain: self.extractor_id.chain,
             protocol_system: self.extractor_id.name.clone(),
             block_number: snapshot_block,
@@ -970,7 +1094,15 @@ where
         };
         let ids = component_ids.clone();
         tokio::spawn(async move {
-            let _ = tx.send(fetch_snapshot_background(rpc, ids, bg_params).await);
+            tokio::select! {
+                result = timeout(SNAPSHOT_FETCH_TIMEOUT, fetch_snapshot_background(rpc, ids, bg_params)) => {
+                    let result = result.unwrap_or_else(|_| Err(SynchronizerError::Timeout(
+                        format!("Background snapshot exceeded {} seconds", SNAPSHOT_FETCH_TIMEOUT.as_secs()))));
+                    let _ = tx.send(result);
+                }
+                // Dropping an invalidated task must also cancel its RPC work.
+                _ = tx.closed() => {}
+            }
         });
         for id in &component_ids {
             self.snapshot_queue
@@ -997,6 +1129,13 @@ where
                     for id in &p.component_ids {
                         self.snapshot_queue.remove(id);
                     }
+                    for id in fetch_result.pending_components {
+                        self.park_for_tokens(id);
+                    }
+                    for id in fetch_result.components.keys() {
+                        self.token_retry_attempts.remove(id);
+                    }
+                    self.remember_tokens(&fetch_result.snapshot.tokens);
                     let new_component_ids: Vec<String> = fetch_result
                         .components
                         .keys()
@@ -1060,6 +1199,102 @@ where
         }
 
         result
+    }
+
+    fn take_snapshot_retries(&mut self, now: tokio::time::Instant) -> Vec<String> {
+        let ids: Vec<_> = self
+            .snapshot_queue
+            .iter()
+            .filter(|(_, status)| {
+                matches!(status, SnapshotStatus::RetryNext) ||
+                    matches!(status, SnapshotStatus::WaitingForTokens(at) if *at <= now)
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in &ids {
+            self.snapshot_queue.remove(id);
+        }
+        ids
+    }
+
+    fn invalidate_pending_snapshots(&mut self, deltas: &BlockAggregatedChanges) {
+        let (_, removed) = self
+            .component_tracker
+            .filter_updated_components(deltas);
+        let mut removed: HashSet<_> = removed.into_iter().collect();
+        removed.extend(
+            deltas
+                .new_protocol_components
+                .iter()
+                .filter(|(_, component)| {
+                    component.change == tycho_common::models::ChangeType::Deletion
+                })
+                .map(|(id, _)| id.clone()),
+        );
+        // A reverted creation is reported here rather than as a `Deletion` change.
+        removed.extend(
+            deltas
+                .deleted_protocol_components
+                .keys()
+                .cloned(),
+        );
+        let tasks = std::mem::take(&mut self.snapshot_tasks);
+        // Any revert cancels every in-flight snapshot, even one taken below the revert target:
+        // the block a snapshot was requested at is not known to be on the surviving fork, and
+        // a fresh request is cheaper than proving it.
+        for task in tasks {
+            if deltas.revert ||
+                task.component_ids
+                    .iter()
+                    .any(|id| removed.contains(id))
+            {
+                for id in &task.component_ids {
+                    if !removed.contains(id) {
+                        self.snapshot_queue
+                            .insert(id.clone(), SnapshotStatus::RetryNext);
+                    }
+                }
+                // Receiver drop cancels the old-fork RPC future. Survivors get a fresh snapshot.
+            } else {
+                self.snapshot_tasks.push(task);
+            }
+        }
+        for id in removed {
+            self.snapshot_queue.remove(&id);
+            self.token_retry_attempts.remove(&id);
+        }
+        if deltas.revert {
+            self.buffered_deltas.clear();
+        }
+    }
+
+    /// Parks a pool whose tokens are pending on the server, doubling the wait on each miss.
+    fn park_for_tokens(&mut self, id: String) {
+        let attempts = self
+            .token_retry_attempts
+            .entry(id.clone())
+            .or_insert(0);
+        let delay = TOKEN_METADATA_RETRY_DELAY
+            .saturating_mul(1u32 << (*attempts).min(16))
+            .min(TOKEN_METADATA_MAX_RETRY_DELAY);
+        *attempts = attempts.saturating_add(1);
+        self.snapshot_queue
+            .insert(id, SnapshotStatus::WaitingForTokens(tokio::time::Instant::now() + delay));
+    }
+
+    /// Ready tokens are cached so a retry or a later snapshot can skip the token endpoint.
+    /// Deltas carry every token created on the chain, tracked or not, so this grows with chain
+    /// history rather than with the tracked set; entries are small and never rewritten.
+    fn remember_tokens(&self, tokens: &HashMap<Bytes, Token>) {
+        let mut known = self
+            .tokens
+            .write()
+            .expect("token metadata lock poisoned");
+        for (address, token) in tokens {
+            if token.metadata_status.is_ready() {
+                known.insert(address.clone(), token.clone());
+            }
+        }
     }
 
     fn is_next_expected(&self, incoming: &BlockHeader) -> bool {
@@ -1365,7 +1600,20 @@ mod test {
         deltas_client: Option<MockDeltasClient>,
     ) -> ProtocolStateSynchronizer<ArcRPCClient<MockRPCClient>, ArcDeltasClient<MockDeltasClient>>
     {
-        let rpc_client = ArcRPCClient(Arc::new(rpc_client.unwrap_or_default()));
+        let mut rpc_client = rpc_client.unwrap_or_default();
+        rpc_client
+            .expect_get_tokens()
+            .returning(|params| {
+                let tokens: Vec<_> = params
+                    .addresses()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|address| Token::new(address, "TEST", 18, 0, &[], Chain::Ethereum, 100))
+                    .collect();
+                let count = tokens.len() as i64;
+                Ok(Page::new(tokens, count, 0, 1000))
+            });
+        let rpc_client = ArcRPCClient(Arc::new(rpc_client));
         let deltas_client = ArcDeltasClient(Arc::new(deltas_client.unwrap_or_default()));
 
         ProtocolStateSynchronizer::new(
@@ -1408,6 +1656,7 @@ mod test {
         rpc.expect_get_snapshots()
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: state_snapshot_native()
                         .into_iter()
                         .map(|state| {
@@ -1435,6 +1684,7 @@ mod test {
         let exp = StateSyncMessage {
             header: header.clone(),
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: state_snapshot_native()
                     .into_iter()
                     .map(|state| {
@@ -1469,6 +1719,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -1476,7 +1727,7 @@ mod test {
             retrieve_balances: true,
             include_tvl: false,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -1500,6 +1751,7 @@ mod test {
         rpc.expect_get_snapshots()
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: state_snapshot_native()
                         .into_iter()
                         .map(|state| {
@@ -1527,6 +1779,7 @@ mod test {
         let exp = StateSyncMessage {
             header: header.clone(),
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: state_snapshot_native()
                     .into_iter()
                     .map(|state| {
@@ -1561,6 +1814,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -1568,7 +1822,7 @@ mod test {
             retrieve_balances: true,
             include_tvl: true,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -1655,6 +1909,7 @@ mod test {
             .returning(move |_request, _chunk_size, _concurrency| {
                 let vm_storage_accounts = state_snapshot_vm();
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
@@ -1701,6 +1956,7 @@ mod test {
         let exp = StateSyncMessage {
             header: header.clone(),
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: [(
                     component.id.clone(),
                     ComponentWithState {
@@ -1741,6 +1997,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -1748,7 +2005,7 @@ mod test {
             retrieve_balances: false,
             include_tvl: false,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -1777,6 +2034,7 @@ mod test {
             .returning(move |_request, _chunk_size, _concurrency| {
                 let vm_storage_accounts = state_snapshot_vm();
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
@@ -1808,6 +2066,7 @@ mod test {
         let exp = StateSyncMessage {
             header: header.clone(),
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: [(
                     component.id.clone(),
                     ComponentWithState {
@@ -1846,6 +2105,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -1853,7 +2113,7 @@ mod test {
             retrieve_balances: false,
             include_tvl: true,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -1898,6 +2158,7 @@ mod test {
             .times(1)
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component2".to_string(),
                         ComponentWithState {
@@ -1949,6 +2210,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -1956,7 +2218,7 @@ mod test {
             retrieve_balances: true,
             include_tvl: false,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -2013,6 +2275,7 @@ mod test {
             )
             .returning(move |_request, _chunk_size, _concurrency| {
                 let snap = Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component3".to_string(),
                         ComponentWithState {
@@ -2062,6 +2325,7 @@ mod test {
             .expect_get_snapshots()
             .returning(|_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [
                         (
                             "Component1".to_string(),
@@ -2267,6 +2531,7 @@ mod test {
                 ..Default::default()
             },
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: [
                     (
                         "Component1".to_string(),
@@ -2358,6 +2623,7 @@ mod test {
                 ..Default::default()
             },
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: [(
                     "Component3".to_string(),
                     ComponentWithState {
@@ -2425,6 +2691,7 @@ mod test {
             )
             .returning(move |_request, _chunk_size, _concurrency| {
                 let snap = Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component3".to_string(),
                         ComponentWithState {
@@ -2469,6 +2736,7 @@ mod test {
             .expect_get_snapshots()
             .returning(|_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [
                         (
                             "Component1".to_string(),
@@ -2682,6 +2950,7 @@ mod test {
                 ..Default::default()
             },
             snapshots: Snapshot {
+                tokens: Default::default(),
                 states: [(
                     "Component3".to_string(),
                     ComponentWithState {
@@ -3567,6 +3836,264 @@ mod test {
         }
     }
 
+    #[tokio::test]
+    async fn pending_pool_gets_fresh_metadata_and_snapshot_on_retry() {
+        let mut rpc = make_mock_client();
+        let first = Bytes::from("0x01");
+        let second = Bytes::from("0x02");
+        let pending = Token::pending(&second, Chain::Ethereum);
+        let ready = Token::new(&second, "RECOVERED", 6, 0, &[Some(30_000)], Chain::Ethereum, 100);
+        let mut sequence = mockall::Sequence::new();
+        rpc.expect_get_tokens()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Ok(Page::new(vec![pending], 1, 0, 1000)));
+        rpc.expect_get_tokens()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Ok(Page::new(vec![ready], 1, 0, 1000)));
+        rpc.expect_get_snapshots()
+            .times(2)
+            .returning(|request, _, _| {
+                assert!(!request.components.is_empty());
+                Ok(Snapshot {
+                    states: request
+                        .components
+                        .iter()
+                        .map(|(id, component)| {
+                            (
+                                id.clone(),
+                                ComponentWithState {
+                                    component: component.clone(),
+                                    state: ProtocolComponentState::new(
+                                        id,
+                                        HashMap::new(),
+                                        HashMap::new(),
+                                    ),
+                                    entrypoints: vec![],
+                                    component_tvl: None,
+                                },
+                            )
+                        })
+                        .collect(),
+                    ..Default::default()
+                })
+            });
+        let components: HashMap<_, _> = [("existing", first.clone()), ("new", second.clone())]
+            .into_iter()
+            .map(|(id, token)| {
+                (
+                    id.to_string(),
+                    ProtocolComponent { id: id.into(), tokens: vec![token], ..Default::default() },
+                )
+            })
+            .collect();
+        let params = FetchSnapshotParams {
+            tokens: Arc::new(RwLock::new(HashMap::from([(
+                first.clone(),
+                Token::new(&first, "KNOWN", 18, 0, &[], Chain::Ethereum, 100),
+            )]))),
+            chain: Chain::Ethereum,
+            protocol_system: "uniswap-v2".into(),
+            block_number: 10,
+            uses_dci: false,
+            retrieve_balances: true,
+            include_tvl: false,
+        };
+        let (initial, _, _, pending) =
+            fetch_snapshot(&rpc, components.clone(), HashSet::new(), &params)
+                .await
+                .unwrap();
+        assert_eq!(pending, vec!["new"]);
+        assert!(initial.states.contains_key("existing"));
+        assert!(!initial.states.contains_key("new"));
+        let (recovered, _, _, pending) = fetch_snapshot(
+            &rpc,
+            components,
+            HashSet::new(),
+            &FetchSnapshotParams { block_number: 12, ..params },
+        )
+        .await
+        .unwrap();
+        assert!(pending.is_empty());
+        assert!(recovered.states.contains_key("new"));
+        assert_eq!(recovered.tokens[&second].decimals, 6);
+    }
+
+    #[tokio::test]
+    async fn metadata_retry_needs_no_new_tvl_event_and_catches_up_partial_deltas() {
+        let mut sync = with_mocked_clients(true, false, None, None).with_partial_blocks(true);
+        let (tx, receiver) = oneshot::channel();
+        sync.snapshot_tasks.push(SnapshotTask {
+            component_ids: vec!["pool".into()],
+            snapshot_block: 10,
+            receiver,
+        });
+        tx.send(Ok(SnapshotFetchResult {
+            pending_components: vec!["pool".into()],
+            components: HashMap::new(),
+            contract_ids: HashSet::new(),
+            dci_update: DCIUpdate::default(),
+            snapshot: Snapshot::default(),
+            snapshot_block: 10,
+        }))
+        .ok()
+        .unwrap();
+        assert!(sync
+            .drain_completed_snapshots()
+            .states
+            .is_empty());
+        assert!(!sync
+            .component_tracker
+            .components
+            .contains_key("pool"));
+        assert!(sync
+            .take_snapshot_retries(tokio::time::Instant::now())
+            .is_empty());
+        assert_eq!(
+            sync.take_snapshot_retries(tokio::time::Instant::now() + Duration::from_secs(6)),
+            vec!["pool"]
+        );
+
+        let component = ProtocolComponent { id: "pool".into(), ..Default::default() };
+        let mut delta = make_block_changes(12, Some(1));
+        delta.state_deltas.insert(
+            "pool".into(),
+            tycho_common::models::protocol::ProtocolComponentStateDelta {
+                component_id: "pool".into(),
+                updated_attributes: HashMap::from([("reserve0".into(), Bytes::from(900u64))]),
+                ..Default::default()
+            },
+        );
+        sync.buffered_deltas.push(delta);
+        let snapshot = Snapshot {
+            states: HashMap::from([(
+                "pool".into(),
+                ComponentWithState {
+                    component: component.clone(),
+                    state: ProtocolComponentState::new(
+                        "pool",
+                        HashMap::from([("reserve0".into(), Bytes::from(100u64))]),
+                        HashMap::new(),
+                    ),
+                    entrypoints: vec![],
+                    component_tvl: None,
+                },
+            )]),
+            ..Default::default()
+        };
+        let (tx, receiver) = oneshot::channel();
+        sync.snapshot_tasks.push(SnapshotTask {
+            component_ids: vec!["pool".into()],
+            snapshot_block: 11,
+            receiver,
+        });
+        tx.send(Ok(SnapshotFetchResult {
+            pending_components: vec![],
+            components: HashMap::from([("pool".into(), component)]),
+            contract_ids: HashSet::new(),
+            dci_update: DCIUpdate::default(),
+            snapshot,
+            snapshot_block: 11,
+        }))
+        .ok()
+        .unwrap();
+        let recovered = sync.drain_completed_snapshots();
+        assert_eq!(
+            recovered.states["pool"]
+                .state
+                .attributes["reserve0"],
+            Bytes::from(900u64)
+        );
+        assert!(sync
+            .component_tracker
+            .components
+            .contains_key("pool"));
+    }
+
+    #[tokio::test]
+    async fn reorg_cancels_old_snapshot_and_removal_clears_pending_retry() {
+        let mut sync = with_mocked_clients(true, false, None, None);
+        let (tx, receiver) = oneshot::channel();
+        sync.snapshot_tasks.push(SnapshotTask {
+            component_ids: vec!["survivor".into(), "removed".into()],
+            snapshot_block: 10,
+            receiver,
+        });
+        sync.snapshot_queue.insert(
+            "removed".into(),
+            SnapshotStatus::WaitingForTokens(tokio::time::Instant::now()),
+        );
+        let mut delta = make_block_changes(11, None);
+        delta.revert = true;
+        delta
+            .component_tvl
+            .insert("removed".into(), 0.0);
+        sync.buffered_deltas.push(delta.clone());
+        sync.invalidate_pending_snapshots(&delta);
+        assert!(tx.is_closed());
+        assert!(sync.snapshot_tasks.is_empty());
+        assert!(sync.buffered_deltas.is_empty());
+        assert!(!sync
+            .snapshot_queue
+            .contains_key("removed"));
+        assert_eq!(sync.snapshot_queue["survivor"], SnapshotStatus::RetryNext);
+    }
+
+    #[tokio::test]
+    async fn reverted_creation_clears_parked_pool_and_in_flight_task() {
+        // The server reports a reverted creation in `deleted_protocol_components`, not as a
+        // `Deletion` change and not through TVL. Without handling it here a parked pool would
+        // be re-checked forever.
+        let mut sync = with_mocked_clients(true, false, None, None);
+        let (tx, receiver) = oneshot::channel();
+        sync.snapshot_tasks.push(SnapshotTask {
+            component_ids: vec!["reverted".into()],
+            snapshot_block: 10,
+            receiver,
+        });
+        sync.park_for_tokens("parked".into());
+        let mut delta = make_block_changes(11, None);
+        delta.revert = true;
+        delta
+            .deleted_protocol_components
+            .insert("parked".into(), ProtocolComponent::default());
+        delta
+            .deleted_protocol_components
+            .insert("reverted".into(), ProtocolComponent::default());
+        sync.invalidate_pending_snapshots(&delta);
+        assert!(tx.is_closed());
+        assert!(sync.snapshot_tasks.is_empty());
+        assert!(sync.snapshot_queue.is_empty());
+        assert!(sync.token_retry_attempts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn parked_pool_backoff_doubles_and_resets_on_admission() {
+        let mut sync = with_mocked_clients(true, false, None, None);
+        let retry_at = |queue: &HashMap<String, SnapshotStatus>| match queue["pool"] {
+            SnapshotStatus::WaitingForTokens(at) => at,
+            ref other => panic!("unexpected status {other:?}"),
+        };
+        let mut expected = TOKEN_METADATA_RETRY_DELAY;
+        for _ in 0..12 {
+            let now = tokio::time::Instant::now();
+            sync.park_for_tokens("pool".into());
+            let wait = retry_at(&sync.snapshot_queue) - now;
+            assert!(wait >= expected && wait <= expected + Duration::from_millis(50));
+            expected = (expected * 2).min(TOKEN_METADATA_MAX_RETRY_DELAY);
+        }
+        assert_eq!(expected, TOKEN_METADATA_MAX_RETRY_DELAY);
+
+        sync.token_retry_attempts.remove("pool");
+        let now = tokio::time::Instant::now();
+        sync.park_for_tokens("pool".into());
+        assert!(
+            retry_at(&sync.snapshot_queue) - now <=
+                TOKEN_METADATA_RETRY_DELAY + Duration::from_millis(50)
+        );
+    }
+
     /// Test that full block as first message in partial mode is accepted
     #[test_log::test(tokio::test)]
     async fn test_partial_mode_accepts_full_block_as_first_message() {
@@ -3720,6 +4247,7 @@ mod test {
         rpc.expect_get_snapshots()
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
@@ -3765,6 +4293,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -3772,7 +4301,7 @@ mod test {
             retrieve_balances: true,
             include_tvl: false,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -3792,6 +4321,7 @@ mod test {
         rpc.expect_get_snapshots()
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
@@ -3837,6 +4367,7 @@ mod test {
             .into_iter()
             .collect();
         let params = FetchSnapshotParams {
+            tokens: Default::default(),
             chain: Chain::Ethereum,
             protocol_system: "uniswap-v2".to_string(),
             block_number: header.number,
@@ -3844,7 +4375,7 @@ mod test {
             retrieve_balances: true,
             include_tvl: false,
         };
-        let (snapshot, _, _) =
+        let (snapshot, _, _, _) =
             fetch_snapshot(&state_sync.rpc_client, components, contract_ids, &params)
                 .await
                 .expect("Retrieving snapshot failed");
@@ -3924,6 +4455,7 @@ mod test {
             )
             .returning(move |_request, _chunk_size, _concurrency| {
                 let snap = Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [
                         (
                             "BrandNew".to_string(),
@@ -3970,6 +4502,7 @@ mod test {
             .expect_get_snapshots()
             .returning(|_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
+                    tokens: Default::default(),
                     states: [
                         (
                             "Component1".to_string(),
@@ -4162,6 +4695,7 @@ mod test {
         // Build the snapshot at block 5: one component with attributes and balances,
         // one VM contract with slots and native balance.
         let mut snapshot = Snapshot {
+            tokens: Default::default(),
             states: [(
                 "comp1".to_string(),
                 ComponentWithState {

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -1453,7 +1453,7 @@ mod test {
         },
         protocol::{ProtocolComponent, ProtocolComponentState},
         token::Token,
-        Chain,
+        Chain, ChangeType,
     };
     use uuid::Uuid;
 
@@ -3879,15 +3879,25 @@ mod test {
                     ..Default::default()
                 })
             });
-        let components: HashMap<_, _> = [("existing", first.clone()), ("new", second.clone())]
-            .into_iter()
-            .map(|(id, token)| {
-                (
-                    id.to_string(),
-                    ProtocolComponent { id: id.into(), tokens: vec![token], ..Default::default() },
-                )
-            })
-            .collect();
+        let pool_contract = Bytes::from("0xaa");
+        let entrypoint_contract = Bytes::from("0xee");
+        let components: HashMap<_, _> = [
+            ("existing", first.clone(), vec![]),
+            ("new", second.clone(), vec![pool_contract.clone()]),
+        ]
+        .into_iter()
+        .map(|(id, token, contract_addresses)| {
+            (
+                id.to_string(),
+                ProtocolComponent {
+                    id: id.into(),
+                    tokens: vec![token],
+                    contract_addresses,
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
         let params = FetchSnapshotParams {
             tokens: Arc::new(RwLock::new(HashMap::from([(
                 first.clone(),
@@ -3900,17 +3910,24 @@ mod test {
             retrieve_balances: true,
             include_tvl: false,
         };
-        let (initial, _, _, pending) =
-            fetch_snapshot(&rpc, components.clone(), HashSet::new(), &params)
-                .await
-                .unwrap();
+        let (initial, _, contract_ids, pending) = fetch_snapshot(
+            &rpc,
+            components.clone(),
+            HashSet::from([entrypoint_contract.clone()]),
+            &params,
+        )
+        .await
+        .unwrap();
         assert_eq!(pending, vec!["new"]);
         assert!(initial.states.contains_key("existing"));
         assert!(!initial.states.contains_key("new"));
-        let (recovered, _, _, pending) = fetch_snapshot(
+        // A parked pool must not install its contracts or leak its pending token.
+        assert!(!contract_ids.contains(&pool_contract));
+        assert!(!initial.tokens.contains_key(&second));
+        let (recovered, _, contract_ids, pending) = fetch_snapshot(
             &rpc,
             components,
-            HashSet::new(),
+            HashSet::from([entrypoint_contract.clone()]),
             &FetchSnapshotParams { block_number: 12, ..params },
         )
         .await
@@ -3918,11 +3935,13 @@ mod test {
         assert!(pending.is_empty());
         assert!(recovered.states.contains_key("new"));
         assert_eq!(recovered.tokens[&second].decimals, 6);
+        // With nothing parked the caller's contract set is used as-is.
+        assert!(contract_ids.contains(&entrypoint_contract));
     }
 
     #[tokio::test]
-    async fn metadata_retry_needs_no_new_tvl_event_and_catches_up_partial_deltas() {
-        let mut sync = with_mocked_clients(true, false, None, None).with_partial_blocks(true);
+    async fn metadata_retry_needs_no_new_tvl_event_and_catches_up_buffered_deltas() {
+        let mut sync = with_mocked_clients(true, false, None, None);
         let (tx, receiver) = oneshot::channel();
         sync.snapshot_tasks.push(SnapshotTask {
             component_ids: vec!["pool".into()],
@@ -3951,21 +3970,27 @@ mod test {
             .take_snapshot_retries(tokio::time::Instant::now())
             .is_empty());
         assert_eq!(
-            sync.take_snapshot_retries(tokio::time::Instant::now() + Duration::from_secs(6)),
+            sync.take_snapshot_retries(
+                tokio::time::Instant::now() + TOKEN_METADATA_RETRY_DELAY + Duration::from_secs(1)
+            ),
             vec!["pool"]
         );
 
         let component = ProtocolComponent { id: "pool".into(), ..Default::default() };
-        let mut delta = make_block_changes(12, Some(1));
-        delta.state_deltas.insert(
-            "pool".into(),
-            tycho_common::models::protocol::ProtocolComponentStateDelta {
-                component_id: "pool".into(),
-                updated_attributes: HashMap::from([("reserve0".into(), Bytes::from(900u64))]),
-                ..Default::default()
-            },
-        );
-        sync.buffered_deltas.push(delta);
+        // The delta at the snapshot block is already reflected in the snapshot and must be
+        // skipped; only the one after it may be applied.
+        for (block, attribute, value) in [(11, "reserve0", 500u64), (12, "reserve1", 900u64)] {
+            let mut delta = make_block_changes(block, None);
+            delta.state_deltas.insert(
+                "pool".into(),
+                tycho_common::models::protocol::ProtocolComponentStateDelta {
+                    component_id: "pool".into(),
+                    updated_attributes: HashMap::from([(attribute.into(), Bytes::from(value))]),
+                    ..Default::default()
+                },
+            );
+            sync.buffered_deltas.push(delta);
+        }
         let snapshot = Snapshot {
             states: HashMap::from([(
                 "pool".into(),
@@ -3999,12 +4024,11 @@ mod test {
         .ok()
         .unwrap();
         let recovered = sync.drain_completed_snapshots();
-        assert_eq!(
-            recovered.states["pool"]
-                .state
-                .attributes["reserve0"],
-            Bytes::from(900u64)
-        );
+        let attributes = &recovered.states["pool"]
+            .state
+            .attributes;
+        assert_eq!(attributes["reserve0"], Bytes::from(100u64));
+        assert_eq!(attributes["reserve1"], Bytes::from(900u64));
         assert!(sync
             .component_tracker
             .components
@@ -4054,7 +4078,7 @@ mod test {
         });
         sync.park_for_tokens("parked".into());
         let mut delta = make_block_changes(11, None);
-        delta.revert = true;
+        delta.revert = false;
         delta
             .deleted_protocol_components
             .insert("parked".into(), ProtocolComponent::default());
@@ -4069,29 +4093,186 @@ mod test {
     }
 
     #[tokio::test]
+    async fn explicit_deletion_clears_parked_pool_and_in_flight_task() {
+        let mut sync = with_mocked_clients(true, false, None, None);
+        let (tx, receiver) = oneshot::channel();
+        sync.snapshot_tasks.push(SnapshotTask {
+            component_ids: vec!["deleted".into()],
+            snapshot_block: 10,
+            receiver,
+        });
+        sync.park_for_tokens("parked".into());
+        let mut delta = make_block_changes(11, None);
+        delta.revert = false;
+        for id in ["parked", "deleted"] {
+            delta.new_protocol_components.insert(
+                id.into(),
+                ProtocolComponent {
+                    id: id.into(),
+                    change: ChangeType::Deletion,
+                    ..Default::default()
+                },
+            );
+        }
+        sync.invalidate_pending_snapshots(&delta);
+        assert!(tx.is_closed());
+        assert!(sync.snapshot_tasks.is_empty());
+        assert!(sync.snapshot_queue.is_empty());
+        assert!(sync.token_retry_attempts.is_empty());
+    }
+
+    #[tokio::test]
     async fn parked_pool_backoff_doubles_and_resets_on_admission() {
         let mut sync = with_mocked_clients(true, false, None, None);
         let retry_at = |queue: &HashMap<String, SnapshotStatus>| match queue["pool"] {
             SnapshotStatus::WaitingForTokens(at) => at,
             ref other => panic!("unexpected status {other:?}"),
         };
+        // Pausing tokio's clock needs its `test-util` feature, which this crate does not
+        // enable. Every delay is a whole number of seconds and parking takes microseconds, so
+        // comparing whole seconds is exact.
         let mut expected = TOKEN_METADATA_RETRY_DELAY;
+        let mut last_wait = Duration::ZERO;
         for _ in 0..12 {
             let now = tokio::time::Instant::now();
             sync.park_for_tokens("pool".into());
-            let wait = retry_at(&sync.snapshot_queue) - now;
-            assert!(wait >= expected && wait <= expected + Duration::from_millis(50));
+            last_wait = retry_at(&sync.snapshot_queue) - now;
+            assert_eq!(last_wait.as_secs(), expected.as_secs());
             expected = (expected * 2).min(TOKEN_METADATA_MAX_RETRY_DELAY);
         }
-        assert_eq!(expected, TOKEN_METADATA_MAX_RETRY_DELAY);
+        assert_eq!(last_wait.as_secs(), TOKEN_METADATA_MAX_RETRY_DELAY.as_secs());
 
-        sync.token_retry_attempts.remove("pool");
+        // Admission through a completed snapshot resets the backoff.
+        let (tx, receiver) = oneshot::channel();
+        sync.snapshot_tasks.push(SnapshotTask {
+            component_ids: vec!["pool".into()],
+            snapshot_block: 10,
+            receiver,
+        });
+        tx.send(Ok(SnapshotFetchResult {
+            pending_components: vec![],
+            components: HashMap::from([(
+                "pool".into(),
+                ProtocolComponent { id: "pool".into(), ..Default::default() },
+            )]),
+            contract_ids: HashSet::new(),
+            dci_update: DCIUpdate::default(),
+            snapshot: Snapshot::default(),
+            snapshot_block: 10,
+        }))
+        .ok()
+        .unwrap();
+        sync.drain_completed_snapshots();
+        assert!(!sync
+            .token_retry_attempts
+            .contains_key("pool"));
+
         let now = tokio::time::Instant::now();
         sync.park_for_tokens("pool".into());
-        assert!(
-            retry_at(&sync.snapshot_queue) - now <=
-                TOKEN_METADATA_RETRY_DELAY + Duration::from_millis(50)
+        assert_eq!(
+            (retry_at(&sync.snapshot_queue) - now).as_secs(),
+            TOKEN_METADATA_RETRY_DELAY.as_secs()
         );
+    }
+
+    #[tokio::test]
+    async fn late_component_ids_stay_pending_in_background_fetch() {
+        let mut rpc = make_mock_client();
+        rpc.expect_get_protocol_components()
+            .times(1)
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 100)));
+        rpc.expect_get_snapshots().times(0);
+        let params = FetchSnapshotParams {
+            tokens: Default::default(),
+            chain: Chain::Ethereum,
+            protocol_system: "uniswap-v2".into(),
+            block_number: 10,
+            uses_dci: false,
+            retrieve_balances: true,
+            include_tvl: false,
+        };
+        let result = fetch_snapshot_background(rpc, vec!["late".into()], params)
+            .await
+            .unwrap();
+        assert_eq!(result.pending_components, vec!["late"]);
+        assert!(result.components.is_empty());
+    }
+
+    #[tokio::test]
+    async fn first_message_drops_deltas_of_pools_parked_for_tokens() {
+        let token = Bytes::from("0x02");
+        let mut rpc_client = make_mock_client();
+        let pending = token.clone();
+        rpc_client
+            .expect_get_tokens()
+            .returning(move |_| {
+                Ok(Page::new(vec![Token::pending(&pending, Chain::Ethereum)], 1, 0, 1000))
+            });
+        let component_token = token.clone();
+        rpc_client
+            .expect_get_protocol_components()
+            .returning(move |_| {
+                Ok(Page::new(
+                    vec![ProtocolComponent {
+                        id: "Component1".to_string(),
+                        tokens: vec![component_token.clone()],
+                        ..Default::default()
+                    }],
+                    1,
+                    0,
+                    100,
+                ))
+            });
+        rpc_client
+            .expect_get_snapshots()
+            .times(0);
+        let mut deltas_client = MockDeltasClient::new();
+        let (tx, rx) = channel(1);
+        deltas_client
+            .expect_subscribe()
+            .return_once(move |_, _| Ok((Uuid::default(), rx)));
+        deltas_client
+            .expect_unsubscribe()
+            .return_once(|_| Ok(()));
+        let mut sync = with_mocked_clients(true, false, Some(rpc_client), Some(deltas_client));
+        sync.initialize()
+            .await
+            .expect("Init failed");
+
+        let mut delta = make_block_changes(1, None);
+        delta.state_deltas.insert(
+            "Component1".into(),
+            tycho_common::models::protocol::ProtocolComponentStateDelta {
+                component_id: "Component1".into(),
+                updated_attributes: HashMap::from([("reserve0".into(), Bytes::from(1u64))]),
+                ..Default::default()
+            },
+        );
+        let (mut block_tx, mut block_rx) = channel::<SyncResult<StateSyncMessage<BlockHeader>>>(15);
+        let (end_tx, end_rx) = oneshot::channel();
+        let driver = async {
+            tx.send(delta)
+                .await
+                .expect("deltas channel closed");
+            let first = timeout(Duration::from_millis(200), block_rx.recv())
+                .await
+                .expect("waiting for first state msg timed out")
+                .expect("state sync block sender closed")
+                .expect("state sync errored");
+            end_tx
+                .send(())
+                .expect("close signal not received");
+            first
+        };
+        let (result, first) = tokio::join!(sync.state_sync(&mut block_tx, end_rx), driver);
+        assert!(result.is_ok());
+        assert!(first.snapshots.states.is_empty());
+        assert!(!first
+            .deltas
+            .expect("first message carries deltas")
+            .state_deltas
+            .contains_key("Component1"));
+        assert!(matches!(sync.snapshot_queue["Component1"], SnapshotStatus::WaitingForTokens(_)));
     }
 
     /// Test that full block as first message in partial mode is accepted

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -293,6 +293,7 @@ impl ProtocolStatesParams {
 #[derive(Clone, PartialEq, Debug)]
 pub struct TokensParams {
     chain: Chain,
+    token_addresses: Option<Vec<Bytes>>,
     min_quality: Option<i32>,
     traded_n_days_ago: Option<u64>,
     page: i64,
@@ -303,11 +304,21 @@ impl TokensParams {
     pub fn new(chain: Chain) -> Self {
         Self {
             chain,
+            token_addresses: None,
             min_quality: None,
             traded_n_days_ago: None,
             page: 0,
             page_size: TokensRequestBody::MAX_PAGE_SIZE_COMPRESSED,
         }
+    }
+
+    pub fn with_addresses(mut self, addresses: Vec<Bytes>) -> Self {
+        self.token_addresses = Some(addresses);
+        self
+    }
+
+    pub fn addresses(&self) -> Option<&[Bytes]> {
+        self.token_addresses.as_deref()
     }
 
     pub fn with_min_quality(mut self, min_quality: i32) -> Self {
@@ -1662,7 +1673,7 @@ impl RPCClient for HttpRPCClient {
 
     async fn get_tokens(&self, params: TokensParams) -> Result<Page<Vec<Token>>, RPCError> {
         let request = TokensRequestBody {
-            token_addresses: None,
+            token_addresses: params.token_addresses,
             min_quality: params.min_quality,
             traded_n_days_ago: params.traded_n_days_ago,
             pagination: PaginationParams { page: params.page, page_size: params.page_size },
@@ -1978,7 +1989,7 @@ impl RPCClient for HttpRPCClient {
             HashMap::new()
         };
 
-        Ok(Snapshot { states, vm_storage })
+        Ok(Snapshot { states, vm_storage, tokens: Default::default() })
     }
 }
 
@@ -2352,6 +2363,7 @@ mod tests {
 
         let expected = vec![
             Token {
+                metadata_status: Default::default(),
                 chain: tycho_common::models::Chain::Ethereum,
                 address: Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap(),
                 symbol: "WETH".to_string(),
@@ -2361,6 +2373,7 @@ mod tests {
                 quality: 100,
             },
             Token {
+                metadata_status: Default::default(),
                 chain: tycho_common::models::Chain::Ethereum,
                 address: Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
                 symbol: "USDC".to_string(),

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -23,8 +23,8 @@ use uuid::Uuid;
 
 use crate::{
     models::{
-        self, chain_config::ChainConfigError, Address, Balance, Code, ComponentId, StoreKey,
-        StoreVal,
+        self, chain_config::ChainConfigError, token::TokenMetadataStatus, Address, Balance, Code,
+        ComponentId, StoreKey, StoreVal,
     },
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
@@ -1259,6 +1259,11 @@ impl TokensRequestResponse {
 #[serde(rename = "Token")]
 /// Token struct for the response from Tycho server for a tokens request.
 pub struct ResponseToken {
+    /// Pending tokens are unavailable regardless of their quality threshold.
+    // Referenced by its bare name so utoipa emits `#/components/schemas/TokenMetadataStatus`,
+    // matching the component registered in the indexer's OpenAPI document.
+    #[serde(default, skip_serializing_if = "TokenMetadataStatus::is_ready")]
+    pub metadata_status: TokenMetadataStatus,
     pub chain: Chain,
     /// The address of this token as hex encoded string
     #[schema(value_type=String, example="0xc9f2e6ea1637E499406986ac50ddC92401ce1f58")]
@@ -1286,6 +1291,7 @@ pub struct ResponseToken {
 impl From<models::token::Token> for ResponseToken {
     fn from(value: models::token::Token) -> Self {
         Self {
+            metadata_status: value.metadata_status,
             chain: value.chain.into(),
             address: value.address,
             symbol: value.symbol,

--- a/crates/tycho-common/src/models/token.rs
+++ b/crates/tycho-common/src/models/token.rs
@@ -309,6 +309,15 @@ mod tests {
         let dto = ResponseToken::from(pending);
         let json = serde_json::to_value(&dto).unwrap();
         assert_eq!(json["metadata_status"], "pending");
+        let mut legacy_dto = json.clone();
+        legacy_dto
+            .as_object_mut()
+            .unwrap()
+            .remove("metadata_status");
+        assert!(serde_json::from_value::<ResponseToken>(legacy_dto)
+            .unwrap()
+            .metadata_status
+            .is_ready());
         let restored: Token = serde_json::from_value::<ResponseToken>(json)
             .unwrap()
             .into();

--- a/crates/tycho-common/src/models/token.rs
+++ b/crates/tycho-common/src/models/token.rs
@@ -17,8 +17,38 @@ pub type TransferCost = u64;
 /// Tax related to a token transfer. Should be given in Basis Points (1/100th of a percent)
 pub type TransferTax = u64;
 
+/// Whether token metadata and transfer analysis have finished. Readiness is independent of
+/// quality: a completed analysis can classify a token as bad, while an RPC timeout cannot.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    Deserialize,
+    Serialize,
+    Eq,
+    PartialEq,
+    Hash,
+    DeepSizeOf,
+    utoipa::ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenMetadataStatus {
+    #[default]
+    Ready,
+    Pending,
+}
+
+impl TokenMetadataStatus {
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready)
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, DeepSizeOf)]
 pub struct Token {
+    #[serde(default, skip_serializing_if = "TokenMetadataStatus::is_ready")]
+    pub metadata_status: TokenMetadataStatus,
     pub address: Bytes,
     pub symbol: String,
     pub decimals: u32,
@@ -46,6 +76,7 @@ impl Token {
         quality: u32,
     ) -> Self {
         Self {
+            metadata_status: TokenMetadataStatus::Ready,
             address: address.clone(),
             symbol: symbol.to_string(),
             decimals,
@@ -53,6 +84,14 @@ impl Token {
             gas: gas.to_owned(),
             chain,
             quality,
+        }
+    }
+
+    /// An unresolved token identity. Its numeric fields must not be used until enrichment finishes.
+    pub fn pending(address: &Bytes, chain: Chain) -> Self {
+        Self {
+            metadata_status: TokenMetadataStatus::Pending,
+            ..Self::new(address, &address.to_string(), 0, 0, &[], chain, 0)
         }
     }
 
@@ -107,6 +146,7 @@ impl From<Arc<Token>> for Address {
 impl From<ResponseToken> for Token {
     fn from(value: ResponseToken) -> Self {
         Self {
+            metadata_status: value.metadata_status,
             chain: value.chain.into(),
             address: value.address,
             symbol: value.symbol,
@@ -252,6 +292,27 @@ mod tests {
         );
 
         assert_eq!(usdc.one(), BigUint::from(1000000u64));
+    }
+
+    #[test]
+    fn metadata_readiness_is_backward_compatible_and_survives_dto_conversion() {
+        let address = Bytes::from("0x01");
+        let ready = Token::new(&address, "TEST", 6, 0, &[], Chain::Ethereum, 100);
+        let legacy = serde_json::to_value(&ready).unwrap();
+        assert!(legacy.get("metadata_status").is_none());
+        assert!(serde_json::from_value::<Token>(legacy)
+            .unwrap()
+            .metadata_status
+            .is_ready());
+
+        let pending = Token::pending(&address, Chain::Ethereum);
+        let dto = ResponseToken::from(pending);
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["metadata_status"], "pending");
+        let restored: Token = serde_json::from_value::<ResponseToken>(json)
+            .unwrap()
+            .into();
+        assert_eq!(restored.metadata_status, TokenMetadataStatus::Pending);
     }
 
     #[tokio::test]

--- a/crates/tycho-common/src/traits.rs
+++ b/crates/tycho-common/src/traits.rs
@@ -186,8 +186,9 @@ pub trait TokenPreProcessor: Send + Sync {
     /// * `block` - The block tag at which the information should be retrieved.
     ///
     /// # Returns
-    /// A vector of `CurrencyToken` objects, each containing the processed information for the
-    /// token.
+    /// Tokens in first-occurrence input order. Implementations may deduplicate addresses and
+    /// return pending identities when enrichment cannot complete. Callers must persist pending
+    /// identities for recovery and must not use their numeric fields for pricing or admission.
     async fn get_tokens(
         &self,
         addresses: Vec<Bytes>,

--- a/crates/tycho-ethereum/CLAUDE.md
+++ b/crates/tycho-ethereum/CLAUDE.md
@@ -15,7 +15,9 @@ gas.rs                  BlockGasPrice / GasPrice (Legacy + EIP-1559) data types
 
 services/
   ├─ account_extractor.rs     Fetches code, balance, storage for accounts at a block height
-  ├─ token_pre_processor.rs   Fetches symbol + decimals; gracefully handles non-standard tokens
+  ├─ token_pre_processor.rs   Fetches symbol + decimals (batched, 4 tokens concurrently) and runs transfer
+  │                           analysis; optional enrichment budget returns Pending identities instead of
+  │                           blocking. Gracefully handles non-standard tokens
   ├─ token_analyzer/
   │    ├─ mod.rs              Public API; re-exports EthCallDetector (primary) and TraceCallDetector (deprecated)
   │    ├─ ethcall_detector.rs EthCallDetector — simulates token transfers via eth_call with bytecode state overrides; works on all EVM chains

--- a/crates/tycho-ethereum/Cargo.toml
+++ b/crates/tycho-ethereum/Cargo.toml
@@ -43,6 +43,7 @@ pretty_assertions.workspace = true
 mockito.workspace = true
 rstest.workspace = true
 tracing-test = "0.2.5"
+tracing-subscriber = { workspace = true, features = ["registry"] }
 
 [[example]]
 name = "run-analysis"

--- a/crates/tycho-ethereum/benchmarks/token-metadata/README.md
+++ b/crates/tycho-ethereum/benchmarks/token-metadata/README.md
@@ -1,0 +1,94 @@
+# Live token-metadata benchmark
+
+This opt-in benchmark sends real, read-only RPC requests through Tycho's token
+preprocessor and `EthCallDetector`. It does not use a mock RPC server and does not
+submit transactions. It is an ignored Rust test so it can reuse private methods
+without adding a production API just for benchmarking.
+
+## Run
+
+From the repository root:
+
+```sh
+ROBINHOOD_RPC_URL=https://rpc.mainnet.chain.robinhood.com \
+TOKEN_BENCH_ROUNDS=10 \
+TOKEN_BENCH_OUTPUT=/tmp/robinhood-token-metadata.jsonl \
+cargo test --locked -p tycho-ethereum --lib benchmark_robinhood_token_metadata \
+  -- --ignored --nocapture --test-threads=1
+
+python3 crates/tycho-ethereum/benchmarks/token-metadata/summarize.py \
+  /tmp/robinhood-token-metadata.jsonl
+```
+
+The benchmark compares `sequential` (original), `concurrent` (no batching) and
+`batched` (current production path). Ten rounds produce 60 measured samples.
+The output must not already exist. Each observation is flushed as it completes,
+so interrupted or failed runs leave their partial evidence intact. An incomplete
+run is not a successful benchmark. Use a fresh filename for every run.
+
+The [documented public Robinhood endpoint](https://docs.robinhood.com/chain/connecting/)
+is rate-limited and not intended for production. The benchmark pauses two seconds
+between samples and defaults to ten rounds. Do not turn it into a public-endpoint
+stress test. A provider endpoint can be supplied through the same environment
+variable. Record which endpoint and machine were used when sharing results, but
+never commit API keys. The report deliberately does not save the RPC URL.
+
+## Workload and checks
+
+- `robinhood.json` uses WETH and USDG held by the RobinSwap pool already recorded
+  in `protocols/substreams/ethereum-uniswap-v3-logs-only/integration_test_robinhood_robinswap_v3.tycho.yaml`.
+  The settlement address is the Robinhood TychoRouter from
+  `docs/for-solvers/execution/contract-addresses.md`; it is an explicit benchmark
+  choice, not an assertion about production's extractor configuration.
+- The benchmark verifies chain ID 4663 and reads the pool's actual token balances
+  at a recorded block. It rejects an unfunded holder: otherwise analysis could
+  return immediately without exercising its simulation RPC.
+- Symbol/decimals must decode to the fixture's expected values. Analysis must
+  produce quality 100 and gas measurements. All variants are warmed before
+  measurement. All returned fields are checked against the preflight result,
+  including ordering, gas, tax and quality, not just token addresses.
+- Warnings invalidate a sample, even when a metadata fallback happens to equal
+  the expected value (for example WETH's default 18 decimals). Existing retry
+  backoff events are counted without printing logs in the timed region.
+- Each round compares one token (WETH) and two tokens (WETH + USDG). The order of
+  variant execution rotates. These counts are **selected
+  workloads**, not measured `new_tokens_count` values from production.
+- The sequential baseline reproduces the original call order and output
+  normalization from `2dc825c14`. Awaiting the new `get_token` in a loop would
+  still overlap its three calls and would be an incorrect baseline.
+- Both concurrent variants call the actual `get_tokens` implementation. For
+  `concurrent`, batching is explicitly disabled on a cloned client; `batched`
+  uses the default batch configuration. This separates the benefit of concurrency
+  from the benefit of batching. No timeout or quality policy is changed by the benchmark.
+- Analysis uses the recorded block throughout; metadata still uses `latest`,
+  matching production. The block hash is checked again at the end. This detects
+  a changed block but does not make it finalized.
+- A 120-second benchmark watchdog records a timed-out sample and stops the run.
+  It is only a harness safety limit, not a fix for production stalls.
+
+## Interpreting the numbers
+
+Raw JSONL contains total `get_tokens` timings and sequential symbol, decimals and
+analysis timings. These are client-side elapsed durations, including decoding,
+retries and backoff where applicable—not isolated network round-trip latency.
+Balances, tokens, block hash, timestamps, retry configuration and individual
+sample outcomes are retained. Failed samples are not silently removed.
+
+The default command uses the existing unoptimized test build; the report records
+`debug_assertions`. It measures network-dominated wall time, not production CPU
+throughput. Use a release build for deployment-profile measurements, accounting
+for its additional disk/build requirements. All variants always share the same
+build, shared HTTP connection pool, holder fixture and block.
+
+With ten observations per variant/workload, nearest-rank p95 equals the maximum.
+This is a small live experiment, not a reliable estimate of production tail
+latency. Repeated calls can benefit from provider caching and connection reuse.
+The two-token fixture does not exercise four-token saturation, unusually large
+blocks, rate-limiting incidents or the reported production stall window.
+
+Production's unknown tokens per block cannot be recovered from public RPC alone:
+they depend on each extractor's protocol coverage and token-cache contents.
+`construct_currency_tokens` already records `new_tokens_count`; obtaining its
+actual distribution requires production traces or an equivalent recorded replay
+with the same cache state. This benchmark does not fabricate that missing data
+and cannot, by itself, establish that issue #1317 is fully resolved.

--- a/crates/tycho-ethereum/benchmarks/token-metadata/robinhood.json
+++ b/crates/tycho-ethereum/benchmarks/token-metadata/robinhood.json
@@ -1,0 +1,17 @@
+{
+  "settlement_contract": "0x09215a470bD585E59EB3F4B612fBD2678131fF9e",
+  "tokens": [
+    {
+      "address": "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+      "owner": "0x216a13f93031ae9e15305b038d5c9dc5f46cf418",
+      "symbol": "WETH",
+      "decimals": 18
+    },
+    {
+      "address": "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+      "owner": "0x216a13f93031ae9e15305b038d5c9dc5f46cf418",
+      "symbol": "USDG",
+      "decimals": 6
+    }
+  ]
+}

--- a/crates/tycho-ethereum/benchmarks/token-metadata/summarize.py
+++ b/crates/tycho-ethereum/benchmarks/token-metadata/summarize.py
@@ -1,0 +1,79 @@
+"""Summarize raw live-benchmark observations without third-party dependencies."""
+
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def timing(values):
+    """Median and nearest-rank p95; with small samples p95 can equal the maximum."""
+    ordered = sorted(values)
+    return (
+        statistics.median(ordered),
+        ordered[math.ceil(0.95 * len(ordered)) - 1],
+        ordered[-1],
+    )
+
+
+def valid_run(rows, run, groups):
+    holder_count = sum(row["kind"] == "holder" for row in rows)
+    expected = {(count, variant) for count in range(1, holder_count + 1)
+                for variant in run.get("variants", ("sequential", "concurrent"))}
+    return (
+        holder_count > 0
+        and set(groups) == expected
+        and rows[-1]["kind"] == "complete"
+        and rows[-1]["block_hash_unchanged"]
+        and rows[-1]["invalid_samples"] == 0
+        and all(
+            len(samples) == run["rounds"]
+            and {sample["round"] for sample in samples} == set(range(run["rounds"]))
+            and all(sample["valid"] for sample in samples)
+            for samples in groups.values()
+        )
+    )
+
+
+def summarize(path):
+    rows = [json.loads(line) for line in Path(path).read_text().splitlines() if line.strip()]
+    run = next(row for row in rows if row["kind"] == "run")
+    groups = defaultdict(list)
+    calls = defaultdict(list)
+    for row in rows:
+        if row["kind"] != "sample":
+            continue
+        groups[(row["count"], row["variant"])].append(row)
+        for call in row.get("calls", []):
+            for method in ("symbol", "decimals", "analysis"):
+                calls[method].append(call[f"{method}_ms"])
+
+    valid = valid_run(rows, run, groups)
+    print(f"Block: {run['block']}; started: {run['started_at']}")
+    print(f"Complete and valid: {valid}")
+    print("\nTokens | Variant | n | p50 ms | p95 ms | max ms | >3s | Invalid | Retry backoffs")
+    print("---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---:")
+    for (count, variant), samples in sorted(groups.items()):
+        # Include failed samples in the table rather than silently dropping slow failures.
+        durations = [sample["elapsed_ms"] for sample in samples]
+        p50, p95, maximum = timing(durations)
+        invalid = sum(not sample["valid"] for sample in samples)
+        retries = sum(sample.get("retry_backoffs", 0) for sample in samples)
+        print(f"{count} | {variant} | {len(samples)} | {p50:.1f} | {p95:.1f} | "
+              f"{maximum:.1f} | {sum(value > 3000 for value in durations)} | {invalid} | {retries}")
+
+    print("\nSequential-call client elapsed time (includes retries, not pure network RTT):")
+    for method, durations in sorted(calls.items()):
+        p50, p95, maximum = timing(durations)
+        print(f"{method}: n={len(durations)}, p50={p50:.1f} ms, "
+              f"p95={p95:.1f} ms, max={maximum:.1f} ms")
+    print("\nSmall public-endpoint sample; not production latency or token-count distributions.")
+    return valid
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: python3 summarize.py REPORT.jsonl")
+    raise SystemExit(0 if summarize(sys.argv[1]) else 1)

--- a/crates/tycho-ethereum/benchmarks/token-metadata/test_summarize.py
+++ b/crates/tycho-ethereum/benchmarks/token-metadata/test_summarize.py
@@ -23,7 +23,8 @@ class SummaryTests(unittest.TestCase):
         self.assertFalse(valid_run(rows, run_with_batching, groups))
         with_batching = {**groups, (1, "batched"): copy.deepcopy(groups[(1, "concurrent")])}
         self.assertTrue(valid_run(rows, run_with_batching, with_batching))
-        for change in ("invalid", "duplicate_round", "missing_sample", "reorg"):
+        for change in ("invalid", "duplicate_round", "missing_sample", "reorg", "no_holders",
+                       "invalid_samples_recorded"):
             with self.subTest(change=change):
                 altered_rows, altered_groups = copy.deepcopy((rows, groups))
                 samples = altered_groups[(1, "concurrent")]
@@ -33,8 +34,12 @@ class SummaryTests(unittest.TestCase):
                     samples[1]["round"] = 0
                 elif change == "missing_sample":
                     samples.pop()
-                else:
+                elif change == "reorg":
                     altered_rows[-1]["block_hash_unchanged"] = False
+                elif change == "no_holders":
+                    altered_rows.pop(0)
+                else:
+                    altered_rows[-1]["invalid_samples"] = 1
                 self.assertFalse(valid_run(altered_rows, run, altered_groups))
 
 

--- a/crates/tycho-ethereum/benchmarks/token-metadata/test_summarize.py
+++ b/crates/tycho-ethereum/benchmarks/token-metadata/test_summarize.py
@@ -1,0 +1,42 @@
+import copy
+import unittest
+
+from summarize import timing, valid_run
+
+
+class SummaryTests(unittest.TestCase):
+    def test_quantiles(self):
+        self.assertEqual(timing([2.0, 1.0]), (1.5, 2.0, 2.0))
+        self.assertEqual(timing(list(range(1, 21))), (10.5, 19, 20))
+
+    def test_incomplete_or_invalid_results_are_not_successful(self):
+        run = {"rounds": 2}
+        rows = [{"kind": "holder"}, {"kind": "complete", "block_hash_unchanged": True,
+                                    "invalid_samples": 0}]
+        groups = {(1, variant): [{"round": index, "valid": True} for index in range(2)]
+                  for variant in ("sequential", "concurrent")}
+        self.assertTrue(valid_run(rows, run, groups))
+        self.assertFalse(valid_run(rows[:-1], run, groups))
+        self.assertFalse(valid_run(rows, run, {}))
+        self.assertFalse(valid_run(rows, run, {(1, "sequential"): groups[(1, "sequential")]}))
+        run_with_batching = {"rounds": 2, "variants": ["sequential", "concurrent", "batched"]}
+        self.assertFalse(valid_run(rows, run_with_batching, groups))
+        with_batching = {**groups, (1, "batched"): copy.deepcopy(groups[(1, "concurrent")])}
+        self.assertTrue(valid_run(rows, run_with_batching, with_batching))
+        for change in ("invalid", "duplicate_round", "missing_sample", "reorg"):
+            with self.subTest(change=change):
+                altered_rows, altered_groups = copy.deepcopy((rows, groups))
+                samples = altered_groups[(1, "concurrent")]
+                if change == "invalid":
+                    samples[0]["valid"] = False
+                elif change == "duplicate_round":
+                    samples[1]["round"] = 0
+                elif change == "missing_sample":
+                    samples.pop()
+                else:
+                    altered_rows[-1]["block_hash_unchanged"] = False
+                self.assertFalse(valid_run(altered_rows, run, altered_groups))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/tycho-ethereum/src/rpc/mod.rs
+++ b/crates/tycho-ethereum/src/rpc/mod.rs
@@ -660,6 +660,88 @@ impl EthereumRpcClient {
             })
     }
 
+    /// Batches two independent calls when the configured batch size permits it.
+    /// Each item retains its own result: one reverting call must not discard the other.
+    #[instrument(level = "debug", skip(self, requests))]
+    pub(crate) async fn eth_call_pair(
+        &self,
+        requests: [TransactionRequest; 2],
+        block: BlockNumberOrTag,
+    ) -> Result<[Result<Bytes, RPCError>; 2], RPCError> {
+        if self
+            .batching
+            .max_batch_size()
+            .unwrap_or(0) <
+            2
+        {
+            // Without a batch there is no shared transport attempt to account for, so each
+            // call keeps its own full retry budget instead of the shared accounting below.
+            let (first, second) = tokio::join!(
+                self.eth_call(requests[0].clone(), block),
+                self.eth_call(requests[1].clone(), block),
+            );
+            return Ok([first, second]);
+        }
+
+        let mut batch_attempts = 0;
+        let (first, second) = self
+            .retry_policy
+            .call_with_retry(|| {
+                batch_attempts += 1;
+                async {
+                    let mut batch = self.inner.new_batch();
+                    let first = batch.add_call::<_, Bytes>("eth_call", &(&requests[0], block))?;
+                    let second = batch.add_call::<_, Bytes>("eth_call", &(&requests[1], block))?;
+                    batch.send().await?;
+                    Ok((first.await, second.await))
+                }
+            })
+            .await
+            .map_err(|e| RPCError::from_alloy("Failed to send eth_call batch", e))?;
+
+        // Retry only a failed item, using the same classification/backoff as eth_call.
+        // Transport retries already consumed part of each item's retry budget.
+        let remaining_retries = self
+            .get_retry_config()
+            .max_retries
+            .saturating_sub(batch_attempts - 1);
+        let (first, second) = tokio::join!(
+            self.retry_batched_eth_call(&requests[0], block, first, remaining_retries),
+            self.retry_batched_eth_call(&requests[1], block, second, remaining_retries),
+        );
+        Ok([first, second])
+    }
+
+    async fn retry_batched_eth_call(
+        &self,
+        request: &TransactionRequest,
+        block: BlockNumberOrTag,
+        initial: TransportResult<Bytes>,
+        remaining_retries: usize,
+    ) -> Result<Bytes, RPCError> {
+        let mut initial = Some(initial);
+        let policy: RetryPolicy =
+            RPCRetryConfig { max_retries: remaining_retries, ..self.get_retry_config() }.into();
+        policy
+            .call_with_retry(|| {
+                let initial = initial.take();
+                async move {
+                    match initial {
+                        Some(result) => result,
+                        None => {
+                            self.inner
+                                .request("eth_call", &(request, block))
+                                .await
+                        }
+                    }
+                }
+            })
+            .await
+            .map_err(|e| {
+                RPCError::from_alloy(format!("Failed eth_call batch item for block {block}"), e)
+            })
+    }
+
     /// Executes `eth_call` with EVM state overrides.
     ///
     /// Injects arbitrary bytecode or storage at specified addresses before the call executes.
@@ -1155,6 +1237,218 @@ mod tests {
 
     fn parse_address(address_str: &str) -> Address {
         Address::from_str(address_str).expect("failed to parse address")
+    }
+
+    fn paired_calls() -> [TransactionRequest; 2] {
+        [
+            TransactionRequest::default().to(Address::repeat_byte(1)),
+            TransactionRequest::default().to(Address::repeat_byte(2)),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_eth_call_pair_restores_response_order() {
+        let mut server = mockito::Server::new_async().await;
+        let batch = server
+            .mock("POST", "/")
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|request| {
+                let requests: Vec<Value> = serde_json::from_slice(request.body().unwrap()).unwrap();
+                assert_eq!(requests.len(), 2);
+                for request in &requests {
+                    assert_eq!(request["method"], "eth_call");
+                    assert_eq!(request["params"][1], "0x64");
+                }
+                json!([
+                    {"jsonrpc": "2.0", "id": requests[1]["id"], "result": "0x02"},
+                    {"jsonrpc": "2.0", "id": requests[0]["id"], "result": "0x01"},
+                ])
+                .to_string()
+                .into_bytes()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        let client = EthereumRpcClient::new(&server.url()).unwrap();
+        let [first, second] = client
+            .eth_call_pair(paired_calls(), BlockNumberOrTag::Number(100))
+            .await
+            .unwrap();
+        assert_eq!(first.unwrap(), Bytes::from(vec![1]));
+        assert_eq!(second.unwrap(), Bytes::from(vec![2]));
+        batch.assert_async().await;
+    }
+
+    #[rstest]
+    #[case::disabled(RPCBatchingConfig::Disabled)]
+    #[case::size_one(RPCBatchingConfig::Enabled {
+        max_batch_size: 1, storage_slot_max_batch_size_override: None,
+    })]
+    #[tokio::test]
+    async fn test_eth_call_pair_respects_batch_configuration(#[case] config: RPCBatchingConfig) {
+        let mut server = mockito::Server::new_async().await;
+        let calls = server
+            .mock("POST", "/")
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                assert!(request.is_object(), "batching is disabled for this request");
+                json!({"jsonrpc": "2.0", "id": request["id"], "result": "0x01"})
+                    .to_string()
+                    .into_bytes()
+            })
+            .expect(2)
+            .create_async()
+            .await;
+        let client = EthereumRpcClient::new(&server.url())
+            .unwrap()
+            .with_batching(config);
+        let results = client
+            .eth_call_pair(paired_calls(), BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        for result in results {
+            assert_eq!(result.unwrap(), Bytes::from(vec![1]));
+        }
+        calls.assert_async().await;
+    }
+
+    #[rstest]
+    #[case::retryable(Some(-32005), true)]
+    #[case::missing_response(None, true)]
+    #[case::permanent(Some(3), false)]
+    #[tokio::test]
+    async fn test_eth_call_pair_preserves_success_and_retries_only_transient_failure(
+        #[case] code: Option<i64>,
+        #[case] retryable: bool,
+    ) {
+        let mut server = mockito::Server::new_async().await;
+        let batch = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(r"^\[".into()))
+            .with_header("content-type", "application/json")
+            .with_body_from_request(move |request| {
+                let requests: Vec<Value> = serde_json::from_slice(request.body().unwrap()).unwrap();
+                let mut responses =
+                    vec![json!({"jsonrpc": "2.0", "id": requests[0]["id"], "result": "0x01"})];
+                if let Some(code) = code {
+                    responses.push(json!({"jsonrpc": "2.0", "id": requests[1]["id"],
+                        "error": {"code": code, "message": "failed call"}}));
+                }
+                serde_json::to_vec(&responses).unwrap()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        let retry = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "eth_call", "params": [{"to": Address::repeat_byte(2)}, "latest"],
+            })))
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                json!({"jsonrpc": "2.0", "id": request["id"], "result": "0x02"})
+                    .to_string()
+                    .into_bytes()
+            })
+            .expect(usize::from(retryable))
+            .create_async()
+            .await;
+        let client = EthereumRpcClient::new(&server.url())
+            .unwrap()
+            .with_retry(RPCRetryConfig::new(1, 1, 1));
+        let [first, second] = client
+            .eth_call_pair(paired_calls(), BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(first.unwrap(), Bytes::from(vec![1]));
+        if retryable {
+            assert_eq!(second.unwrap(), Bytes::from(vec![2]));
+        } else {
+            assert!(second
+                .unwrap_err()
+                .is_execution_reverted());
+        }
+        batch.assert_async().await;
+        retry.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_eth_call_pair_bounds_transport_retries() {
+        let mut server = mockito::Server::new_async().await;
+        let failure = server
+            .mock("POST", "/")
+            .with_status(503)
+            .expect(3)
+            .create_async()
+            .await;
+        let client = EthereumRpcClient::new(&server.url())
+            .unwrap()
+            .with_retry(RPCRetryConfig::new(2, 1, 1));
+        assert!(client
+            .eth_call_pair(paired_calls(), BlockNumberOrTag::Latest)
+            .await
+            .is_err());
+        failure.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_eth_call_pair_shares_retry_budget_between_transport_and_items() {
+        let mut server = mockito::Server::new_async().await;
+        // Matching mocks are consumed in insertion order until their expected hits.
+        let transport_failure = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(r"^\[".into()))
+            .with_status(503)
+            .expect(1)
+            .create_async()
+            .await;
+        let partial = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(r"^\[".into()))
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|request| {
+                let requests: Vec<Value> = serde_json::from_slice(request.body().unwrap()).unwrap();
+                json!([
+                    {"jsonrpc": "2.0", "id": requests[0]["id"], "result": "0x01"},
+                    {"jsonrpc": "2.0", "id": requests[1]["id"],
+                     "error": {"code": -32005, "message": "rate limited"}},
+                ])
+                .to_string()
+                .into_bytes()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        let item_failure = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "eth_call", "params": [{"to": Address::repeat_byte(2)}, "latest"],
+            })))
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                json!({"jsonrpc": "2.0", "id": request["id"],
+                    "error": {"code": -32005, "message": "rate limited"}})
+                .to_string()
+                .into_bytes()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        let client = EthereumRpcClient::new(&server.url())
+            .unwrap()
+            .with_retry(RPCRetryConfig::new(2, 1, 1));
+        let [first, second] = client
+            .eth_call_pair(paired_calls(), BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(first.unwrap(), Bytes::from(vec![1]));
+        assert!(second.is_err());
+        transport_failure.assert_async().await;
+        partial.assert_async().await;
+        item_failure.assert_async().await;
     }
 
     #[tokio::test]

--- a/crates/tycho-ethereum/src/rpc/mod.rs
+++ b/crates/tycho-ethereum/src/rpc/mod.rs
@@ -683,7 +683,7 @@ impl EthereumRpcClient {
             return Ok([first, second]);
         }
 
-        let mut batch_attempts = 0;
+        let mut batch_attempts: usize = 0;
         let (first, second) = self
             .retry_policy
             .call_with_retry(|| {
@@ -704,7 +704,7 @@ impl EthereumRpcClient {
         let remaining_retries = self
             .get_retry_config()
             .max_retries
-            .saturating_sub(batch_attempts - 1);
+            .saturating_sub(batch_attempts.saturating_sub(1));
         let (first, second) = tokio::join!(
             self.retry_batched_eth_call(&requests[0], block, first, remaining_retries),
             self.retry_batched_eth_call(&requests[1], block, second, remaining_retries),

--- a/crates/tycho-ethereum/src/services/token_pre_processor.rs
+++ b/crates/tycho-ethereum/src/services/token_pre_processor.rs
@@ -1,7 +1,8 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use alloy::{primitives::Address, rpc::types::BlockNumberOrTag, sol_types::SolCall};
 use async_trait::async_trait;
+use futures::{stream, StreamExt};
 use tracing::{instrument, warn};
 use tycho_common::{
     models::{
@@ -18,29 +19,67 @@ use crate::{
     erc20::{decimalsCall, symbolCall},
     rpc::EthereumRpcClient,
     services::token_analyzer::{call_request, EthCallDetector},
-    BytesCodec,
+    BytesCodec, RPCError,
 };
+
+// At most 12 concurrent RPC calls per get_tokens invocation: three per token.
+const MAX_CONCURRENT_TOKENS: usize = 4;
 
 #[derive(Debug, Clone)]
 pub struct EthereumTokenPreProcessor {
     rpc: EthereumRpcClient,
     chain: Chain,
     settlement_contract: Address,
+    enrichment_budget: Option<Duration>,
 }
 
 impl EthereumTokenPreProcessor {
     pub fn new(rpc: &EthereumRpcClient, chain: Chain, settlement_contract: Address) -> Self {
-        EthereumTokenPreProcessor { rpc: rpc.clone(), chain, settlement_contract }
+        EthereumTokenPreProcessor {
+            rpc: rpc.clone(),
+            chain,
+            settlement_contract,
+            enrichment_budget: None,
+        }
     }
 
+    /// Enables deferred enrichment. Callers must persist pending tokens and run recovery before
+    /// enabling this; older clients do not understand their readiness status.
+    pub fn with_enrichment_budget(mut self, budget: Duration) -> Self {
+        self.enrichment_budget = Some(budget);
+        self
+    }
+
+    /// Retries metadata and analysis for a token that was left pending.
+    ///
+    /// Returns `Err` when the RPC did not answer (transport failure, provider error, timeout)
+    /// so the caller can keep the token pending. Everything the RPC did answer is treated as it
+    /// is on the hot path: a reverting or undecodable `symbol`/`decimals` call receives the
+    /// legacy fallbacks, and a token without a funded owner receives a Bad verdict. The caller
+    /// owns the timeout for this attempt.
+    pub async fn recover_token(
+        &self,
+        address: Bytes,
+        finder: Arc<dyn TokenOwnerFinding>,
+        block: BlockTag,
+    ) -> Result<Token, String> {
+        let detector = EthCallDetector::new(&self.rpc, finder, self.settlement_contract);
+        self.fetch_token(address, &detector, block, true)
+            .await
+    }
+
+    #[cfg(test)]
     async fn call_symbol(&self, token: Address) -> String {
         let calldata = symbolCall {}.abi_encode();
-
-        let result = match self
+        let result = self
             .rpc
             .eth_call(call_request(None, token, calldata), BlockNumberOrTag::Latest)
-            .await
-        {
+            .await;
+        Self::decode_symbol(token, result)
+    }
+
+    fn decode_symbol(token: Address, result: Result<Bytes, RPCError>) -> String {
+        let result = match result {
             Ok(result) => result,
             Err(e) => {
                 warn!(?e, ?token, "Failed to call symbol function, using address as fallback");
@@ -61,14 +100,18 @@ impl EthereumTokenPreProcessor {
         }
     }
 
+    #[cfg(test)]
     async fn call_decimals(&self, token: Address) -> u8 {
         let calldata = decimalsCall {}.abi_encode();
-
-        let result = match self
+        let result = self
             .rpc
             .eth_call(call_request(None, token, calldata), BlockNumberOrTag::Latest)
-            .await
-        {
+            .await;
+        Self::decode_decimals(token, result)
+    }
+
+    fn decode_decimals(token: Address, result: Result<Bytes, RPCError>) -> u8 {
+        let result = match result {
             Ok(result) => result,
             Err(e) => {
                 warn!(?e, ?token, "Failed to call decimals function, using default decimals 18");
@@ -88,6 +131,117 @@ impl EthereumTokenPreProcessor {
             }
         }
     }
+
+    async fn call_metadata(&self, token: Address, strict: bool) -> Result<(String, u8), String> {
+        let requests = [
+            call_request(None, token, symbolCall {}.abi_encode()),
+            call_request(None, token, decimalsCall {}.abi_encode()),
+        ];
+        match self
+            .rpc
+            .eth_call_pair(requests, BlockNumberOrTag::Latest)
+            .await
+        {
+            Ok([symbol, decimals]) => {
+                // Strict mode defers only what a later retry could change. A revert means the
+                // contract has no usable `symbol`/`decimals`; retrying it forever would keep the
+                // token pending and its pools unavailable, where legacy stored the fallbacks and
+                // let analysis decide the quality. Undecodable return data is handled the same
+                // way inside the decode helpers.
+                if strict {
+                    for result in [&symbol, &decimals] {
+                        if let Err(e) = result {
+                            if !e.is_execution_reverted() {
+                                return Err(e.to_string());
+                            }
+                        }
+                    }
+                }
+                Ok((Self::decode_symbol(token, symbol), Self::decode_decimals(token, decimals)))
+            }
+            Err(e) => {
+                if strict {
+                    return Err(e.to_string());
+                }
+                warn!(?e, ?token, "Failed to fetch token metadata batch, using existing fallbacks");
+                Ok((format!("0x{:x}", token), 18))
+            }
+        }
+    }
+
+    async fn get_token(
+        &self,
+        address: Bytes,
+        detector: &EthCallDetector,
+        block: BlockTag,
+    ) -> Token {
+        match self
+            .fetch_token(address.clone(), detector, block, self.enrichment_budget.is_some())
+            .await
+        {
+            Ok(token) => token,
+            Err(error) => {
+                warn!(?address, %error, "Token enrichment deferred");
+                Token::pending(&address, self.chain)
+            }
+        }
+    }
+
+    async fn fetch_token(
+        &self,
+        address: Bytes,
+        detector: &EthCallDetector,
+        block: BlockTag,
+        strict: bool,
+    ) -> Result<Token, String> {
+        let token_address = Address::from_bytes(&address);
+        let (metadata, analysis) = tokio::join!(
+            self.call_metadata(token_address, strict),
+            detector.analyze(address.clone(), block),
+        );
+
+        let (symbol, decimals) = metadata?;
+        if strict {
+            if let Err(error) = &analysis {
+                return Err(error.clone());
+            }
+        }
+        let (token_quality, gas, tax) = analysis.unwrap_or_else(|e| {
+            warn!(address=?address, error=?e, "TokenDetectionFailure");
+            (TokenQuality::bad("Detection failed"), None, None)
+        });
+
+        let mut quality = 100;
+
+        if let TokenQuality::Bad { reason } = token_quality {
+            warn!(address=?address, ?reason, "BadToken");
+            // Flag this token as bad using quality, an external script is responsible for
+            // analyzing these tokens again.
+            quality = 10;
+        };
+
+        // If quality is 100 but it's a fee token, set quality to 50
+        if quality == 100 && tax.is_some_and(|tax_value| tax_value > 0) {
+            quality = 50;
+        }
+
+        Ok(Token {
+            metadata_status: Default::default(),
+            address,
+            symbol: symbol
+                .replace('\0', "")
+                .graphemes(true)
+                .take(255)
+                .collect::<String>(),
+            decimals: decimals.into(),
+            tax: tax.unwrap_or(0),
+            gas: gas
+                .map(|g| vec![Some(g)])
+                .unwrap_or_else(Vec::new),
+            chain: self.chain,
+            quality,
+        })
+    }
 }
 
 #[async_trait]
@@ -97,7 +251,7 @@ impl TokenPreProcessor for EthereumTokenPreProcessor {
     #[instrument(
         name = "fetch_onchain_token_metadata",
         skip_all,
-        fields(n_addresses = addresses.len(), block = ?block)
+        fields(n_addresses = tracing::field::Empty, block = ?block)
     )]
     async fn get_tokens(
         &self,
@@ -105,66 +259,72 @@ impl TokenPreProcessor for EthereumTokenPreProcessor {
         token_finder: Arc<dyn TokenOwnerFinding>,
         block: BlockTag,
     ) -> Vec<Token> {
-        let mut tokens_info = Vec::new();
-
-        for address in addresses {
-            let token_address = Address::from_bytes(&address);
-
-            // Make RPC calls directly for symbol and decimals
-            let symbol = self.call_symbol(token_address).await;
-            let decimals = self.call_decimals(token_address).await;
-
-            let detector =
-                EthCallDetector::new(&self.rpc, token_finder.clone(), self.settlement_contract);
-
-            let (token_quality, gas, tax) = detector
-                .analyze(address.clone(), block)
-                .await
-                .unwrap_or_else(|e| {
-                    warn!(error=?e, "TokenDetectionFailure");
-                    (TokenQuality::bad("Detection failed"), None, None)
-                });
-
-            let mut quality = 100;
-
-            if let TokenQuality::Bad { reason } = token_quality {
-                warn!(address=?address, ?reason, "BadToken");
-                // Flag this token as bad using quality, an external script is responsible for
-                // analyzing these tokens again.
-                quality = 10;
+        let mut seen = HashSet::new();
+        let addresses: Vec<_> = addresses
+            .into_iter()
+            .filter(|a| seen.insert(a.clone()))
+            .collect();
+        // Recorded after deduplication so the span agrees with the
+        // `token_enrichment_unknown_tokens` metric, which counts unique addresses.
+        tracing::Span::current().record("n_addresses", addresses.len());
+        let detector = EthCallDetector::new(&self.rpc, token_finder, self.settlement_contract);
+        let mut tokens: Vec<_> = addresses
+            .iter()
+            .map(|a| Token::pending(a, self.chain))
+            .collect();
+        {
+            let mut work = stream::iter(addresses.into_iter().enumerate())
+                .map(|(index, address)| {
+                    let token = self.get_token(address, &detector, block);
+                    async move { (index, token.await) }
+                })
+                .buffer_unordered(MAX_CONCURRENT_TOKENS);
+            let collect = async {
+                while let Some((index, token)) = work.next().await {
+                    tokens[index] = token;
+                }
             };
-
-            // If quality is 100 but it's a fee token, set quality to 50
-            if quality == 100 && tax.is_some_and(|tax_value| tax_value > 0) {
-                quality = 50;
+            // One deadline includes queued tokens and RPC retries. Per-token timeouts would
+            // multiply the budget across waves. Dropping the stream cancels unfinished requests.
+            match self.enrichment_budget {
+                Some(budget) => {
+                    if tokio::time::timeout(budget, collect)
+                        .await
+                        .is_err()
+                    {
+                        warn!(budget_ms = budget.as_millis(), "Token enrichment deadline exceeded");
+                    }
+                }
+                None => collect.await,
             }
-
-            tokens_info.push(Token {
-                address,
-                symbol: symbol
-                    .replace('\0', "")
-                    .graphemes(true)
-                    .take(255)
-                    .collect::<String>(),
-                decimals: decimals.into(),
-                tax: tax.unwrap_or(0),
-                gas: gas
-                    .map(|g| vec![Some(g)])
-                    .unwrap_or_else(Vec::new),
-                chain: self.chain,
-                quality,
-            });
         }
-
-        tokens_info
+        tokens
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use std::str::FromStr;
+mod live_benchmark;
 
-    use alloy::primitives::address;
+#[cfg(test)]
+mod recovery_tests;
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        str::FromStr,
+        sync::atomic::{AtomicU64, Ordering},
+        time::Duration,
+    };
+
+    use alloy::{
+        primitives::{address, U256},
+        sol_types::SolValue,
+    };
+    use mockito::{Matcher, Server};
+    use rstest::rstest;
+    use serde_json::{json, Value};
+    use tokio::sync::{mpsc, oneshot};
     use tycho_common::models::token::TokenOwnerStore;
 
     use super::*;
@@ -172,9 +332,374 @@ mod tests {
 
     const COWSWAP_SETTLEMENT: Address = address!("c9f2e6ea1637E499406986ac50ddC92401ce1f58");
 
+    fn mock_processor(server: &mockito::ServerGuard) -> EthereumTokenPreProcessor {
+        let rpc = EthereumRpcClient::new(&server.url())
+            .unwrap()
+            .with_batching(crate::rpc::config::RPCBatchingConfig::Disabled);
+        EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, COWSWAP_SETTLEMENT)
+    }
+
+    #[tokio::test]
+    async fn test_get_tokens_batches_metadata_and_keeps_analysis_at_requested_block() {
+        let mut server = Server::new_async().await;
+        let response = server.mock("POST", "/")
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                let response = if let Some(calls) = request.as_array() {
+                    assert_eq!(calls.len(), 2);
+                    Value::Array(calls.iter().rev().map(|call| {
+                        assert_eq!(call["method"], "eth_call");
+                        assert_eq!(call["params"][1], "latest");
+                        let input = call["params"][0]["input"].as_str().unwrap();
+                        let result = if input == Bytes::from(symbolCall {}.abi_encode()).to_string() {
+                            "TEST".abi_encode()
+                        } else {
+                            assert_eq!(input, Bytes::from(decimalsCall {}.abi_encode()).to_string());
+                            decimalsCall::abi_encode_returns(&6)
+                        };
+                        json!({"jsonrpc": "2.0", "id": call["id"], "result": Bytes::from(result)})
+                    }).collect())
+                } else {
+                    assert_eq!(request["method"], "eth_call");
+                    assert_eq!(request["params"][1], "0x64");
+                    assert!(request["params"][2].is_object());
+                    let result: Vec<u8> = [1, 1, 1, 0, 100_000, 0, 0, 100_000, 30_000, 25_000]
+                        .into_iter().flat_map(|value| U256::from(value).to_be_bytes::<32>()).collect();
+                    json!({"jsonrpc": "2.0", "id": request["id"], "result": Bytes::from(result)})
+                };
+                response.to_string().into_bytes()
+            }).expect(2).create_async().await;
+        let address = Address::repeat_byte(1).to_bytes();
+        let owners = TokenOwnerStore::new(
+            [(address.clone(), (Address::repeat_byte(2).to_bytes(), 200_000u64.into()))].into(),
+        );
+        let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+        let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, COWSWAP_SETTLEMENT);
+        let tokens = processor
+            .get_tokens(vec![address.clone()], Arc::new(owners), BlockTag::Number(100))
+            .await;
+        let expected =
+            vec![Token::new(&address, "TEST", 6, 0, &[Some(27_500)], Chain::Ethereum, 100)];
+        assert_eq!(serde_json::to_value(tokens).unwrap(), serde_json::to_value(expected).unwrap());
+        response.assert_async().await;
+    }
+
+    #[derive(Debug)]
+    struct GatedTokenOwnerFinder {
+        started: mpsc::UnboundedSender<(Bytes, oneshot::Sender<()>)>,
+    }
+
+    #[async_trait]
+    impl TokenOwnerFinding for GatedTokenOwnerFinder {
+        async fn find_owner(
+            &self,
+            token: Bytes,
+            _min_balance: Bytes,
+        ) -> Result<Option<(Bytes, Bytes)>, String> {
+            let (release, wait) = oneshot::channel();
+            self.started
+                .send((token, release))
+                .unwrap();
+            wait.await.unwrap();
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_tokens_fetches_metadata_and_analysis_concurrently() {
+        let mut server = Server::new_async().await;
+        let address = Address::repeat_byte(1).to_bytes();
+        let (started, mut incoming) = mpsc::unbounded_channel();
+        let mut mocks = Vec::new();
+        for (call, result) in [
+            (symbolCall {}.abi_encode(), "TEST".abi_encode()),
+            (decimalsCall {}.abi_encode(), decimalsCall::abi_encode_returns(&6)),
+        ] {
+            let id = Arc::new(AtomicU64::new(0));
+            let request_id = id.clone();
+            let started = started.clone();
+            let mock = server
+                .mock("POST", "/")
+                .match_body(Matcher::PartialJson(json!({
+                    "method": "eth_call",
+                    "params": [{"to": address, "input": Bytes::from(call.clone())}, "latest"]
+                })))
+                .with_header_from_request("content-type", move |request| {
+                    let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                    request_id.store(request["id"].as_u64().unwrap(), Ordering::SeqCst);
+                    "application/json".to_string()
+                })
+                .with_chunked_body(move |writer| {
+                    let (release, wait) = oneshot::channel();
+                    started
+                        .send((Bytes::from(call.clone()), release))
+                        .unwrap();
+                    // The test releases responses only after all three operations have started.
+                    wait.blocking_recv()
+                        .map_err(std::io::Error::other)?;
+                    let response = json!({
+                        "jsonrpc": "2.0", "id": id.load(Ordering::SeqCst),
+                        "result": Bytes::from(result.clone())
+                    });
+                    writer.write_all(response.to_string().as_bytes())
+                })
+                .expect(1)
+                .create_async()
+                .await;
+            mocks.push(mock);
+        }
+
+        let processor = mock_processor(&server);
+        let mut fetch = Box::pin(processor.get_tokens(
+            vec![address.clone()],
+            Arc::new(GatedTokenOwnerFinder { started }),
+            BlockTag::Latest,
+        ));
+        let mut releases = Vec::new();
+        let mut calls = Vec::new();
+        let started = tokio::time::timeout(Duration::from_secs(5), async {
+            for _ in 0..3 {
+                tokio::select! {
+                    result = &mut fetch => panic!("fetch finished before release: {result:?}"),
+                    next = incoming.recv() => {
+                        let (call, release) = next.unwrap();
+                        calls.push(call);
+                        releases.push(release);
+                    }
+                }
+            }
+        })
+        .await;
+        for release in releases {
+            release.send(()).unwrap();
+        }
+        // Drop queued release handles as well if the test timed out, unblocking mock threads.
+        drop(incoming);
+        started.expect("symbol, decimals and analysis should overlap");
+        assert!(calls.contains(&Bytes::from(symbolCall {}.abi_encode())));
+        assert!(calls.contains(&Bytes::from(decimalsCall {}.abi_encode())));
+        assert!(calls.contains(&address));
+        let tokens = tokio::time::timeout(Duration::from_secs(5), fetch)
+            .await
+            .unwrap();
+        assert_eq!(tokens[0].symbol, "TEST");
+        assert_eq!(tokens[0].decimals, 6);
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_tokens_refills_capacity_and_preserves_order() {
+        let mut server = Server::new_async().await;
+        // Input order deliberately differs from address order.
+        let addresses: Vec<_> = (1..=MAX_CONCURRENT_TOKENS * 2 + 1)
+            .rev()
+            .map(|i| Address::repeat_byte(i as u8).to_bytes())
+            .collect();
+        let metadata = server
+            .mock("POST", "/")
+            .with_body_from_request(|request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                json!({"jsonrpc": "2.0", "id": request["id"], "result": "0x"})
+                    .to_string()
+                    .into_bytes()
+            })
+            .expect(addresses.len() * 2)
+            .create_async()
+            .await;
+        let processor = mock_processor(&server);
+        let (started, mut incoming) = mpsc::unbounded_channel();
+        let finder = Arc::new(GatedTokenOwnerFinder { started });
+        let mut fetch = Box::pin(processor.get_tokens(addresses.clone(), finder, BlockTag::Latest));
+
+        let mut releases = HashMap::new();
+        for _ in 0..MAX_CONCURRENT_TOKENS {
+            let (address, release) = tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::select! {
+                    result = &mut fetch => panic!("fetch finished before release: {result:?}"),
+                    next = incoming.recv() => next.unwrap(),
+                }
+            })
+            .await
+            .expect("tokens should start concurrently");
+            assert!(releases
+                .insert(address, release)
+                .is_none());
+        }
+        for address in &addresses[..MAX_CONCURRENT_TOKENS] {
+            assert!(releases.contains_key(address));
+        }
+
+        // Hold the first token pending while repeatedly freeing another slot. A replacement
+        // must start after each completion, without waiting for the first token to finish.
+        let first_release = releases.remove(&addresses[0]).unwrap();
+        let mut next_release = releases.remove(&addresses[1]).unwrap();
+        for expected in &addresses[MAX_CONCURRENT_TOKENS..] {
+            assert!(futures::poll!(&mut fetch).is_pending());
+            assert!(incoming.try_recv().is_err(), "token concurrency limit exceeded");
+
+            next_release.send(()).unwrap();
+            let (address, release) = tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::select! {
+                    result = &mut fetch => panic!("fetch finished before release: {result:?}"),
+                    next = incoming.recv() => next.unwrap(),
+                }
+            })
+            .await
+            .expect("a free slot should be refilled while the first token is pending");
+            assert_eq!(&address, expected);
+            next_release = release;
+        }
+
+        next_release.send(()).unwrap();
+        for release in releases.into_values() {
+            release.send(()).unwrap();
+        }
+        assert!(futures::poll!(&mut fetch).is_pending());
+        first_release.send(()).unwrap();
+
+        let tokens = tokio::time::timeout(Duration::from_secs(5), fetch)
+            .await
+            .expect("all tokens should finish after release");
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.address.clone())
+                .collect::<Vec<_>>(),
+            addresses
+        );
+        assert!(tokens
+            .iter()
+            .all(|token| token.quality == 10));
+        metadata.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_tokens_preserves_metadata_and_analysis_results() {
+        let mut server = Server::new_async().await;
+        let addresses: Vec<_> = (1..=3)
+            .map(|i| Address::repeat_byte(i).to_bytes())
+            .collect();
+        let holders: Vec<_> = (11..=13)
+            .map(|i| Address::repeat_byte(i).to_bytes())
+            .collect();
+        let owners = TokenOwnerStore::new(
+            addresses
+                .iter()
+                .cloned()
+                .zip(
+                    holders
+                        .into_iter()
+                        .map(|holder| (holder, 200_000u64.into())),
+                )
+                .collect(),
+        );
+        let rpc = server
+            .mock("POST", "/")
+            .with_body_from_request(|request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                assert_eq!(request["method"], "eth_call");
+                let tx = &request["params"][0];
+                let to = Address::from_str(tx["to"].as_str().unwrap()).unwrap();
+                let input = tx["input"].as_str().unwrap();
+                let response = if input == Bytes::from(symbolCall {}.abi_encode()).to_string() {
+                    assert_eq!(request["params"][1], "latest");
+                    json!({"result": Bytes::from(format!("{}\0", "👩‍💻".repeat(256)).abi_encode())})
+                } else if input == Bytes::from(decimalsCall {}.abi_encode()).to_string() {
+                    assert_eq!(request["params"][1], "latest");
+                    json!({"result": Bytes::from(decimalsCall::abi_encode_returns(&(to[0] + 5)))})
+                } else {
+                    assert!(input.starts_with("0x521c6539"));
+                    assert_eq!(request["params"][1], "0x64");
+                    assert!(request["params"][2].is_object(), "analysis needs state overrides");
+                    if to[0] == 12 {
+                        json!({"error": {"code": 3, "message": "execution reverted"}})
+                    } else {
+                        let received = if to[0] == 13 { 99_000 } else { 100_000 };
+                        // Analyzer ABI: three success flags, five balances, then two gas costs.
+                        let result: Vec<u8> =
+                            [1, 1, 1, 0, received, 0, 0, received, 30_000, 25_000]
+                                .into_iter()
+                                .flat_map(|value| U256::from(value).to_be_bytes::<32>())
+                                .collect();
+                        json!({"result": Bytes::from(result)})
+                    }
+                };
+                let mut response = response;
+                response["jsonrpc"] = json!("2.0");
+                response["id"] = request["id"].clone();
+                response.to_string().into_bytes()
+            })
+            .expect(9)
+            .create_async()
+            .await;
+        let tokens = mock_processor(&server)
+            .get_tokens(addresses.clone(), Arc::new(owners), BlockTag::Number(100))
+            .await;
+        let symbol = "👩‍💻".repeat(255);
+        let expected = vec![
+            Token::new(&addresses[0], &symbol, 6, 0, &[Some(27_500)], Chain::Ethereum, 100),
+            Token::new(&addresses[1], &symbol, 7, 0, &[], Chain::Ethereum, 10),
+            Token::new(&addresses[2], &symbol, 8, 100, &[Some(27_500)], Chain::Ethereum, 10),
+        ];
+        // Token equality compares addresses only; compare every returned field here.
+        assert_eq!(serde_json::to_value(tokens).unwrap(), serde_json::to_value(expected).unwrap());
+        rpc.assert_async().await;
+    }
+
+    #[rstest]
+    #[case::rpc_error(json!({"error": {"code": -32602, "message": "invalid params"}}))]
+    #[case::invalid_abi(json!({"result": "0x"}))]
+    #[tokio::test]
+    async fn test_get_tokens_preserves_fallbacks(#[case] response: Value) {
+        let mut server = Server::new_async().await;
+        let rpc = server
+            .mock("POST", "/")
+            .with_body_from_request(move |request| {
+                let request: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+                let mut response = response.clone();
+                response["jsonrpc"] = json!("2.0");
+                response["id"] = request["id"].clone();
+                response.to_string().into_bytes()
+            })
+            .expect(3)
+            .create_async()
+            .await;
+        let address = Address::repeat_byte(1).to_bytes();
+        let owners = TokenOwnerStore::new(
+            [(address.clone(), (Address::repeat_byte(2).to_bytes(), 200_000u64.into()))].into(),
+        );
+        let tokens = mock_processor(&server)
+            .get_tokens(vec![address.clone()], Arc::new(owners), BlockTag::Latest)
+            .await;
+        let expected =
+            vec![Token::new(&address, &address.to_string(), 18, 0, &[], Chain::Ethereum, 10)];
+        assert_eq!(serde_json::to_value(tokens).unwrap(), serde_json::to_value(expected).unwrap());
+        rpc.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_tokens_empty() {
+        let mut server = Server::new_async().await;
+        let rpc = server
+            .mock("POST", "/")
+            .expect(0)
+            .create_async()
+            .await;
+        let (started, mut incoming) = mpsc::unbounded_channel();
+        let tokens = mock_processor(&server)
+            .get_tokens(Vec::new(), Arc::new(GatedTokenOwnerFinder { started }), BlockTag::Latest)
+            .await;
+        assert!(tokens.is_empty());
+        assert!(incoming.try_recv().is_err());
+        rpc.assert_async().await;
+    }
+
     impl TestFixture {
         fn create_token_preprocessor(&self) -> EthereumTokenPreProcessor {
-            // We do not enable batching as the token pre-processor does not leverage it currently
+            // These fixtures expect individual calls; batching is covered by dedicated tests.
             let rpc = self.create_rpc_client(false);
 
             EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, COWSWAP_SETTLEMENT)

--- a/crates/tycho-ethereum/src/services/token_pre_processor.rs
+++ b/crates/tycho-ethereum/src/services/token_pre_processor.rs
@@ -328,7 +328,10 @@ mod tests {
     use tycho_common::models::token::TokenOwnerStore;
 
     use super::*;
-    use crate::test_fixtures::{TestFixture, TEST_BLOCK_NUMBER, TOKEN_HOLDERS, USDC_STR, WETH_STR};
+    use crate::{
+        rpc::config::RPCRetryConfig,
+        test_fixtures::{TestFixture, TEST_BLOCK_NUMBER, TOKEN_HOLDERS, USDC_STR, WETH_STR},
+    };
 
     const COWSWAP_SETTLEMENT: Address = address!("c9f2e6ea1637E499406986ac50ddC92401ce1f58");
 
@@ -678,6 +681,36 @@ mod tests {
             vec![Token::new(&address, &address.to_string(), 18, 0, &[], Chain::Ethereum, 10)];
         assert_eq!(serde_json::to_value(tokens).unwrap(), serde_json::to_value(expected).unwrap());
         rpc.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_tokens_keeps_legacy_fallbacks_when_the_batch_transport_fails() {
+        // Without an enrichment budget the hot path never defers: a batch that fails at the
+        // transport level still yields a ready token with the legacy fallbacks, and analysis
+        // (no funded owner here) decides the quality.
+        let mut server = Server::new_async().await;
+        let unavailable = server
+            .mock("POST", "/")
+            .with_status(503)
+            .expect(1)
+            .create_async()
+            .await;
+        let rpc = EthereumRpcClient::new(&server.url())
+            .unwrap()
+            .with_retry(RPCRetryConfig::new(0, 1, 1));
+        let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, COWSWAP_SETTLEMENT);
+        let address = Address::repeat_byte(1).to_bytes();
+        let tokens = processor
+            .get_tokens(
+                vec![address.clone()],
+                Arc::new(TokenOwnerStore::new(Default::default())),
+                BlockTag::Latest,
+            )
+            .await;
+        let expected =
+            vec![Token::new(&address, &address.to_string(), 18, 0, &[], Chain::Ethereum, 10)];
+        assert_eq!(serde_json::to_value(tokens).unwrap(), serde_json::to_value(expected).unwrap());
+        unavailable.assert_async().await;
     }
 
     #[tokio::test]

--- a/crates/tycho-ethereum/src/services/token_pre_processor/live_benchmark.rs
+++ b/crates/tycho-ethereum/src/services/token_pre_processor/live_benchmark.rs
@@ -1,0 +1,382 @@
+//! Opt-in network benchmark; see benchmarks/token-metadata/README.md.
+
+use std::{
+    collections::HashMap,
+    env,
+    fs::OpenOptions,
+    io::Write,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::{Duration, Instant},
+};
+
+use alloy::{primitives::U256, rpc::types::BlockId};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tracing_subscriber::{layer::Context, prelude::*, Layer, Registry};
+use tycho_common::models::token::TokenOwnerStore;
+
+use super::*;
+use crate::{erc20::balanceOfCall, rpc::config::RPCBatchingConfig};
+
+#[derive(Deserialize)]
+struct Fixture {
+    settlement_contract: Address,
+    tokens: Vec<Holder>,
+}
+
+#[derive(Deserialize)]
+struct Holder {
+    address: Address,
+    owner: Address,
+    symbol: String,
+    decimals: u8,
+}
+
+#[derive(Clone, Default)]
+struct Observations {
+    warnings: Arc<AtomicUsize>,
+    retry_backoffs: Arc<AtomicUsize>,
+}
+
+impl Layer<Registry> for Observations {
+    fn register_callsite(
+        &self,
+        _: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        // Tests also exercise these callsites without a subscriber on other threads.
+        // Resolve enablement against the current dispatcher when collecting observations.
+        tracing::subscriber::Interest::sometimes()
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, Registry>) {
+        let metadata = event.metadata();
+        if metadata
+            .target()
+            .starts_with("tycho_ethereum") &&
+            *metadata.level() <= tracing::Level::WARN
+        {
+            self.warnings
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if metadata.target() == "tycho_ethereum::rpc::retry" &&
+            metadata
+                .fields()
+                .field("attempts_left")
+                .is_some()
+        {
+            self.retry_backoffs
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+impl Observations {
+    fn take(&self) -> (usize, usize) {
+        (
+            self.warnings.swap(0, Ordering::Relaxed),
+            self.retry_backoffs
+                .swap(0, Ordering::Relaxed),
+        )
+    }
+}
+
+fn record(output: &mut impl Write, value: Value) {
+    serde_json::to_writer(&mut *output, &value).unwrap();
+    writeln!(output).unwrap();
+    // Preserve completed observations even if a later request fails or the run is interrupted.
+    output.flush().unwrap();
+}
+
+// Sequential call order and output normalization from 2dc825c14. Keep
+// this independent of get_token: awaiting get_token sequentially would still run its
+// three calls concurrently and would not measure the original implementation.
+async fn sequential(
+    processor: &EthereumTokenPreProcessor,
+    addresses: &[Bytes],
+    detector: &EthCallDetector,
+    block: BlockTag,
+) -> (Vec<Token>, Vec<Value>) {
+    let mut tokens = Vec::with_capacity(addresses.len());
+    let mut calls = Vec::with_capacity(addresses.len());
+    for address in addresses {
+        let start = Instant::now();
+        let symbol = processor
+            .call_symbol(Address::from_bytes(address))
+            .await;
+        let symbol_ms = start.elapsed().as_secs_f64() * 1000.0;
+        let start = Instant::now();
+        let decimals = processor
+            .call_decimals(Address::from_bytes(address))
+            .await;
+        let decimals_ms = start.elapsed().as_secs_f64() * 1000.0;
+        let start = Instant::now();
+        let analysis = detector
+            .analyze(address.clone(), block)
+            .await;
+        let analysis_ms = start.elapsed().as_secs_f64() * 1000.0;
+        let analysis_ok = analysis.is_ok();
+        let (token_quality, gas, tax) =
+            analysis.unwrap_or_else(|_| (TokenQuality::bad("Detection failed"), None, None));
+        let mut quality = if token_quality.is_good() { 100 } else { 10 };
+        if quality == 100 && tax.is_some_and(|tax_value| tax_value > 0) {
+            quality = 50;
+        }
+        tokens.push(Token {
+            metadata_status: Default::default(),
+            address: address.clone(),
+            symbol: symbol
+                .replace('\0', "")
+                .graphemes(true)
+                .take(255)
+                .collect(),
+            decimals: decimals.into(),
+            tax: tax.unwrap_or(0),
+            gas: gas
+                .map(|g| vec![Some(g)])
+                .unwrap_or_default(),
+            chain: processor.chain,
+            quality,
+        });
+        calls.push(json!({
+            "address": address, "symbol_ms": symbol_ms, "decimals_ms": decimals_ms,
+            "analysis_ms": analysis_ms, "analysis_ok": analysis_ok,
+        }));
+    }
+    (tokens, calls)
+}
+
+/// Real RPC calls, not a CI timing assertion or a production load test.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "requires explicit RPC access; see benchmarks/token-metadata/README.md"]
+async fn benchmark_robinhood_token_metadata() {
+    let rpc_url = env::var("ROBINHOOD_RPC_URL").expect("Set ROBINHOOD_RPC_URL explicitly");
+    let report_path = env::var("TOKEN_BENCH_OUTPUT").expect("Set TOKEN_BENCH_OUTPUT");
+    let rounds: usize = env::var("TOKEN_BENCH_ROUNDS")
+        .unwrap_or_else(|_| "10".into())
+        .parse()
+        .expect("TOKEN_BENCH_ROUNDS must be an integer");
+    assert!((1..=100).contains(&rounds), "Use 1–100 rounds; this is not a load test");
+    let fixture: Fixture =
+        serde_json::from_str(include_str!("../../../benchmarks/token-metadata/robinhood.json"))
+            .unwrap();
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(report_path)
+        .expect("Report must be a new file; existing measurements are never overwritten");
+    let rpc = EthereumRpcClient::new(&rpc_url).unwrap();
+    let identity_rpc = alloy::rpc::client::ClientBuilder::default().http(rpc_url.parse().unwrap());
+    let chain_id: U256 = identity_rpc
+        .request_noparams("eth_chainId")
+        .await
+        .unwrap();
+    assert_eq!(chain_id, U256::from(4663), "Expected Robinhood mainnet");
+    let observations = Observations::default();
+    // All benchmark futures run on this thread. Observe existing tracing events without
+    // logging inside timed regions or changing the production RPC client.
+    let subscriber = tracing_subscriber::registry().with(observations.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let processor =
+        EthereumTokenPreProcessor::new(&rpc, Chain::Robinhood, fixture.settlement_contract);
+    let concurrent_processor = EthereumTokenPreProcessor::new(
+        &rpc.clone()
+            .with_batching(RPCBatchingConfig::Disabled),
+        Chain::Robinhood,
+        fixture.settlement_contract,
+    );
+    let block = rpc
+        .eth_get_block_by_number(BlockId::Number(BlockNumberOrTag::Latest))
+        .await
+        .expect("Cannot read the benchmark block");
+    let number = block.header.number;
+    let block_tag = BlockTag::Number(number);
+    let retry = rpc.get_retry_config();
+    record(
+        &mut output,
+        json!({
+            "kind": "run", "started_at": chrono::Utc::now().to_rfc3339(),
+            "chain": "robinhood", "block": number, "block_hash": block.header.hash,
+            "block_timestamp": block.header.timestamp, "rounds": rounds,
+            "settlement_contract": fixture.settlement_contract,
+            "max_concurrent_tokens": MAX_CONCURRENT_TOKENS,
+            "max_retries": retry.max_retries, "initial_backoff_ms": retry.initial_backoff_ms,
+            "max_backoff_ms": retry.max_backoff_ms,
+            "metadata_block": "latest", "analysis_block": number,
+            "debug_assertions": cfg!(debug_assertions),
+            "variants": ["sequential", "concurrent", "batched"],
+            "metadata_batch_size": rpc.get_batching_config().max_batch_size(),
+            "workload": "selected real pool tokens; NOT observed production cache misses",
+            "timing": "client-side elapsed milliseconds, including retries",
+        }),
+    );
+
+    let mut owners = HashMap::new();
+    for holder in &fixture.tokens {
+        let result = rpc
+            .eth_call(
+                call_request(
+                    None,
+                    holder.address,
+                    balanceOfCall { _owner: holder.owner }.abi_encode(),
+                ),
+                BlockNumberOrTag::Number(number),
+            )
+            .await
+            .expect("Cannot fetch the real holder balance");
+        let balance = balanceOfCall::abi_decode_returns_validate(&result).unwrap();
+        // Without a funded owner, analyze returns before making its simulation RPC.
+        assert!(balance >= U256::from(100_000), "Fixture holder has insufficient balance");
+        owners.insert(holder.address.to_bytes(), (holder.owner.to_bytes(), balance.to_bytes()));
+        record(
+            &mut output,
+            json!({
+                "kind": "holder", "address": holder.address, "owner": holder.owner,
+                "balance": balance.to_string(), "block": number,
+            }),
+        );
+    }
+    let finder = Arc::new(TokenOwnerStore::new(owners));
+    let detector = EthCallDetector::new(&rpc, finder.clone(), fixture.settlement_contract);
+    let addresses: Vec<_> = fixture
+        .tokens
+        .iter()
+        .map(|holder| holder.address.to_bytes())
+        .collect();
+
+    // Validate metadata without the production fallbacks, then require a successful
+    // simulation with gas measurements. Fast failures must not look like an improvement.
+    for holder in &fixture.tokens {
+        let symbol = rpc
+            .eth_call(
+                call_request(None, holder.address, symbolCall {}.abi_encode()),
+                BlockNumberOrTag::Latest,
+            )
+            .await
+            .expect("Symbol RPC failed during preflight");
+        assert_eq!(symbolCall::abi_decode_returns_validate(&symbol).unwrap(), holder.symbol);
+        let decimals = rpc
+            .eth_call(
+                call_request(None, holder.address, decimalsCall {}.abi_encode()),
+                BlockNumberOrTag::Latest,
+            )
+            .await
+            .expect("Decimals RPC failed during preflight");
+        assert_eq!(decimalsCall::abi_decode_returns_validate(&decimals).unwrap(), holder.decimals);
+    }
+    let (reference, calls) = sequential(&processor, &addresses, &detector, block_tag).await;
+    record(&mut output, json!({"kind": "preflight", "tokens": reference, "calls": calls}));
+    for (token, holder) in reference.iter().zip(&fixture.tokens) {
+        assert_eq!(token.symbol, holder.symbol);
+        assert_eq!(token.decimals, u32::from(holder.decimals));
+        assert_eq!(
+            token.quality, 100,
+            "Fixture must complete the transfer simulation successfully"
+        );
+        assert!(!token.gas.is_empty(), "Analysis must not skip the simulation RPC");
+    }
+    for processor in [&processor, &concurrent_processor] {
+        let warmup = processor
+            .get_tokens(addresses.clone(), finder.clone(), block_tag)
+            .await;
+        assert_eq!(
+            serde_json::to_value(&warmup).unwrap(),
+            serde_json::to_value(&reference).unwrap()
+        );
+    }
+    assert_eq!(observations.take().0, 0, "Preflight/warmup emitted warnings");
+
+    let mut invalid = 0;
+    for round in 0..rounds {
+        for count in 1..=addresses.len() {
+            // Rotate which implementation goes first to reduce connection/cache-order bias.
+            let mut variants = ["sequential", "concurrent", "batched"];
+            variants.rotate_left((round + count) % 3);
+            for variant in variants {
+                // Keep this small experiment gentle on shared, rate-limited public endpoints.
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                let input = addresses[..count].to_vec();
+                let start = Instant::now();
+                let result = tokio::time::timeout(Duration::from_secs(120), async {
+                    if variant == "sequential" {
+                        sequential(&processor, &input, &detector, block_tag).await
+                    } else {
+                        let processor =
+                            if variant == "batched" { &processor } else { &concurrent_processor };
+                        (
+                            processor
+                                .get_tokens(input, finder.clone(), block_tag)
+                                .await,
+                            Vec::new(),
+                        )
+                    }
+                })
+                .await;
+                let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+                let (warnings, retry_backoffs) = observations.take();
+                let Ok((tokens, calls)) = result else {
+                    record(
+                        &mut output,
+                        json!({"kind": "sample", "round": round,
+                        "variant": variant, "count": count, "elapsed_ms": elapsed_ms,
+                        "valid": false, "timed_out": true}),
+                    );
+                    panic!("Benchmark watchdog expired; partial observations were preserved");
+                };
+                // Token::PartialEq compares only addresses; compare every serialized field.
+                let valid = warnings == 0 &&
+                    serde_json::to_value(&tokens).unwrap() ==
+                        serde_json::to_value(&reference[..count]).unwrap();
+                invalid += usize::from(!valid);
+                record(
+                    &mut output,
+                    json!({"kind": "sample", "round": round,
+                    "variant": variant, "count": count, "elapsed_ms": elapsed_ms,
+                    "valid": valid, "warnings": warnings, "retry_backoffs": retry_backoffs,
+                    "tokens": tokens, "calls": calls}),
+                );
+                eprintln!(
+                    "round {round}, {count} tokens, {variant}: {elapsed_ms:.1} ms, valid={valid}"
+                );
+            }
+        }
+    }
+    let end_block = rpc
+        .eth_get_block_by_number(BlockId::Number(BlockNumberOrTag::Number(number)))
+        .await
+        .expect("Cannot verify the benchmark block after the run");
+    let canonical = end_block.header.hash == block.header.hash;
+    record(
+        &mut output,
+        json!({"kind": "complete", "finished_at": chrono::Utc::now().to_rfc3339(),
+        "invalid_samples": invalid, "block_hash_unchanged": canonical}),
+    );
+    assert!(canonical, "Benchmark block changed; do not compare results across a reorg");
+    assert_eq!(invalid, 0, "Invalid outputs were recorded; do not report them as speedups");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_benchmark_detects_decimals_fallback_matching_expected_value() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/")
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc":"2.0","id":0,"result":"0x"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let observations = Observations::default();
+    let subscriber = tracing_subscriber::registry().with(observations.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Robinhood, Address::ZERO);
+    // A value-only check would accept this as WETH's real decimals, despite invalid ABI.
+    assert_eq!(
+        processor
+            .call_decimals(Address::repeat_byte(1))
+            .await,
+        18
+    );
+    assert_eq!(observations.take(), (1, 0));
+    assert_eq!(observations.take(), (0, 0));
+    response.assert_async().await;
+}

--- a/crates/tycho-ethereum/src/services/token_pre_processor/recovery_tests.rs
+++ b/crates/tycho-ethereum/src/services/token_pre_processor/recovery_tests.rs
@@ -1,0 +1,262 @@
+use std::{
+    future::pending,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Instant,
+};
+
+use alloy::sol_types::SolValue;
+use mockito::Server;
+use serde_json::{json, Value};
+use tycho_common::models::token::{TokenMetadataStatus, TokenOwnerStore};
+
+use super::*;
+use crate::rpc::config::RPCRetryConfig;
+
+fn rpc_error_mock(code: i64, message: &'static str) -> impl Fn(&mockito::Request) -> Vec<u8> {
+    move |request| {
+        let calls: Vec<Value> = serde_json::from_slice(request.body().unwrap()).unwrap();
+        serde_json::to_vec(
+            &calls
+                .iter()
+                .map(|call| {
+                    json!({
+                        "jsonrpc": "2.0", "id": call["id"],
+                        "error": {"code": code, "message": message}
+                    })
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+}
+
+#[derive(Debug)]
+struct HangingOwnerFinder {
+    active: Arc<AtomicUsize>,
+}
+
+struct ActiveAttempt(Arc<AtomicUsize>);
+
+impl Drop for ActiveAttempt {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl TokenOwnerFinding for HangingOwnerFinder {
+    async fn find_owner(&self, token: Bytes, _: Bytes) -> Result<Option<(Bytes, Bytes)>, String> {
+        // One token completes; every other token holds its concurrency slot until cancelled.
+        if token == Address::repeat_byte(1).to_bytes() {
+            return Ok(None);
+        }
+        self.active
+            .fetch_add(1, Ordering::SeqCst);
+        let _attempt = ActiveAttempt(self.active.clone());
+        pending().await
+    }
+}
+
+fn metadata_response(request: &Value) -> Value {
+    let result =
+        if request["params"][0]["input"] == Bytes::from(symbolCall {}.abi_encode()).to_string() {
+            "TEST".abi_encode()
+        } else {
+            decimalsCall::abi_encode_returns(&6)
+        };
+    json!({"jsonrpc": "2.0", "id": request["id"], "result": Bytes::from(result)})
+}
+
+#[tokio::test]
+async fn collection_deadline_preserves_completed_tokens_and_cancels_queued_work() {
+    let mut server = Server::new_async().await;
+    let _metadata = server
+        .mock("POST", "/")
+        .with_body_from_request(|request| {
+            let calls: Vec<Value> = serde_json::from_slice(request.body().unwrap()).unwrap();
+            serde_json::to_vec(
+                &calls
+                    .iter()
+                    .map(metadata_response)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap()
+        })
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
+        .with_enrichment_budget(Duration::from_millis(200));
+    let active = Arc::new(AtomicUsize::new(0));
+    let addresses: Vec<_> = (1..=12)
+        .map(|id| Address::repeat_byte(id).to_bytes())
+        .collect();
+    let mut duplicated = addresses.clone();
+    duplicated.push(addresses[0].clone());
+    // A per-token timeout would need several waves, exceeding this outer bound.
+    let tokens = tokio::time::timeout(
+        Duration::from_millis(500),
+        processor.get_tokens(
+            duplicated,
+            Arc::new(HangingOwnerFinder { active: active.clone() }),
+            BlockTag::Latest,
+        ),
+    )
+    .await
+    .expect("the entire collection must share a deadline");
+    assert_eq!(
+        tokens
+            .iter()
+            .map(|t| t.address.clone())
+            .collect::<Vec<_>>(),
+        addresses
+    );
+    assert_eq!(tokens[0].metadata_status, TokenMetadataStatus::Ready);
+    assert_eq!(tokens[0].decimals, 6);
+    assert!(tokens[1..]
+        .iter()
+        .all(|t| t.metadata_status == TokenMetadataStatus::Pending));
+    assert_eq!(active.load(Ordering::SeqCst), 0, "unfinished analyses must be dropped");
+}
+
+#[tokio::test]
+async fn stalled_metadata_is_pending_even_when_analysis_finishes() {
+    // Accepting a connection without sending headers stalls both batched metadata calls.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap();
+    let rpc =
+        EthereumRpcClient::new(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
+        .with_enrichment_budget(Duration::from_millis(20));
+    let address = Address::repeat_byte(1).to_bytes();
+    let tokens = tokio::time::timeout(
+        Duration::from_millis(300),
+        processor.get_tokens(
+            vec![address],
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(tokens[0].metadata_status, TokenMetadataStatus::Pending);
+    assert_eq!(tokens[0].quality, 0);
+}
+
+#[tokio::test]
+async fn strict_recovery_stays_pending_when_the_rpc_does_not_answer() {
+    // A provider error that is neither transient nor a revert: the RPC did not evaluate the
+    // call, so no fallback may be stored and the token must stay pending.
+    let mut server = Server::new_async().await;
+    let _failure = server
+        .mock("POST", "/")
+        .with_body_from_request(rpc_error_mock(-32601, "method not found"))
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
+    let result = processor
+        .recover_token(
+            Address::repeat_byte(1).to_bytes(),
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        )
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn strict_recovery_uses_legacy_fallbacks_when_metadata_reverts() {
+    // The contract answered and reverted: retrying later cannot change that, so the token gets
+    // the same address symbol and 18 decimals the hot path always stored, and analysis
+    // (no funded owner here) still decides the quality.
+    let mut server = Server::new_async().await;
+    let _revert = server
+        .mock("POST", "/")
+        .with_body_from_request(rpc_error_mock(3, "execution reverted"))
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
+    let address = Address::repeat_byte(1);
+    let token = processor
+        .recover_token(
+            address.to_bytes(),
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        )
+        .await
+        .expect("a revert is a definitive answer");
+    assert_eq!(token.metadata_status, TokenMetadataStatus::Ready);
+    assert_eq!(token.symbol, format!("0x{address:x}"));
+    assert_eq!(token.decimals, 18);
+    assert_eq!(token.quality, 10);
+}
+
+#[tokio::test]
+async fn every_token_is_pending_when_all_requests_stall() {
+    // More tokens than concurrency slots: the ones still queued when the deadline hits must
+    // come back pending too, in input order.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap();
+    let rpc =
+        EthereumRpcClient::new(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
+        .with_enrichment_budget(Duration::from_millis(50));
+    let addresses: Vec<_> = (1..=(MAX_CONCURRENT_TOKENS as u8 + 2))
+        .map(|id| Address::repeat_byte(id).to_bytes())
+        .collect();
+    let tokens = tokio::time::timeout(
+        Duration::from_millis(500),
+        processor.get_tokens(
+            addresses.clone(),
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        tokens
+            .iter()
+            .map(|t| t.address.clone())
+            .collect::<Vec<_>>(),
+        addresses
+    );
+    assert!(tokens
+        .iter()
+        .all(|t| t.metadata_status == TokenMetadataStatus::Pending));
+}
+
+#[tokio::test]
+async fn deadline_covers_retry_backoff() {
+    // A retryable transport error with a one-second backoff would exceed the budget several
+    // times over. The deadline must cut through the backoff sleep, not wait for it.
+    let mut server = Server::new_async().await;
+    let _unavailable = server
+        .mock("POST", "/")
+        .with_status(503)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url())
+        .unwrap()
+        .with_retry(RPCRetryConfig::new(3, 1_000, 1_000));
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
+        .with_enrichment_budget(Duration::from_millis(200));
+    let started = Instant::now();
+    let tokens = tokio::time::timeout(
+        Duration::from_millis(700),
+        processor.get_tokens(
+            vec![Address::repeat_byte(1).to_bytes()],
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        ),
+    )
+    .await
+    .expect("budget must bound retry backoff");
+    assert!(started.elapsed() < Duration::from_millis(700));
+    assert_eq!(tokens[0].metadata_status, TokenMetadataStatus::Pending);
+}

--- a/crates/tycho-ethereum/src/services/token_pre_processor/recovery_tests.rs
+++ b/crates/tycho-ethereum/src/services/token_pre_processor/recovery_tests.rs
@@ -1,16 +1,20 @@
 use std::{
     future::pending,
     sync::atomic::{AtomicUsize, Ordering},
-    time::Instant,
 };
 
 use alloy::sol_types::SolValue;
 use mockito::Server;
+use rstest::rstest;
 use serde_json::{json, Value};
 use tycho_common::models::token::{TokenMetadataStatus, TokenOwnerStore};
 
 use super::*;
 use crate::rpc::config::RPCRetryConfig;
+
+fn rpc_error(id: &Value, code: i64, message: &str) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}})
+}
 
 fn rpc_error_mock(code: i64, message: &'static str) -> impl Fn(&mockito::Request) -> Vec<u8> {
     move |request| {
@@ -18,11 +22,31 @@ fn rpc_error_mock(code: i64, message: &'static str) -> impl Fn(&mockito::Request
         serde_json::to_vec(
             &calls
                 .iter()
+                .map(|call| rpc_error(&call["id"], code, message))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+}
+
+/// Answers every item of a metadata batch by the ERC-20 function it calls, inside the single
+/// array response the batch expects.
+fn per_field_mock(
+    symbol: impl Fn(&Value) -> Value + Send + Sync + 'static,
+    decimals: impl Fn(&Value) -> Value + Send + Sync + 'static,
+) -> impl Fn(&mockito::Request) -> Vec<u8> {
+    let symbol_input = Bytes::from(symbolCall {}.abi_encode()).to_string();
+    move |request| {
+        let calls: Vec<Value> = serde_json::from_slice(request.body().unwrap()).unwrap();
+        serde_json::to_vec(
+            &calls
+                .iter()
                 .map(|call| {
-                    json!({
-                        "jsonrpc": "2.0", "id": call["id"],
-                        "error": {"code": code, "message": message}
-                    })
+                    if call["params"][0]["input"] == symbol_input {
+                        symbol(call)
+                    } else {
+                        decimals(call)
+                    }
                 })
                 .collect::<Vec<_>>(),
         )
@@ -57,6 +81,20 @@ impl TokenOwnerFinding for HangingOwnerFinder {
     }
 }
 
+#[derive(Debug, Default)]
+struct CountingOwnerFinder {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl TokenOwnerFinding for CountingOwnerFinder {
+    async fn find_owner(&self, _: Bytes, _: Bytes) -> Result<Option<(Bytes, Bytes)>, String> {
+        self.calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }
+}
+
 fn metadata_response(request: &Value) -> Value {
     let result =
         if request["params"][0]["input"] == Bytes::from(symbolCall {}.abi_encode()).to_string() {
@@ -86,16 +124,16 @@ async fn collection_deadline_preserves_completed_tokens_and_cancels_queued_work(
         .await;
     let rpc = EthereumRpcClient::new(&server.url()).unwrap();
     let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
-        .with_enrichment_budget(Duration::from_millis(200));
+        .with_enrichment_budget(Duration::from_secs(1));
     let active = Arc::new(AtomicUsize::new(0));
     let addresses: Vec<_> = (1..=12)
         .map(|id| Address::repeat_byte(id).to_bytes())
         .collect();
     let mut duplicated = addresses.clone();
     duplicated.push(addresses[0].clone());
-    // A per-token timeout would need several waves, exceeding this outer bound.
+    // A per-token timeout would need three waves of 1 s each, exceeding this 2.5 s bound.
     let tokens = tokio::time::timeout(
-        Duration::from_millis(500),
+        Duration::from_millis(2_500),
         processor.get_tokens(
             duplicated,
             Arc::new(HangingOwnerFinder { active: active.clone() }),
@@ -120,41 +158,73 @@ async fn collection_deadline_preserves_completed_tokens_and_cancels_queued_work(
 }
 
 #[tokio::test]
-async fn stalled_metadata_is_pending_even_when_analysis_finishes() {
-    // Accepting a connection without sending headers stalls both batched metadata calls.
+async fn stalled_metadata_leaves_every_token_pending_even_when_analysis_finishes() {
+    // Accepting a connection without sending headers stalls every batched metadata call, while
+    // analysis finishes at once. More tokens than concurrency slots: the ones still queued when
+    // the deadline hits must come back pending too, in input order.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .unwrap();
     let rpc =
         EthereumRpcClient::new(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
     let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
-        .with_enrichment_budget(Duration::from_millis(20));
-    let address = Address::repeat_byte(1).to_bytes();
+        .with_enrichment_budget(Duration::from_millis(50));
+    let addresses: Vec<_> = (1..=(MAX_CONCURRENT_TOKENS as u8 + 2))
+        .map(|id| Address::repeat_byte(id).to_bytes())
+        .collect();
+    let finder = Arc::new(CountingOwnerFinder::default());
     let tokens = tokio::time::timeout(
-        Duration::from_millis(300),
-        processor.get_tokens(
-            vec![address],
-            Arc::new(TokenOwnerStore::new(Default::default())),
-            BlockTag::Latest,
-        ),
+        Duration::from_millis(500),
+        processor.get_tokens(addresses.clone(), finder.clone(), BlockTag::Latest),
     )
     .await
     .unwrap();
-    assert_eq!(tokens[0].metadata_status, TokenMetadataStatus::Pending);
-    assert_eq!(tokens[0].quality, 0);
+    assert_eq!(
+        tokens
+            .iter()
+            .map(|t| t.address.clone())
+            .collect::<Vec<_>>(),
+        addresses
+    );
+    assert!(tokens
+        .iter()
+        .all(|t| t.metadata_status == TokenMetadataStatus::Pending && t.quality == 0));
+    assert_eq!(
+        finder.calls.load(Ordering::SeqCst),
+        MAX_CONCURRENT_TOKENS,
+        "only tokens that got a concurrency slot run analysis"
+    );
 }
 
+#[derive(Debug, Clone, Copy)]
+enum NoAnswer {
+    ProviderError,
+    TransportFailure,
+}
+
+#[rstest]
+#[case::provider_error(NoAnswer::ProviderError)]
+#[case::transport_failure(NoAnswer::TransportFailure)]
 #[tokio::test]
-async fn strict_recovery_stays_pending_when_the_rpc_does_not_answer() {
-    // A provider error that is neither transient nor a revert: the RPC did not evaluate the
-    // call, so no fallback may be stored and the token must stay pending.
+async fn strict_recovery_stays_pending_when_the_rpc_does_not_answer(#[case] failure: NoAnswer) {
+    // A provider error that is neither transient nor a revert is an answer that carries no
+    // data; a transport failure is no answer at all. Neither tells anything about the token, so
+    // no fallback may be stored and the token must stay pending.
     let mut server = Server::new_async().await;
-    let _failure = server
-        .mock("POST", "/")
-        .with_body_from_request(rpc_error_mock(-32601, "method not found"))
-        .create_async()
-        .await;
+    let mock = server.mock("POST", "/").expect(1);
+    let mock = match failure {
+        NoAnswer::ProviderError => {
+            mock.with_body_from_request(rpc_error_mock(-32601, "method not found"))
+        }
+        NoAnswer::TransportFailure => mock.with_status(503),
+    }
+    .create_async()
+    .await;
     let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let rpc = match failure {
+        NoAnswer::ProviderError => rpc,
+        NoAnswer::TransportFailure => rpc.with_retry(RPCRetryConfig::new(0, 1, 1)),
+    };
     let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
     let result = processor
         .recover_token(
@@ -164,6 +234,42 @@ async fn strict_recovery_stays_pending_when_the_rpc_does_not_answer() {
         )
         .await;
     assert!(result.is_err());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn strict_recovery_stays_pending_when_analysis_rpc_fails() {
+    // Metadata answers, but the analysis simulation gets a provider error: the verdict is
+    // unknown, so strict mode must not store a Bad quality it cannot back up.
+    let mut server = Server::new_async().await;
+    let _rpc = server
+        .mock("POST", "/")
+        .with_body_from_request(|request| {
+            let body: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+            let response = match body.as_array() {
+                Some(calls) => Value::Array(
+                    calls
+                        .iter()
+                        .map(metadata_response)
+                        .collect(),
+                ),
+                None => rpc_error(&body["id"], -32601, "method not found"),
+            };
+            response.to_string().into_bytes()
+        })
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
+    let address = Address::repeat_byte(1).to_bytes();
+    let owners = TokenOwnerStore::new(
+        [(address.clone(), (Address::repeat_byte(9).to_bytes(), Bytes::from("0x0186a0")))].into(),
+    );
+    let error = processor
+        .recover_token(address, Arc::new(owners), BlockTag::Latest)
+        .await
+        .expect_err("an unanswered analysis must keep the token pending");
+    assert!(error.contains("eth_call with state overrides failed"), "{error}");
 }
 
 #[tokio::test]
@@ -195,39 +301,100 @@ async fn strict_recovery_uses_legacy_fallbacks_when_metadata_reverts() {
 }
 
 #[tokio::test]
-async fn every_token_is_pending_when_all_requests_stall() {
-    // More tokens than concurrency slots: the ones still queued when the deadline hits must
-    // come back pending too, in input order.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .unwrap();
-    let rpc =
-        EthereumRpcClient::new(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
-    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
-        .with_enrichment_budget(Duration::from_millis(50));
-    let addresses: Vec<_> = (1..=(MAX_CONCURRENT_TOKENS as u8 + 2))
-        .map(|id| Address::repeat_byte(id).to_bytes())
-        .collect();
-    let tokens = tokio::time::timeout(
-        Duration::from_millis(500),
-        processor.get_tokens(
-            addresses.clone(),
+async fn strict_recovery_falls_back_only_for_the_reverting_field() {
+    // One batch item reverts while the other answers: only the reverting field takes its
+    // legacy fallback; the answered field keeps the on-chain value.
+    let mut server = Server::new_async().await;
+    let batch = server
+        .mock("POST", "/")
+        .with_body_from_request(per_field_mock(
+            |call| rpc_error(&call["id"], 3, "execution reverted"),
+            |call| {
+                json!({
+                    "jsonrpc": "2.0", "id": call["id"],
+                    "result": Bytes::from(decimalsCall::abi_encode_returns(&6))
+                })
+            },
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
+    let address = Address::repeat_byte(1);
+    let token = processor
+        .recover_token(
+            address.to_bytes(),
             Arc::new(TokenOwnerStore::new(Default::default())),
             BlockTag::Latest,
-        ),
-    )
-    .await
-    .unwrap();
-    assert_eq!(
-        tokens
-            .iter()
-            .map(|t| t.address.clone())
-            .collect::<Vec<_>>(),
-        addresses
-    );
-    assert!(tokens
-        .iter()
-        .all(|t| t.metadata_status == TokenMetadataStatus::Pending));
+        )
+        .await
+        .expect("a reverting symbol must not defer a token whose decimals answered");
+    assert_eq!(token.metadata_status, TokenMetadataStatus::Ready);
+    assert_eq!(token.symbol, format!("0x{address:x}"));
+    assert_eq!(token.decimals, 6);
+    batch.assert_async().await;
+}
+
+#[tokio::test]
+async fn strict_recovery_stays_pending_when_one_field_has_no_answer() {
+    // One batch item answers while the other gets a provider error: a later retry could still
+    // fetch the missing field, so strict mode must keep the token pending.
+    let mut server = Server::new_async().await;
+    let _batch = server
+        .mock("POST", "/")
+        .with_body_from_request(per_field_mock(
+            |call| {
+                json!({
+                    "jsonrpc": "2.0", "id": call["id"],
+                    "result": Bytes::from("TEST".abi_encode())
+                })
+            },
+            |call| rpc_error(&call["id"], -32601, "method not found"),
+        ))
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
+    let result = processor
+        .recover_token(
+            Address::repeat_byte(1).to_bytes(),
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        )
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn strict_recovery_uses_legacy_fallbacks_when_metadata_is_undecodable() {
+    // The contract answered with data that is not a valid `symbol`/`decimals` return: like a
+    // revert, retrying cannot change that, so the hot-path fallbacks apply and analysis (no
+    // funded owner here) decides the quality.
+    let mut server = Server::new_async().await;
+    let _undecodable = server
+        .mock("POST", "/")
+        .with_body_from_request(per_field_mock(
+            |call| json!({"jsonrpc": "2.0", "id": call["id"], "result": "0x"}),
+            |call| json!({"jsonrpc": "2.0", "id": call["id"], "result": "0x"}),
+        ))
+        .create_async()
+        .await;
+    let rpc = EthereumRpcClient::new(&server.url()).unwrap();
+    let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO);
+    let address = Address::repeat_byte(1);
+    let token = processor
+        .recover_token(
+            address.to_bytes(),
+            Arc::new(TokenOwnerStore::new(Default::default())),
+            BlockTag::Latest,
+        )
+        .await
+        .expect("undecodable return data is a definitive answer");
+    assert_eq!(token.metadata_status, TokenMetadataStatus::Ready);
+    assert_eq!(token.symbol, format!("0x{address:x}"));
+    assert_eq!(token.decimals, 18);
+    assert_eq!(token.quality, 10);
 }
 
 #[tokio::test]
@@ -235,10 +402,10 @@ async fn deadline_covers_retry_backoff() {
     // A retryable transport error with a one-second backoff would exceed the budget several
     // times over. The deadline must cut through the backoff sleep, not wait for it.
     let mut server = Server::new_async().await;
-    let _unavailable = server
+    let unavailable = server
         .mock("POST", "/")
         .with_status(503)
-        .expect_at_least(1)
+        .expect(1)
         .create_async()
         .await;
     let rpc = EthereumRpcClient::new(&server.url())
@@ -246,7 +413,6 @@ async fn deadline_covers_retry_backoff() {
         .with_retry(RPCRetryConfig::new(3, 1_000, 1_000));
     let processor = EthereumTokenPreProcessor::new(&rpc, Chain::Ethereum, Address::ZERO)
         .with_enrichment_budget(Duration::from_millis(200));
-    let started = Instant::now();
     let tokens = tokio::time::timeout(
         Duration::from_millis(700),
         processor.get_tokens(
@@ -257,6 +423,6 @@ async fn deadline_covers_retry_backoff() {
     )
     .await
     .expect("budget must bound retry backoff");
-    assert!(started.elapsed() < Duration::from_millis(700));
     assert_eq!(tokens[0].metadata_status, TokenMetadataStatus::Pending);
+    unavailable.assert_async().await;
 }

--- a/crates/tycho-indexer/CLAUDE.md
+++ b/crates/tycho-indexer/CLAUDE.md
@@ -22,6 +22,7 @@ extractor/
   chain_state.rs            ChainState — tracks current tip and finality horizon
   u256_num.rs               U256 numeric utilities
   token_analysis_cron.rs    Background job: token quality / tax analysis
+  token_metadata_recovery.rs Background worker: retries enrichment for tokens left Pending by the hot-path budget
   dynamic_contract_indexer/ DCI optional extension (see below)
     dci.rs                  Core DCI: DynamicContractIndexer implementation
     cache.rs                DCI component/contract cache
@@ -72,6 +73,9 @@ extension `E`. It is the single point that turns raw Substreams messages into ty
 2. Run post-processor if configured.
 3. Call `E::process_block_update()` (DCI — see below).
 4. Fetch metadata for any new token addresses via `T` (ERC-20 symbol / decimals over RPC).
+   With `TOKEN_ENRICHMENT_BUDGET_MS > 0` the whole batch shares one deadline; tokens that miss
+   it are stored as `Pending` and repaired later by `token_metadata_recovery` (see
+   `docs/token-metadata-recovery.md`). Budget `0` (default) keeps the legacy blocking fetch.
 5. Insert `BlockChanges` into `ReorgBuffer`.
 6. When `ReorgBuffer` has `>= commit_batch_size` blocks before `finalized_block_height`, drain them
    and schedule a DB write (see Persistence).

--- a/crates/tycho-indexer/src/cli.rs
+++ b/crates/tycho-indexer/src/cli.rs
@@ -323,6 +323,8 @@ mod cli_tests {
             "256",
             "--rpc-url",
             "http://example.com",
+            "--token-enrichment-budget-ms",
+            "1000",
             "run",
             "--api_token",
             "your_api_token",
@@ -339,9 +341,14 @@ mod cli_tests {
         ])
         .expect("parse errored");
 
+        assert_eq!(
+            cli.global_args
+                .token_enrichment_budget_ms,
+            1000
+        );
         let expected_args = Cli {
             global_args: GlobalArgs {
-                token_enrichment_budget_ms: 0,
+                token_enrichment_budget_ms: 1000,
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
                 database_insert_batch_size: 256,

--- a/crates/tycho-indexer/src/cli.rs
+++ b/crates/tycho-indexer/src/cli.rs
@@ -45,6 +45,10 @@ pub enum Command {
 #[derive(Parser, Debug, Clone, PartialEq)]
 #[command(version, about, long_about = None)]
 pub struct GlobalArgs {
+    /// Token-enrichment budget in milliseconds. Zero preserves legacy behavior.
+    /// Enable only after upgrading clients to support pending token metadata.
+    #[clap(long, env = "TOKEN_ENRICHMENT_BUDGET_MS", default_value = "0")]
+    pub token_enrichment_budget_ms: u64,
     /// PostgresDB Connection Url
     #[clap(
         long,
@@ -337,6 +341,7 @@ mod cli_tests {
 
         let expected_args = Cli {
             global_args: GlobalArgs {
+                token_enrichment_budget_ms: 0,
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
                 database_insert_batch_size: 256,
@@ -405,6 +410,7 @@ mod cli_tests {
 
         let expected_args = Cli {
             global_args: GlobalArgs {
+                token_enrichment_budget_ms: 0,
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
                 database_insert_batch_size: 0,

--- a/crates/tycho-indexer/src/extractor/mod.rs
+++ b/crates/tycho-indexer/src/extractor/mod.rs
@@ -42,6 +42,7 @@ pub mod reorg_buffer;
 pub mod runner;
 pub mod supervisor;
 pub mod token_analysis_cron;
+pub mod token_metadata_recovery;
 mod u256_num;
 
 #[cfg(test)]

--- a/crates/tycho-indexer/src/extractor/protocol_cache.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_cache.rs
@@ -64,6 +64,14 @@ struct TokenPrices {
     last_price_update: NaiveDateTime,
 }
 
+/// A `Pending` identity must never replace a `Ready` entry. Blocks buffered before a recovery
+/// write committed still carry the pending placeholder, and a database read started before that
+/// commit can return it too; in both cases the cached entry is the newer truth.
+fn keeps_ready_entry(existing: Option<&Token>, incoming: &Token) -> bool {
+    !incoming.metadata_status.is_ready() &&
+        existing.is_some_and(|old| old.metadata_status.is_ready())
+}
+
 impl ProtocolMemoryCache {
     pub fn new(
         chain: Chain,
@@ -146,6 +154,18 @@ impl ProtocolMemoryCache {
             size_of::<Duration>() +
             size_of_val(&self.gateway)
     }
+
+    /// Best effort: the cache can hold pending identities from blocks that were reverted and
+    /// never re-included, so some of these addresses may have no database row at all.
+    pub async fn pending_token_addresses(&self) -> Vec<Bytes> {
+        self.tokens
+            .read()
+            .await
+            .values()
+            .filter(|token| !token.metadata_status.is_ready())
+            .map(|token| token.address.clone())
+            .collect()
+    }
 }
 
 #[async_trait]
@@ -194,6 +214,9 @@ impl ProtocolDataCache for ProtocolMemoryCache {
                 .into_iter()
                 .for_each(|t| {
                     n_fetched += 1;
+                    if keeps_ready_entry(cached_tokens.get(&t.address), &t) {
+                        return;
+                    }
                     cached_tokens.insert(t.address.clone(), t);
                 });
             debug!(n_missing = missing.len(), n_fetched, resource = "token", "CacheMiss");
@@ -218,11 +241,12 @@ impl ProtocolDataCache for ProtocolMemoryCache {
         tokens: T,
     ) -> Result<(), StorageError> {
         let mut guard = self.tokens.write().await;
-        guard.extend(
-            tokens
-                .into_iter()
-                .map(|t| (t.address.clone(), t)),
-        );
+        for token in tokens {
+            if keeps_ready_entry(guard.get(&token.address), &token) {
+                continue;
+            }
+            guard.insert(token.address.clone(), token);
+        }
         Ok(())
     }
 
@@ -301,6 +325,44 @@ mod tests {
 
     use super::*;
     use crate::testing::MockGateway;
+
+    #[tokio::test]
+    async fn recovered_metadata_survives_a_stale_pending_block() {
+        let cache = ProtocolMemoryCache::new(
+            Chain::Ethereum,
+            Duration::seconds(60),
+            Arc::new(MockGateway::new()),
+        );
+        let address = Bytes::from("0x01");
+        let pending = Token::pending(&address, Chain::Ethereum);
+        cache
+            .add_tokens([pending.clone()])
+            .await
+            .unwrap();
+        assert_eq!(cache.pending_token_addresses().await, vec![address.clone()]);
+        let ready = Token::new(&address, "RECOVERED", 6, 25, &[Some(42_000)], Chain::Ethereum, 50);
+        cache.add_tokens([ready]).await.unwrap();
+        cache
+            .add_tokens([pending])
+            .await
+            .unwrap();
+        let result = cache
+            .get_tokens(&[address])
+            .await
+            .unwrap()
+            .remove(0)
+            .unwrap();
+        assert!(result.metadata_status.is_ready());
+        assert_eq!(
+            (result.symbol.as_str(), result.decimals, result.tax, result.quality),
+            ("RECOVERED", 6, 25, 50)
+        );
+        assert_eq!(result.gas, vec![Some(42_000)]);
+        assert!(cache
+            .pending_token_addresses()
+            .await
+            .is_empty());
+    }
 
     #[tokio::test]
     async fn test_get_token_prices() {

--- a/crates/tycho-indexer/src/extractor/protocol_cache.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_cache.rs
@@ -347,7 +347,7 @@ mod tests {
             .await
             .unwrap();
         let result = cache
-            .get_tokens(&[address])
+            .get_tokens(std::slice::from_ref(&address))
             .await
             .unwrap()
             .remove(0)
@@ -362,6 +362,64 @@ mod tests {
             .pending_token_addresses()
             .await
             .is_empty());
+
+        // Ready-to-ready updates still apply.
+        cache
+            .add_tokens([Token::new(&address, "V2", 6, 25, &[], Chain::Ethereum, 10)])
+            .await
+            .unwrap();
+        let updated = cache
+            .get_tokens(&[address])
+            .await
+            .unwrap()
+            .remove(0)
+            .unwrap();
+        assert_eq!((updated.symbol.as_str(), updated.quality), ("V2", 10));
+    }
+
+    #[tokio::test]
+    async fn db_fill_never_downgrades_a_ready_entry() {
+        let ready_address = Bytes::from("0x01");
+        let missing_address = Bytes::from("0x02");
+        // A database read started before the recovery write committed still returns the
+        // pending placeholder for the ready token alongside the missing one.
+        let stale = Token::pending(&ready_address, Chain::Ethereum);
+        let missing = Token::new(&missing_address, "B", 18, 0, &[None], Chain::Ethereum, 100);
+        let mut gateway = MockGateway::new();
+        gateway
+            .expect_get_tokens()
+            .times(1)
+            .return_once(move |_, _, _, _, _| {
+                Box::pin(
+                    async move { Ok(WithTotal { entity: vec![stale, missing], total: Some(2) }) },
+                )
+            });
+        let cache =
+            ProtocolMemoryCache::new(Chain::Ethereum, Duration::seconds(60), Arc::new(gateway));
+        cache
+            .add_tokens([Token::new(
+                &ready_address,
+                "RECOVERED",
+                6,
+                25,
+                &[Some(42_000)],
+                Chain::Ethereum,
+                50,
+            )])
+            .await
+            .unwrap();
+
+        let result = cache
+            .get_tokens(&[ready_address, missing_address])
+            .await
+            .unwrap();
+
+        let ready = result[0].as_ref().unwrap();
+        assert!(ready.metadata_status.is_ready());
+        assert_eq!((ready.symbol.as_str(), ready.decimals, ready.quality), ("RECOVERED", 6, 50));
+        let filled = result[1].as_ref().unwrap();
+        assert!(filled.metadata_status.is_ready());
+        assert_eq!(filled.symbol, "B");
     }
 
     #[tokio::test]

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -412,8 +412,8 @@ where
             balances
         };
 
-        // collect token decimals and prices to calculate tvl in the next step
-        // most of this data should be in the cache.
+        // Prices are denominated in raw token units. This calculation does not use token
+        // decimals, including the placeholders carried by pending metadata.
         let addresses = balances
             .values()
             .flat_map(|b| b.clone().into_keys())
@@ -626,6 +626,15 @@ where
             .flat_map(|pc| pc.tokens.clone().into_iter())
             .collect::<Vec<_>>();
 
+        // The pre-processor deduplicates again; this pass exists so the cache lookup, the
+        // `new_tokens_count` span field and `token_enrichment_unknown_tokens` count unique
+        // addresses rather than pool memberships.
+        let mut seen = HashSet::new();
+        let new_token_addresses: Vec<_> = new_token_addresses
+            .into_iter()
+            .filter(|address| seen.insert(address.clone()))
+            .collect();
+
         // Separate between known and unkown tokens
         let is_token_known = self
             .protocol_cache
@@ -701,19 +710,26 @@ where
             .map(|t| (t.address.clone(), t));
 
         tracing::Span::current().record("new_tokens_count", unknown_tokens.len());
+        histogram!("token_enrichment_unknown_tokens", "chain" => self.chain.to_string(), "extractor" => self.name.clone())
+            .record(unknown_tokens.len() as f64);
         if !unknown_tokens.is_empty() {
             debug!(?unknown_tokens, block_number = msg.block.number, "NewTokens");
         }
 
-        let new_tokens: HashMap<Address, Token> = self
+        let enrichment_started = std::time::Instant::now();
+        let fetched = self
             .token_pre_processor
             .get_tokens(unknown_tokens, Arc::new(tf), BlockTag::Number(msg.block.number))
-            .await
+            .await;
+        histogram!("token_enrichment_seconds", "chain" => self.chain.to_string(), "extractor" => self.name.clone())
+            .record(enrichment_started.elapsed().as_secs_f64());
+        counter!("token_metadata_deferred", "chain" => self.chain.to_string(), "extractor" => self.name.clone())
+            .increment(fetched.iter().filter(|token| !token.metadata_status.is_ready()).count() as u64);
+        Ok(fetched
             .into_iter()
             .map(|t| (t.address.clone(), t))
             .chain(existing_tokens)
-            .collect();
-        Ok(new_tokens)
+            .collect())
     }
 
     /// Process a full block

--- a/crates/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/crates/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -412,12 +412,26 @@ where
             balances
         };
 
-        // Prices are denominated in raw token units. This calculation does not use token
-        // decimals, including the placeholders carried by pending metadata.
+        // Prices are denominated in raw token units, so token decimals play no part here. A
+        // pending token is excluded regardless: its identity is unfinished, and a price written
+        // for it by the external price feed may have been derived from the placeholder row.
         let addresses = balances
             .values()
             .flat_map(|b| b.clone().into_keys())
             .collect::<Vec<_>>();
+        let pending: HashSet<&Bytes> = self
+            .protocol_cache
+            .get_tokens(&addresses)
+            .await?
+            .iter()
+            .zip(addresses.iter())
+            .filter(|(token, _)| {
+                token
+                    .as_ref()
+                    .is_some_and(|t| !t.metadata_status.is_ready())
+            })
+            .map(|(_, address)| address)
+            .collect();
 
         let prices = self
             .protocol_cache
@@ -442,6 +456,9 @@ where
                 let component_tvl: f64 = bal
                     .iter()
                     .filter_map(|(addr, bal)| {
+                        if pending.contains(addr) {
+                            return None;
+                        }
                         let price = *prices.get(addr)?;
                         let tvl = bal.balance_float / price;
                         Some(tvl)
@@ -2200,6 +2217,7 @@ mod test {
     use float_eq::assert_float_eq;
     use futures03::FutureExt;
     use mockall::mock;
+    use rstest::rstest;
     use tycho_common::{models::blockchain::TxWithChanges, traits::TokenOwnerFinding};
 
     use super::*;
@@ -2851,8 +2869,12 @@ mod test {
         assert_eq!(res, exp);
     }
 
+    #[rstest]
+    #[case::all_ready(false, 66.39849612683253)]
+    // Token 2 pending: only token 1 counts, whatever price row the feed wrote for token 2.
+    #[case::second_token_pending(true, 11_304_207_639.4e18 / 344101538937875300000000000.0)]
     #[test_log::test(tokio::test)]
-    async fn test_handle_tvl_changes() {
+    async fn test_handle_tvl_changes(#[case] second_pending: bool, #[case] exp_tvl: f64) {
         let mut msg = BlockAggregatedChanges {
             component_balances: HashMap::from([(
                 "comp1".to_string(),
@@ -2925,15 +2947,22 @@ mod test {
                     Chain::Ethereum,
                     100,
                 ),
-                Token::new(
-                    &Bytes::from("0x0000000000000000000000000000000000000002"),
-                    "USDC",
-                    6,
-                    0,
-                    &[],
-                    Chain::Ethereum,
-                    100,
-                ),
+                if second_pending {
+                    Token::pending(
+                        &Bytes::from("0x0000000000000000000000000000000000000002"),
+                        Chain::Ethereum,
+                    )
+                } else {
+                    Token::new(
+                        &Bytes::from("0x0000000000000000000000000000000000000002"),
+                        "USDC",
+                        6,
+                        0,
+                        &[],
+                        Chain::Ethereum,
+                        100,
+                    )
+                },
             ])
             .await
             .expect("adding tokens failed");
@@ -2975,8 +3004,6 @@ mod test {
         )
         .await
         .expect("extractor init failed");
-
-        let exp_tvl = 66.39849612683253;
 
         extractor
             .handle_tvl_changes(&mut msg)

--- a/crates/tycho-indexer/src/extractor/runner.rs
+++ b/crates/tycho-indexer/src/extractor/runner.rs
@@ -260,7 +260,14 @@ impl ExtractorRunner {
                                     })?;
                                     for msg in msgs {
                                         trace!("Propagating block data message.");
+                                        let block_ts = msg.block.ts.and_utc().timestamp() as f64;
                                         Self::propagate_msg(&self.subscriptions, msg).await;
+                                        // A heartbeat or an incoming block is not evidence that the
+                                        // extractor produced fresh state. Set after fan-out completes;
+                                        // individual subscriber send failures are only logged.
+                                        gauge!("extractor_last_published_block_timestamp_seconds",
+                                            "chain" => id.chain.to_string(), "extractor" => id.name.to_string())
+                                            .set(block_ts);
                                     }
 
                                     let duration_ms = start_time.elapsed().as_millis() as f64;

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Instant};
 
+use anyhow::Context;
 use chrono::NaiveDateTime;
 use futures03::{future::try_join_all, FutureExt};
 use tokio::sync::Semaphore;
@@ -97,7 +98,16 @@ async fn run_analysis_pass(
             break;
         }
     }
-    info!(matched = tokens.len(), ?pass, "Starting analysis pass");
+    // Pending metadata is completed by the recovery worker, and `update_tokens` rejects it.
+    // The quality ranges used today already exclude pending rows; keep the guard explicit so
+    // a wider range cannot abort a whole pass.
+    let matched = tokens.len();
+    tokens.retain(|t| t.metadata_status.is_ready());
+    let skipped_pending = matched - tokens.len();
+    if skipped_pending > 0 {
+        warn!(skipped_pending, ?pass, "Skipping tokens with pending metadata");
+    }
+    info!(matched, skipped_pending, ?pass, "Starting analysis pass");
 
     let start = Instant::now();
     let sem = Arc::new(Semaphore::new(analyze_args.concurrency));
@@ -151,7 +161,7 @@ struct PassOutcome {
 async fn analyze_batch(
     chain: Chain,
     rpc: &EthereumRpcClient,
-    mut tokens: Vec<Token>,
+    tokens: Vec<Token>,
     sem: Arc<Semaphore>,
     gw: Arc<dyn ProtocolGateway + Send + Sync>,
     settlement_contract: alloy::primitives::Address,
@@ -162,8 +172,56 @@ async fn analyze_batch(
         .iter()
         .map(|t| t.address.clone())
         .collect::<Vec<_>>();
+    let owners = find_token_owners(chain, &addresses, gw.as_ref())
+        .await
+        .context("failed to resolve token owners for analysis batch")?;
+    let analyzer = EthCallDetector::new(rpc, Arc::new(owners), settlement_contract);
+    let mut outcome = PassOutcome::default();
+    let mut analyzed = Vec::with_capacity(tokens.len());
+    for mut t in tokens {
+        debug!(?t.address, "Analyzing token");
+        let (token_quality, gas, tax) = match analyzer
+            .analyze(t.address.clone(), BlockTag::Latest)
+            .await
+        {
+            Ok(res) => res,
+            Err(error) => {
+                warn!(address = ?t.address, ?error, "Token quality detection failed");
+                outcome.failed += 1;
+                continue;
+            }
+        };
+
+        let quality_before = t.quality;
+        apply_analysis(&mut t, token_quality, gas, tax, pass);
+        if t.quality > quality_before {
+            outcome.promoted += 1;
+        } else if t.quality < quality_before {
+            outcome.demoted += 1;
+        } else {
+            outcome.unchanged += 1;
+        }
+        analyzed.push(t);
+    }
+
+    // A token without a verdict keeps its stored values. Writing it again would only churn
+    // the database row and the token cache.
+    if !analyzed.is_empty() {
+        gw.update_tokens(&analyzed)
+            .await
+            .context("failed to persist token analysis results")?;
+    }
+    Ok(outcome)
+}
+
+/// Resolves the protocol-specific balance owner instead of assuming every pool holds its tokens.
+pub(crate) async fn find_token_owners(
+    chain: Chain,
+    addresses: &[Bytes],
+    gw: &(dyn ProtocolGateway + Send + Sync),
+) -> anyhow::Result<TokenOwnerStore> {
     let token_owner = gw
-        .get_token_owners(&chain, &addresses, Some(100_000f64))
+        .get_token_owners(&chain, addresses, Some(100_000f64))
         .await?;
     let component_ids = token_owner
         .values()
@@ -215,41 +273,7 @@ async fn analyze_batch(
             }
         })
         .collect::<HashMap<_, _>>();
-    let analyzer = EthCallDetector::new(
-        rpc,
-        Arc::new(TokenOwnerStore::new(liquidity_token_owners)),
-        settlement_contract,
-    );
-    let mut outcome = PassOutcome::default();
-    for t in tokens.iter_mut() {
-        debug!(?t.address, "Analyzing token");
-        let (token_quality, gas, tax) = match analyzer
-            .analyze(t.address.clone(), BlockTag::Latest)
-            .await
-        {
-            Ok(res) => res,
-            Err(error) => {
-                warn!(?error, "Token quality detection failed");
-                outcome.failed += 1;
-                continue;
-            }
-        };
-
-        let quality_before = t.quality;
-        apply_analysis(t, token_quality, gas, tax, pass);
-        if t.quality > quality_before {
-            outcome.promoted += 1;
-        } else if t.quality < quality_before {
-            outcome.demoted += 1;
-        } else {
-            outcome.unchanged += 1;
-        }
-    }
-
-    if !tokens.is_empty() {
-        gw.update_tokens(&tokens).await?;
-    }
-    Ok(outcome)
+    Ok(TokenOwnerStore::new(liquidity_token_owners))
 }
 
 /// Applies an analysis verdict to the token's quality, gas and tax fields.
@@ -526,6 +550,142 @@ mod test {
     async fn test_recovery_pass_counts_unchanged() {
         let outcome = run_outcome_batch(AnalysisPass::Recovery, 5).await;
         assert_eq!(outcome, PassOutcome { unchanged: 2, ..Default::default() });
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_failed_analysis_is_not_written_back() {
+        // Token 1 has no owner: the analyzer returns Bad without an RPC call and the retry
+        // pass demotes it. Token 2 has an owner, so the analyzer simulates a transfer; the
+        // mock RPC answers with a non-retryable, non-revert error, which is a failure.
+        let mut server = mockito::Server::new_async().await;
+        let _rpc_error = server
+            .mock("POST", "/")
+            .with_body_from_request(|request| {
+                let body: serde_json::Value =
+                    serde_json::from_slice(request.body().unwrap()).unwrap();
+                let error_for = |call: &serde_json::Value| {
+                    serde_json::json!({
+                        "jsonrpc": "2.0", "id": call["id"],
+                        "error": {"code": -32601, "message": "method not found"}
+                    })
+                };
+                let response = match body.as_array() {
+                    Some(calls) => serde_json::Value::Array(calls.iter().map(error_for).collect()),
+                    None => error_for(&body),
+                };
+                serde_json::to_vec(&response).unwrap()
+            })
+            .create_async()
+            .await;
+        let rpc = EthereumRpcClient::new(&server.url()).expect("url parses");
+
+        let owned = "0x0000000000000000000000000000000000000002";
+        let pool = "0x7ec8e94a9b379f6b90ee5af7b9a78624280b50ea";
+        let mut gw = testing::MockGateway::new();
+        gw.expect_get_token_owners()
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Ok(HashMap::from([(
+                        Bytes::from(owned),
+                        (pool.to_string(), Bytes::from("0x0186a0")),
+                    )]))
+                })
+            });
+        gw.expect_get_protocol_components()
+            .returning(move |_, _, _, _, _| {
+                Box::pin(async move {
+                    Ok(WithTotal {
+                        entity: vec![ProtocolComponent::new(
+                            pool,
+                            "uniswap_v2",
+                            "pool",
+                            Chain::Ethereum,
+                            vec![Bytes::from(owned)],
+                            vec![],
+                            HashMap::new(),
+                            ChangeType::Creation,
+                            Bytes::from("0x00"),
+                            NaiveDateTime::default(),
+                        )],
+                        total: Some(1),
+                    })
+                })
+            });
+        gw.expect_get_protocol_states()
+            .returning(|_, _, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_update_tokens()
+            .times(1)
+            .withf(|updated| {
+                updated.len() == 1 &&
+                    updated[0].address ==
+                        Bytes::from("0x0000000000000000000000000000000000000001") &&
+                    updated[0].quality == 7
+            })
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        let outcome = analyze_batch(
+            Chain::Ethereum,
+            &rpc,
+            vec![
+                test_token_at("0x0000000000000000000000000000000000000001", 8),
+                test_token_at(owned, 8),
+            ],
+            Arc::new(Semaphore::new(1)),
+            Arc::new(gw),
+            "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+                .parse()
+                .unwrap(),
+            AnalysisPass::Retry,
+        )
+        .await
+        .expect("analyze batch failed");
+        assert_eq!(outcome, PassOutcome { demoted: 1, failed: 1, ..Default::default() });
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_pending_tokens_are_skipped_before_analysis() {
+        let rpc = EthereumRpcClient::new("http://localhost:1").expect("url parses");
+        let args = wiring_args(0);
+        let mut gw = testing::MockGateway::new();
+        gw.expect_get_tokens()
+            .returning(|_, _, _, _, _| {
+                Box::pin(async {
+                    Ok(WithTotal {
+                        entity: vec![
+                            test_token_at("0x0000000000000000000000000000000000000001", 8),
+                            Token::pending(
+                                &Bytes::from("0x0000000000000000000000000000000000000002"),
+                                Chain::Ethereum,
+                            ),
+                        ],
+                        total: Some(2),
+                    })
+                })
+            });
+        gw.expect_get_token_owners()
+            .returning(|_, _, _| Box::pin(async { Ok(HashMap::new()) }));
+        gw.expect_get_protocol_components()
+            .returning(|_, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_get_protocol_states()
+            .returning(|_, _, _, _, _, _| {
+                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            });
+        gw.expect_update_tokens()
+            .times(1)
+            .withf(|updated| {
+                updated.len() == 1 &&
+                    updated[0].address ==
+                        Bytes::from("0x0000000000000000000000000000000000000001")
+            })
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        analyze_tokens(args, &rpc, Arc::new(gw))
+            .await
+            .expect("analyze tokens failed");
     }
 
     // requires a running ethereum node

--- a/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/crates/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -558,8 +558,9 @@ mod test {
         // pass demotes it. Token 2 has an owner, so the analyzer simulates a transfer; the
         // mock RPC answers with a non-retryable, non-revert error, which is a failure.
         let mut server = mockito::Server::new_async().await;
-        let _rpc_error = server
+        let rpc_error = server
             .mock("POST", "/")
+            .expect_at_least(1)
             .with_body_from_request(|request| {
                 let body: serde_json::Value =
                     serde_json::from_slice(request.body().unwrap()).unwrap();
@@ -642,33 +643,65 @@ mod test {
         .await
         .expect("analyze batch failed");
         assert_eq!(outcome, PassOutcome { demoted: 1, failed: 1, ..Default::default() });
+        rpc_error.assert_async().await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_pending_tokens_are_skipped_before_analysis() {
-        let rpc = EthereumRpcClient::new("http://localhost:1").expect("url parses");
+        // The pending token has an owner, so analyzing it would simulate a transfer over RPC.
+        // The ready token has none and is demoted without any RPC call, so any request that
+        // reaches the server can only come from the pending token.
+        let mut server = mockito::Server::new_async().await;
+        let rpc_calls = server
+            .mock("POST", "/")
+            .expect(0)
+            .create_async()
+            .await;
+        let rpc = EthereumRpcClient::new(&server.url()).expect("url parses");
         let args = wiring_args(0);
+        let pending = "0x0000000000000000000000000000000000000002";
+        let pool = "0x7ec8e94a9b379f6b90ee5af7b9a78624280b50ea";
         let mut gw = testing::MockGateway::new();
         gw.expect_get_tokens()
-            .returning(|_, _, _, _, _| {
-                Box::pin(async {
+            .returning(move |_, _, _, _, _| {
+                Box::pin(async move {
                     Ok(WithTotal {
                         entity: vec![
                             test_token_at("0x0000000000000000000000000000000000000001", 8),
-                            Token::pending(
-                                &Bytes::from("0x0000000000000000000000000000000000000002"),
-                                Chain::Ethereum,
-                            ),
+                            Token::pending(&Bytes::from(pending), Chain::Ethereum),
                         ],
                         total: Some(2),
                     })
                 })
             });
         gw.expect_get_token_owners()
-            .returning(|_, _, _| Box::pin(async { Ok(HashMap::new()) }));
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Ok(HashMap::from([(
+                        Bytes::from(pending),
+                        (pool.to_string(), Bytes::from("0x0186a0")),
+                    )]))
+                })
+            });
         gw.expect_get_protocol_components()
-            .returning(|_, _, _, _, _| {
-                Box::pin(async { Ok(WithTotal { entity: vec![], total: Some(0) }) })
+            .returning(move |_, _, _, _, _| {
+                Box::pin(async move {
+                    Ok(WithTotal {
+                        entity: vec![ProtocolComponent::new(
+                            pool,
+                            "uniswap_v2",
+                            "pool",
+                            Chain::Ethereum,
+                            vec![Bytes::from(pending)],
+                            vec![],
+                            HashMap::new(),
+                            ChangeType::Creation,
+                            Bytes::from("0x00"),
+                            NaiveDateTime::default(),
+                        )],
+                        total: Some(1),
+                    })
+                })
             });
         gw.expect_get_protocol_states()
             .returning(|_, _, _, _, _, _| {
@@ -686,6 +719,7 @@ mod test {
         analyze_tokens(args, &rpc, Arc::new(gw))
             .await
             .expect("analyze tokens failed");
+        rpc_calls.assert_async().await;
     }
 
     // requires a running ethereum node

--- a/crates/tycho-indexer/src/extractor/token_metadata_recovery.rs
+++ b/crates/tycho-indexer/src/extractor/token_metadata_recovery.rs
@@ -1,0 +1,263 @@
+//! Retries enrichment after pending token identities have reached finalized storage.
+//! No RPC work or recovery write runs on the extractor's block-processing future.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use futures03::{stream, StreamExt};
+use metrics::{counter, gauge};
+use tokio::time::{sleep, timeout, Instant};
+use tracing::warn;
+use tycho_common::{
+    models::{blockchain::BlockTag, Chain},
+    Bytes,
+};
+use tycho_ethereum::services::token_pre_processor::EthereumTokenPreProcessor;
+use tycho_storage::postgres::cache::CachedGateway;
+
+use super::{
+    protocol_cache::{ProtocolDataCache, ProtocolMemoryCache},
+    token_analysis_cron::find_token_owners,
+    ExtractionError,
+};
+
+const PAGE_SIZE: i64 = 32;
+const CONCURRENCY: usize = 4;
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
+const RETRY_INTERVAL: Duration = Duration::from_secs(5);
+/// With nothing pending the sweep is a single aggregate query; there is no reason to run it at
+/// the page cadence.
+const IDLE_INTERVAL: Duration = Duration::from_secs(60);
+/// Longest wait between attempts for one token. Bounds the RPC cost of a token that keeps
+/// failing without giving up on it: a stalled provider or an unfunded pool can recover later.
+const MAX_BACKOFF: Duration = Duration::from_secs(60 * 60);
+
+/// Per-token exponential backoff, kept in memory only. A restart resets it, which is
+/// acceptable: the durable queue is the source of truth and one extra attempt is cheap.
+#[derive(Default)]
+struct RetryBackoff {
+    attempts: HashMap<Bytes, (u32, Instant)>,
+}
+
+impl RetryBackoff {
+    fn is_due(&self, address: &Bytes, now: Instant) -> bool {
+        self.attempts
+            .get(address)
+            .is_none_or(|(_, due)| *due <= now)
+    }
+
+    fn record_failure(&mut self, address: Bytes, now: Instant) {
+        let attempts = self
+            .attempts
+            .get(&address)
+            .map_or(0, |(attempts, _)| *attempts);
+        let delay = RETRY_INTERVAL
+            .saturating_mul(1u32 << attempts.min(16))
+            .min(MAX_BACKOFF);
+        self.attempts
+            .insert(address, (attempts.saturating_add(1), now + delay));
+    }
+
+    fn record_success(&mut self, address: &Bytes) {
+        self.attempts.remove(address);
+    }
+
+    /// Drops bookkeeping for tokens that left the durable queue through another writer.
+    fn retain_pending(&mut self, still_pending: &HashSet<Bytes>) {
+        self.attempts
+            .retain(|address, _| still_pending.contains(address));
+    }
+}
+
+/// Runs until cancelled by its owner. Errors leave rows pending for a later sweep.
+///
+/// Recovery applies the same rules as the hot path: metadata that reverts gets the legacy
+/// fallbacks, a token without a funded owner gets a Bad verdict, and only an RPC that does not
+/// answer keeps the token pending. Otherwise a token that was merely deferred by a slow RPC
+/// would end up in a different state than the same token fetched on a fast one.
+pub async fn run(
+    chain: Chain,
+    gateway: CachedGateway,
+    cache: ProtocolMemoryCache,
+    processor: EthereumTokenPreProcessor,
+) -> Result<(), ExtractionError> {
+    let mut after_id = 0;
+    let mut backoff = RetryBackoff::default();
+    let mut seen_this_sweep = HashSet::new();
+    loop {
+        if after_id == 0 {
+            backoff.retain_pending(&seen_this_sweep);
+            seen_this_sweep.clear();
+            match timeout(ATTEMPT_TIMEOUT, gateway.pending_token_metadata_stats(chain)).await {
+                Ok(Ok((count, oldest))) => {
+                    gauge!("token_metadata_pending_count", "chain" => chain.to_string())
+                        .set(count as f64);
+                    let age = oldest
+                        .map(|ts| {
+                            (chrono::Utc::now().naive_utc() - ts)
+                                .num_seconds()
+                                .max(0)
+                        })
+                        .unwrap_or(0);
+                    gauge!("token_metadata_pending_age_seconds", "chain" => chain.to_string())
+                        .set(age as f64);
+                    if count == 0 {
+                        sleep(IDLE_INTERVAL).await;
+                        continue;
+                    }
+                }
+                result => warn!(?result, "Could not measure pending token metadata"),
+            }
+            // A successful repair in another process (or an ambiguous commit response) can
+            // remove a row from the durable queue before this cache has observed it. Addresses
+            // without a database row (reverted blocks) simply never come back ready.
+            for addresses in cache
+                .pending_token_addresses()
+                .await
+                .chunks(PAGE_SIZE as usize)
+            {
+                match timeout(ATTEMPT_TIMEOUT, gateway.ready_token_metadata(chain, addresses)).await
+                {
+                    Ok(Ok(ready)) => cache.add_tokens(ready).await?,
+                    result => warn!(?result, "Could not reconcile pending token cache"),
+                }
+            }
+        }
+        // The cursor advances even on failed attempts. A poison token must not keep later
+        // pages from being visited, and a shrinking pending set must not shift an OFFSET.
+        let page = match timeout(
+            ATTEMPT_TIMEOUT,
+            gateway.pending_token_metadata(chain, after_id, PAGE_SIZE),
+        )
+        .await
+        {
+            Ok(Ok(page)) => page,
+            result => {
+                warn!(?result, "Could not read pending token metadata");
+                sleep(RETRY_INTERVAL).await;
+                continue;
+            }
+        };
+        if page.is_empty() {
+            after_id = 0;
+            sleep(RETRY_INTERVAL).await;
+            continue;
+        }
+        after_id = page.last().expect("nonempty page").0;
+        let now = Instant::now();
+        let addresses: Vec<_> = page
+            .iter()
+            .map(|(_, token, _)| token.address.clone())
+            .inspect(|address| {
+                seen_this_sweep.insert(address.clone());
+            })
+            .filter(|address| backoff.is_due(address, now))
+            .collect();
+        if addresses.is_empty() {
+            continue;
+        }
+        let owners =
+            match timeout(ATTEMPT_TIMEOUT, find_token_owners(chain, &addresses, &gateway)).await {
+                Ok(Ok(owners)) => Arc::new(owners),
+                result => {
+                    warn!(?result, "Could not resolve pending token owners");
+                    sleep(RETRY_INTERVAL).await;
+                    continue;
+                }
+            };
+        let mut work = stream::iter(addresses)
+            .map(|address| {
+                let owners = owners.clone();
+                let processor = &processor;
+                async move {
+                    let attempt =
+                        processor.recover_token(address.clone(), owners, BlockTag::Latest);
+                    (address, timeout(ATTEMPT_TIMEOUT, attempt).await)
+                }
+            })
+            .buffer_unordered(CONCURRENCY);
+        let mut ready = Vec::new();
+        while let Some((address, result)) = work.next().await {
+            match result {
+                Ok(Ok(token)) => ready.push(token),
+                result => {
+                    backoff.record_failure(address, now);
+                    counter!("token_metadata_recovery_attempts", "chain" => chain.to_string(), "outcome" => "deferred").increment(1);
+                    warn!(?result, "Token metadata recovery deferred");
+                }
+            }
+        }
+        // Do not time out the commit future: cancelling after PostgreSQL commits would make
+        // its acknowledgement ambiguous. A DB failure leaves the cache untouched.
+        if !ready.is_empty() {
+            match gateway
+                .complete_token_metadata(&ready)
+                .await
+            {
+                Ok(completed) => {
+                    let already_complete = ready.len() - completed.len();
+                    counter!("token_metadata_recovery_attempts", "chain" => chain.to_string(), "outcome" => "completed").increment(completed.len() as u64);
+                    counter!("token_metadata_recovery_attempts", "chain" => chain.to_string(), "outcome" => "already_complete").increment(already_complete as u64);
+                    for token in &ready {
+                        backoff.record_success(&token.address);
+                    }
+                    cache.add_tokens(completed).await?;
+                }
+                Err(error) => {
+                    counter!("token_metadata_recovery_attempts", "chain" => chain.to_string(), "outcome" => "commit_failed").increment(ready.len() as u64);
+                    warn!(%error, "Could not persist recovered token metadata");
+                }
+            }
+        }
+        sleep(RETRY_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn address(id: u8) -> Bytes {
+        Bytes::from(vec![id])
+    }
+
+    #[test]
+    fn unknown_tokens_are_due_immediately() {
+        let backoff = RetryBackoff::default();
+        assert!(backoff.is_due(&address(1), Instant::now()));
+    }
+
+    #[test]
+    fn failures_double_the_wait_up_to_the_cap() {
+        let mut backoff = RetryBackoff::default();
+        let now = Instant::now();
+        let token = address(1);
+        let mut expected = RETRY_INTERVAL;
+        for _ in 0..20 {
+            backoff.record_failure(token.clone(), now);
+            let (_, due) = backoff.attempts[&token];
+            assert_eq!(due - now, expected);
+            assert!(!backoff.is_due(&token, now + expected - Duration::from_millis(1)));
+            assert!(backoff.is_due(&token, now + expected));
+            expected = (expected * 2).min(MAX_BACKOFF);
+        }
+        assert_eq!(backoff.attempts[&token].1 - now, MAX_BACKOFF);
+    }
+
+    #[test]
+    fn success_resets_and_stale_entries_are_pruned() {
+        let mut backoff = RetryBackoff::default();
+        let now = Instant::now();
+        backoff.record_failure(address(1), now);
+        backoff.record_failure(address(2), now);
+        backoff.record_success(&address(1));
+        assert!(backoff.is_due(&address(1), now));
+        assert!(!backoff.is_due(&address(2), now));
+
+        backoff.retain_pending(&HashSet::new());
+        assert!(backoff.is_due(&address(2), now));
+    }
+}

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -341,7 +341,7 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
     main_runtime.spawn(async move {
         let (res, _, _) = select_all(other_tasks).await;
 
-        if services_ctrl_tx.send(res.unwrap_or_else(|join_err| Err(ExtractionError::Unknown(format!("Task panicked: {join_err}"))))).is_err() {
+        if services_ctrl_tx.send(service_task_result(res)).is_err() {
             error!("Fatal service task exited and failed trying to communicate with main thread. Exiting the process...");
             process::exit(1);
         }
@@ -420,8 +420,20 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
     all_tasks.append(&mut other_tasks);
 
     let (res, _, _) = select_all(all_tasks).await;
-    res.expect("Tasks should not panic")?;
-    Ok(())
+    service_task_result(res)
+}
+
+/// Shutdown aborts the token-metadata recovery worker, and that abort can be observed by the
+/// task supervisor before the shutdown handler itself returns. A cancelled join is part of a
+/// clean shutdown, not a failure; only a panic is.
+fn service_task_result(
+    res: Result<Result<(), ExtractionError>, tokio::task::JoinError>,
+) -> Result<(), ExtractionError> {
+    match res {
+        Ok(result) => result,
+        Err(join_err) if join_err.is_cancelled() => Ok(()),
+        Err(join_err) => Err(ExtractionError::Unknown(format!("Task panicked: {join_err}"))),
+    }
 }
 
 #[tokio::main]
@@ -494,7 +506,7 @@ async fn create_indexing_tasks(
         .enable_token_cache()
         .build()
         .await?;
-    let token_processor = EthereumTokenPreProcessor::new(
+    let mut token_processor = EthereumTokenPreProcessor::new(
         &rpc_client,
         *chains
             .first()
@@ -502,21 +514,28 @@ async fn create_indexing_tasks(
         settlement_contract,
     );
 
-    let (supervisors, extractor_handles, pending_deltas_rxs) = build_all_extractors(
-        &extractors_config,
-        chains,
-        &global_args.endpoint_url,
-        global_args.s3_bucket.as_deref(),
-        &substreams_args.substreams_api_token,
-        &cached_gw,
-        global_args.database_insert_batch_size,
-        &token_processor,
-        &rpc_client,
-        extraction_runtime,
-        substreams_args.enable_partial_blocks,
-    )
-    .await
-    .map_err(|e| ExtractionError::Setup(format!("Failed to create extractors: {e}")))?;
+    if global_args.token_enrichment_budget_ms > 0 {
+        token_processor = token_processor.with_enrichment_budget(std::time::Duration::from_millis(
+            global_args.token_enrichment_budget_ms,
+        ));
+    }
+
+    let (supervisors, extractor_handles, pending_deltas_rxs, protocol_cache) =
+        build_all_extractors(
+            &extractors_config,
+            chains,
+            &global_args.endpoint_url,
+            global_args.s3_bucket.as_deref(),
+            &substreams_args.substreams_api_token,
+            &cached_gw,
+            global_args.database_insert_batch_size,
+            &token_processor,
+            &rpc_client,
+            extraction_runtime,
+            substreams_args.enable_partial_blocks,
+        )
+        .await
+        .map_err(|e| ExtractionError::Setup(format!("Failed to create extractors: {e}")))?;
 
     let server_url = format!("http://{}:{}", global_args.server_ip, global_args.server_port);
     let api_key = env::var("AUTH_API_KEY").map_err(|_| {
@@ -537,8 +556,21 @@ async fn create_indexing_tasks(
             .run()?;
     info!(server_url, "Http and Ws server started");
 
-    let shutdown_task =
-        tokio::spawn(shutdown_handler(server_handle, extractor_handles, Some(gw_writer_handle)));
+    // Disabling deferral must not strand tokens persisted while it was enabled. One worker per
+    // process, on the first configured chain, mirrors the single `token_processor` above.
+    let recovery_task = tokio::spawn(tycho_indexer::extractor::token_metadata_recovery::run(
+        chains[0],
+        cached_gw.clone(),
+        protocol_cache,
+        token_processor,
+    ));
+    let recovery_abort = recovery_task.abort_handle();
+    let shutdown_task = tokio::spawn(async move {
+        let result =
+            shutdown_handler(server_handle, extractor_handles, Some(gw_writer_handle)).await;
+        recovery_abort.abort();
+        result
+    });
 
     let runtime = extraction_runtime
         .cloned()
@@ -549,7 +581,8 @@ async fn create_indexing_tasks(
         .map(|supervisor| runtime.spawn(supervisor.run()))
         .collect::<Vec<_>>();
 
-    Ok((supervisor_tasks, vec![server_task, shutdown_task]))
+    let other_tasks = vec![server_task, shutdown_task, recovery_task];
+    Ok((supervisor_tasks, other_tasks))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -570,6 +603,7 @@ async fn build_all_extractors(
         Vec<ExtractorSupervisor>,
         Vec<ExtractorHandle>,
         Vec<tokio::sync::mpsc::Receiver<tycho_indexer::extractor::DeltaCommand>>,
+        ProtocolMemoryCache,
     ),
     ExtractionError,
 > {
@@ -636,7 +670,7 @@ async fn build_all_extractors(
         pending_deltas_rxs.push(pd_rx);
     }
 
-    Ok((supervisors, extractor_handles, pending_deltas_rxs))
+    Ok((supervisors, extractor_handles, pending_deltas_rxs, protocol_cache))
 }
 
 async fn with_transaction<F, Fut, R>(gw: &CachedGateway, block: &Block, f: F) -> R

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -844,6 +844,35 @@ async fn run_analyze_tokens(
 mod tests {
     use tycho_common::models::chain_config::ChainTokenConfig;
 
+    use super::{service_task_result, ExtractionError};
+
+    #[tokio::test]
+    async fn aborted_service_task_is_a_clean_shutdown() {
+        let handle: tokio::task::JoinHandle<Result<(), ExtractionError>> =
+            tokio::spawn(std::future::pending());
+        handle.abort();
+
+        assert_eq!(service_task_result(handle.await), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn panicked_service_task_is_an_error() {
+        let handle: tokio::task::JoinHandle<Result<(), ExtractionError>> =
+            tokio::spawn(async { panic!("boom") });
+
+        match service_task_result(handle.await) {
+            Err(ExtractionError::Unknown(message)) => assert!(message.contains("Task panicked")),
+            other => panic!("expected a panic to be reported, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn service_task_error_passes_through() {
+        let result = service_task_result(Ok(Err(ExtractionError::Unknown("x".into()))));
+
+        assert_eq!(result, Err(ExtractionError::Unknown("x".into())));
+    }
+
     #[test]
     fn test_chain_token_invalid_hex() {
         assert!(ChainTokenConfig::try_new("0xGGGGGGGG", "ETH", 18).is_err());

--- a/crates/tycho-indexer/src/services/api_docs.rs
+++ b/crates/tycho-indexer/src/services/api_docs.rs
@@ -1,13 +1,16 @@
-use tycho_common::dto::{
-    AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
-    ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
-    PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
-    ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
-    ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
-    RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
-    StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
-    TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
-    VersionParam,
+use tycho_common::{
+    dto::{
+        AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
+        ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
+        PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
+        ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
+        ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
+        RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
+        StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
+        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
+        VersionParam,
+    },
+    models::token::TokenMetadataStatus,
 };
 use utoipa::{
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
@@ -57,6 +60,7 @@ impl Modify for SecurityAddon {
         schemas(PaginationParams),
         schemas(PaginationResponse),
         schemas(ResponseToken),
+        schemas(TokenMetadataStatus),
         schemas(ProtocolComponentsRequestBody),
         schemas(ProtocolComponentRequestResponse),
         schemas(ProtocolComponent),

--- a/crates/tycho-simulation/examples/capture_vm_fixtures.rs
+++ b/crates/tycho-simulation/examples/capture_vm_fixtures.rs
@@ -213,10 +213,28 @@ fn capture_target(
     );
 
     let filtered_states = HashMap::from([(component_id, component_with_state.clone())]);
+    // Keep only the metadata the server attached for this component's tokens; the fixture
+    // must decode standalone, so the tokens travel with the snapshot as they would live.
+    let filtered_tokens: HashMap<Bytes, _> = state_msg
+        .snapshots
+        .tokens
+        .iter()
+        .filter(|(addr, _)| {
+            component_with_state
+                .component
+                .tokens
+                .contains(*addr)
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
 
     let filtered_state_msg = dto::StateSyncMessage {
         header: state_msg.header.clone(),
-        snapshots: dto::Snapshot { states: filtered_states, vm_storage: filtered_vm_storage },
+        snapshots: dto::Snapshot {
+            tokens: filtered_tokens,
+            states: filtered_states,
+            vm_storage: filtered_vm_storage,
+        },
         deltas: None,
         removed_components: HashMap::new(),
     };

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -202,7 +202,10 @@ where
     /// own token metadata for decoding.
     pub async fn set_tokens(&self, tokens: HashMap<Bytes, Token>) {
         let mut guard = self.state.write().await;
-        guard.tokens = tokens;
+        guard.tokens = tokens
+            .into_iter()
+            .filter(|(_, token)| token.metadata_status.is_ready())
+            .collect();
     }
 
     pub fn skip_state_decode_failures(&mut self, skip: bool) {
@@ -355,23 +358,22 @@ where
             .unwrap_or(false);
 
         for (protocol, protocol_msg) in msg.state_msgs.iter() {
-            // Add any new tokens
-            if let Some(deltas) = protocol_msg.deltas.as_ref() {
-                let mut state_guard = self.state.write().await;
-
-                let new_tokens = deltas
-                    .new_tokens
-                    .iter()
-                    .filter(|(addr, t)| {
-                        t.quality >= self.min_token_quality &&
-                            !state_guard.tokens.contains_key(*addr)
-                    })
-                    .map(|(addr, t)| (addr.clone(), t.clone()))
-                    .collect::<HashMap<Bytes, Token>>();
-
-                if !new_tokens.is_empty() {
-                    debug!(n = new_tokens.len(), "NewTokens");
-                    state_guard.tokens.extend(new_tokens);
+            // Snapshot metadata can arrive long after the creation delta, when deferred
+            // enrichment completes. Readiness is mandatory even with min_token_quality = 0.
+            {
+                let mut state = self.state.write().await;
+                let delta_tokens = protocol_msg
+                    .deltas
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|deltas| deltas.new_tokens.iter());
+                for (address, token) in delta_tokens.chain(protocol_msg.snapshots.tokens.iter()) {
+                    if token.metadata_status.is_ready() && token.quality >= self.min_token_quality {
+                        state
+                            .tokens
+                            .entry(address.clone())
+                            .or_insert_with(|| token.clone());
+                    }
                 }
             }
 
@@ -618,7 +620,6 @@ where
                             }
                             None => {
                                 count_token_skips += 1;
-                                msg_failed_components.insert(id.clone());
                                 debug!("Token not found {}, ignoring pool {:x?}", token, id);
                                 continue 'snapshot_loop;
                             }
@@ -1572,6 +1573,89 @@ mod tests {
         assert_eq!(res2.states.len(), 1);
         assert_eq!(res1.sync_states.len(), 1);
         assert_eq!(res2.sync_states.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pending_metadata_defers_pool_even_at_zero_quality_and_snapshot_repairs_it() {
+        let mut decoder = setup_decoder(false).await;
+        decoder.min_token_quality(0);
+        let mut msg = load_test_msg("uniswap_v2_snapshot");
+        let addresses: Vec<_> = msg
+            .state_msgs
+            .values()
+            .flat_map(|m| {
+                m.snapshots
+                    .states
+                    .values()
+                    .flat_map(|s| s.component.tokens.clone())
+            })
+            .collect();
+        let pending: HashMap<_, _> = addresses
+            .iter()
+            .map(|address| (address.clone(), Token::pending(address, Chain::Ethereum)))
+            .collect();
+        decoder
+            .set_tokens(pending.clone())
+            .await;
+        for state_msg in msg.state_msgs.values_mut() {
+            state_msg.snapshots.tokens = pending.clone();
+        }
+        assert!(decoder
+            .decode(&msg)
+            .await
+            .unwrap()
+            .states
+            .is_empty());
+        assert!(decoder
+            .state
+            .read()
+            .await
+            .tokens
+            .is_empty());
+        assert!(decoder
+            .state
+            .read()
+            .await
+            .failed_components
+            .is_empty());
+
+        for state_msg in msg.state_msgs.values_mut() {
+            state_msg.snapshots.tokens = addresses
+                .iter()
+                .map(|address| {
+                    (
+                        address.clone(),
+                        Token::new(
+                            address,
+                            "RECOVERED",
+                            18,
+                            0,
+                            &[Some(30_000)],
+                            Chain::Ethereum,
+                            100,
+                        ),
+                    )
+                })
+                .collect();
+        }
+        let recovered = decoder.decode(&msg).await.unwrap();
+        assert_eq!(recovered.states.len(), 1);
+        assert!(decoder
+            .state
+            .read()
+            .await
+            .failed_components
+            .is_empty());
+        let delta = load_test_msg("uniswap_v2_delta");
+        assert_eq!(
+            decoder
+                .decode(&delta)
+                .await
+                .unwrap()
+                .states
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1646,7 +1646,17 @@ mod tests {
             .await
             .failed_components
             .is_empty());
-        let delta = load_test_msg("uniswap_v2_delta");
+        // A pending token announced by a delta is deferred the same way, even at zero quality.
+        let mut delta = load_test_msg("uniswap_v2_delta");
+        let late_token = Bytes::from("0x0a").lpad(20, 0);
+        for state_msg in delta.state_msgs.values_mut() {
+            state_msg
+                .deltas
+                .as_mut()
+                .expect("delta message")
+                .new_tokens
+                .insert(late_token.clone(), Token::pending(&late_token, Chain::Ethereum));
+        }
         assert_eq!(
             decoder
                 .decode(&delta)
@@ -1656,6 +1666,12 @@ mod tests {
                 .len(),
             1
         );
+        assert!(!decoder
+            .state
+            .read()
+            .await
+            .tokens
+            .contains_key(&late_token));
     }
 
     #[tokio::test]
@@ -1701,6 +1717,13 @@ mod tests {
             .expect("decode failure");
 
         assert_eq!(res1.states.len(), 0);
+        // A missing token is temporary: the pool must stay eligible for a later snapshot.
+        assert!(decoder
+            .state
+            .read()
+            .await
+            .failed_components
+            .is_empty());
     }
 
     #[tokio::test]
@@ -1740,6 +1763,12 @@ mod tests {
                     panic!("Expected failures to be raised")
                 } else {
                     assert_eq!(res.states.len(), 0);
+                    assert!(decoder
+                        .state
+                        .read()
+                        .await
+                        .failed_components
+                        .contains("0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852"));
                 }
             }
         }

--- a/crates/tycho-simulation/src/evm/protocol/ekubo/test_cases.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo/test_cases.rs
@@ -45,6 +45,7 @@ pub struct TestCase {
 impl TestCase {
     pub fn token0(&self) -> Token {
         Token {
+            metadata_status: Default::default(),
             address: self
                 .state_after_transition
                 .key()
@@ -62,6 +63,7 @@ impl TestCase {
 
     pub fn token1(&self) -> Token {
         Token {
+            metadata_status: Default::default(),
             address: self
                 .state_after_transition
                 .key()

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/test_cases.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/test_cases.rs
@@ -65,6 +65,7 @@ pub struct TestCase {
 impl TestCase {
     pub fn token0(&self) -> Token {
         Token {
+            metadata_status: Default::default(),
             address: self
                 .state_after_transition
                 .key()
@@ -82,6 +83,7 @@ impl TestCase {
 
     pub fn token1(&self) -> Token {
         Token {
+            metadata_status: Default::default(),
             address: self
                 .state_after_transition
                 .key()

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
@@ -396,6 +396,7 @@ impl RFQClient for BebopClient {
                                     current_components = new_components.clone();
 
                                     let snapshot = Snapshot {
+                                        tokens: Default::default(),
                                         states: new_components,
                                         vm_storage: HashMap::new(),
                                     };

--- a/crates/tycho-simulation/src/rfq/protocols/hashflow/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/hashflow/client.rs
@@ -333,6 +333,7 @@ impl RFQClient for HashflowClient {
                         current_components = new_components.clone();
 
                         let snapshot = Snapshot {
+                            tokens: Default::default(),
                             states: new_components,
                             vm_storage: HashMap::new(),
                         };

--- a/crates/tycho-simulation/src/rfq/protocols/liquorice/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/liquorice/client.rs
@@ -371,6 +371,7 @@ impl RFQClient for LiquoriceClient {
                         current_components = new_components.clone();
 
                         let snapshot = Snapshot {
+                            tokens: Default::default(),
                             states: new_components,
                             vm_storage: HashMap::new(),
                         };

--- a/crates/tycho-simulation/src/rfq/protocols/metric/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/client.rs
@@ -460,7 +460,7 @@ impl RFQClient for MetricClient {
 
                 yield Ok(("metric".to_string(), StateSyncMessage {
                     header: TimestampHeader { timestamp },
-                    snapshots: Snapshot { states: new_components, vm_storage: HashMap::new() },
+                    snapshots: Snapshot { states: new_components, vm_storage: HashMap::new(), tokens: HashMap::new() },
                     deltas: None,
                     removed_components,
                 }));

--- a/crates/tycho-simulation/src/rfq/stream.rs
+++ b/crates/tycho-simulation/src/rfq/stream.rs
@@ -247,6 +247,7 @@ mod tests {
                         ProtocolComponent { protocol_system: name.clone(), ..Default::default() };
 
                     let snapshot = Snapshot {
+                        tokens: Default::default(),
                         states: HashMap::from([(
                             name.clone(),
                             ComponentWithState {

--- a/crates/tycho-storage/migrations/2026-09-07_token_metadata_readiness/down.sql
+++ b/crates/tycho-storage/migrations/2026-09-07_token_metadata_readiness/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX token_pending_metadata_idx;
+ALTER TABLE token DROP COLUMN metadata_pending;

--- a/crates/tycho-storage/migrations/2026-09-07_token_metadata_readiness/up.sql
+++ b/crates/tycho-storage/migrations/2026-09-07_token_metadata_readiness/up.sql
@@ -1,0 +1,3 @@
+-- Legacy rows keep their existing admission behavior. Pending is distinct from token quality.
+ALTER TABLE token ADD COLUMN metadata_pending BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX token_pending_metadata_idx ON token (id) WHERE metadata_pending;

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -603,6 +603,88 @@ impl Clone for CachedGateway {
 }
 
 impl CachedGateway {
+    /// Reconciles local pending entries with committed metadata, including repairs made by
+    /// another process or a write whose commit acknowledgement was lost.
+    pub async fn ready_token_metadata(
+        &self,
+        chain: Chain,
+        addresses: &[Address],
+    ) -> Result<Vec<Token>, StorageError> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| StorageError::Unexpected(e.to_string()))?;
+        let ready = self
+            .state_gateway
+            .ready_token_metadata(chain, addresses, &mut conn)
+            .await?;
+        if let Some(cache) = &self.state_gateway.token_cache {
+            cache.upsert_tokens(&ready);
+        }
+        Ok(ready)
+    }
+
+    /// Reads the durable recovery queue, bypassing caches and any uncommitted block writes.
+    /// The id cursor avoids skipping rows when earlier tokens leave the pending set.
+    pub async fn pending_token_metadata(
+        &self,
+        chain: Chain,
+        after_id: i64,
+        limit: i64,
+    ) -> Result<Vec<(i64, Token, NaiveDateTime)>, StorageError> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| StorageError::Unexpected(e.to_string()))?;
+        self.state_gateway
+            .pending_token_metadata(chain, after_id, limit, &mut conn)
+            .await
+    }
+
+    pub async fn pending_token_metadata_stats(
+        &self,
+        chain: Chain,
+    ) -> Result<(i64, Option<NaiveDateTime>), StorageError> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| StorageError::Unexpected(e.to_string()))?;
+        self.state_gateway
+            .pending_token_metadata_stats(chain, &mut conn)
+            .await
+    }
+
+    /// Repairs finalized pending rows and publishes to the token cache only after commit.
+    /// Old block inserts use ON CONFLICT DO NOTHING, so they cannot undo this transition.
+    pub async fn complete_token_metadata(
+        &self,
+        tokens: &[Token],
+    ) -> Result<Vec<Token>, StorageError> {
+        let mut conn =
+            self.pool.get().await.map_err(|e| {
+                StorageError::Unexpected(format!("Failed to retrieve connection: {e}"))
+            })?;
+        let completed = conn
+            .transaction(|conn| {
+                async {
+                    self.state_gateway
+                        .complete_token_metadata(tokens, conn)
+                        .await
+                        .map_err(PostgresError)
+                }
+                .scope_boxed()
+            })
+            .await
+            .map_err(StorageError::from)?;
+        if let Some(cache) = &self.state_gateway.token_cache {
+            cache.upsert_tokens(&completed);
+        }
+        Ok(completed)
+    }
+
     // Accumulating transactions does not drop previous data nor are transactions nested.
     pub async fn start_transaction(&self, block: &models::blockchain::Block, owner: Option<&str>) {
         let mut open_tx = self.open_tx.lock().await;

--- a/crates/tycho-storage/src/postgres/mod.rs
+++ b/crates/tycho-storage/src/postgres/mod.rs
@@ -155,6 +155,8 @@ mod orm;
 mod protocol;
 mod schema;
 pub mod token_cache;
+#[cfg(test)]
+mod token_metadata_tests;
 mod versioning;
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations/");

--- a/crates/tycho-storage/src/postgres/orm.rs
+++ b/crates/tycho-storage/src/postgres/orm.rs
@@ -1383,6 +1383,7 @@ pub struct Token {
     pub inserted_ts: NaiveDateTime,
     pub modified_ts: NaiveDateTime,
     pub quality: i32,
+    pub metadata_pending: bool,
 }
 
 #[derive(AsChangeset, Insertable, Debug)]
@@ -1395,6 +1396,7 @@ pub struct NewToken {
     pub tax: i64,
     pub gas: Vec<Option<i64>>,
     pub quality: i32,
+    pub metadata_pending: bool,
 }
 
 impl NewToken {
@@ -1402,13 +1404,14 @@ impl NewToken {
     /// IMPORTANT: Update this if you add/remove fields!
     /// Used to calculate MAX_BATCH_SIZE to avoid exceeding PostgreSQL's i16 parameter limit
     /// (32767).
-    pub const FIELD_COUNT: usize = 6;
+    pub const FIELD_COUNT: usize = 7;
     /// Maximum number of rows that can be inserted in a single batch.
     /// PostgreSQL wire protocol uses i16 for parameter count (max 32767).
     pub const MAX_BATCH_SIZE: usize = 32767 / Self::FIELD_COUNT;
 
     pub fn from_token(account_id: i64, token: &models::token::Token) -> Self {
         Self {
+            metadata_pending: !token.metadata_status.is_ready(),
             account_id,
             symbol: token.symbol.clone(),
             decimals: token.decimals as i32,

--- a/crates/tycho-storage/src/postgres/protocol.rs
+++ b/crates/tycho-storage/src/postgres/protocol.rs
@@ -1048,20 +1048,7 @@ impl PostgresGateway {
         let tokens: Vec<Token> = results
             .into_iter()
             .map(|(orm_token, address_)| {
-                let gas_usage: Vec<_> = orm_token
-                    .gas
-                    .iter()
-                    .map(|u| u.map(|g| g as u64))
-                    .collect();
-                Token::new(
-                    &address_,
-                    orm_token.symbol.as_str(),
-                    orm_token.decimals as u32,
-                    orm_token.tax as u64,
-                    gas_usage.as_slice(),
-                    chain,
-                    orm_token.quality as u32,
-                )
+                super::token_cache::to_model_token(&orm_token, &address_, chain)
             })
             .collect();
 
@@ -1178,11 +1165,127 @@ impl PostgresGateway {
         Ok(())
     }
 
+    // The pending queries filter on the bare column rather than `= $1` so PostgreSQL can prove
+    // the `token_pending_metadata_idx` partial-index predicate under a generic plan.
+    pub(crate) async fn pending_token_metadata(
+        &self,
+        chain: Chain,
+        after_id: i64,
+        limit: i64,
+        conn: &mut AsyncPgConnection,
+    ) -> Result<Vec<(i64, Token, NaiveDateTime)>, StorageError> {
+        let rows = schema::token::table
+            .inner_join(schema::account::table)
+            .filter(schema::account::chain_id.eq(self.get_chain_id(&chain)?))
+            .filter(schema::token::metadata_pending)
+            .filter(schema::token::id.gt(after_id))
+            .order(schema::token::id.asc())
+            .limit(limit)
+            .select((orm::Token::as_select(), schema::account::address))
+            .load::<(orm::Token, Address)>(conn)
+            .await
+            .map_err(PostgresError::from)?;
+        Ok(rows
+            .into_iter()
+            .map(|(row, address)| (row.id, Token::pending(&address, chain), row.inserted_ts))
+            .collect())
+    }
+
+    pub(crate) async fn pending_token_metadata_stats(
+        &self,
+        chain: Chain,
+        conn: &mut AsyncPgConnection,
+    ) -> Result<(i64, Option<NaiveDateTime>), StorageError> {
+        schema::token::table
+            .inner_join(schema::account::table)
+            .filter(schema::account::chain_id.eq(self.get_chain_id(&chain)?))
+            .filter(schema::token::metadata_pending)
+            .select((diesel::dsl::count_star(), diesel::dsl::min(schema::token::inserted_ts)))
+            .first(conn)
+            .await
+            .map_err(|error| PostgresError::from(error).into())
+    }
+
+    pub(crate) async fn ready_token_metadata(
+        &self,
+        chain: Chain,
+        addresses: &[Address],
+        conn: &mut AsyncPgConnection,
+    ) -> Result<Vec<Token>, StorageError> {
+        let rows = schema::token::table
+            .inner_join(schema::account::table)
+            .filter(schema::account::chain_id.eq(self.get_chain_id(&chain)?))
+            .filter(schema::account::address.eq_any(addresses))
+            .filter(diesel::dsl::not(schema::token::metadata_pending))
+            .select((orm::Token::as_select(), schema::account::address))
+            .load::<(orm::Token, Address)>(conn)
+            .await
+            .map_err(PostgresError::from)?;
+        Ok(rows
+            .into_iter()
+            .map(|(row, address)| super::token_cache::to_model_token(&row, &address, chain))
+            .collect())
+    }
+
+    /// Completes only still-pending rows. Cache publication belongs to the caller after commit.
+    pub(crate) async fn complete_token_metadata(
+        &self,
+        tokens: &[Token],
+        conn: &mut AsyncPgConnection,
+    ) -> Result<Vec<Token>, StorageError> {
+        let mut completed = Vec::new();
+        for token in tokens {
+            // Completing with a still-pending value would clear the flag while leaving the
+            // placeholder symbol and zero decimals in place: a fake-ready row that consumers
+            // would price with.
+            if !token.metadata_status.is_ready() {
+                return Err(StorageError::Unexpected(
+                    "Cannot complete pending token metadata".into(),
+                ));
+            }
+            let account_ids = schema::account::table
+                .filter(schema::account::chain_id.eq(self.get_chain_id(&token.chain)?))
+                .filter(schema::account::address.eq(&token.address))
+                .select(schema::account::id);
+            let gas: Vec<_> = token
+                .gas
+                .iter()
+                .map(|g| g.map(|g| g as i64))
+                .collect();
+            let count = diesel::update(schema::token::table)
+                .filter(schema::token::account_id.eq_any(account_ids))
+                .filter(schema::token::metadata_pending)
+                .set((
+                    schema::token::symbol.eq(truncate_to_byte_limit(&token.symbol, 255)),
+                    schema::token::decimals.eq(token.decimals as i32),
+                    schema::token::quality.eq(token.quality as i32),
+                    schema::token::gas.eq(gas),
+                    schema::token::tax.eq(token.tax as i64),
+                    schema::token::metadata_pending.eq(false),
+                ))
+                .execute(conn)
+                .await
+                .map_err(PostgresError::from)?;
+            if count != 0 {
+                completed.push(token.clone());
+            }
+        }
+        Ok(completed)
+    }
+
     pub async fn update_tokens(
         &self,
         tokens: &[Token],
         conn: &mut AsyncPgConnection,
     ) -> Result<(), StorageError> {
+        if tokens
+            .iter()
+            .any(|item| !item.metadata_status.is_ready())
+        {
+            return Err(StorageError::Unexpected(
+                "Pending metadata must be completed through recovery".into(),
+            ));
+        }
         trace!(addresses=?tokens.iter().map(|t| &t.address).collect::<Vec<_>>(), "Updating tokens");
         let address_to_db_id = {
             let token_addresses: HashSet<Address> = tokens
@@ -1204,7 +1307,8 @@ impl PostgresGateway {
             .collect::<HashMap<Bytes, i64>>()
         };
         use schema::token::dsl::*;
-        async {
+        let updated = async {
+            let mut updated = Vec::new();
             for t in tokens.iter() {
                 if let Some(db_id) = address_to_db_id.get(&t.address) {
                     let gas_val = t
@@ -1212,7 +1316,7 @@ impl PostgresGateway {
                         .iter()
                         .map(|v| v.map(|g| g as i64))
                         .collect::<Vec<_>>();
-                    diesel::update(schema::token::table)
+                    let count = diesel::update(schema::token::table)
                         .set((
                             symbol.eq(&t.symbol),
                             decimals.eq(t.decimals as i32),
@@ -1221,14 +1325,17 @@ impl PostgresGateway {
                             gas.eq(gas_val),
                         ))
                         .filter(id.eq(db_id))
+                        // Ordinary quality updates cannot complete unresolved metadata.
+                        .filter(metadata_pending.eq(false))
                         .execute(conn)
                         .await
                         .map_err(PostgresError::from)?;
+                    if count != 0 { updated.push(t.clone()); }
                 } else {
                     warn!(address=?&t.address, "Tried to update non existing token! Consider inserting it first!");
                 }
             }
-            Ok::<(), StorageError>(())
+            Ok::<_, StorageError>(updated)
         }
         .instrument(debug_span!("update_token_rows"))
         .await?;
@@ -1236,11 +1343,6 @@ impl PostgresGateway {
         if let Some(token_cache) = &self.token_cache {
             // Only tokens present in the DB were updated above; the cache mirrors the
             // DB, so restrict the write-through to those as well.
-            let updated: Vec<Token> = tokens
-                .iter()
-                .filter(|t| address_to_db_id.contains_key(&t.address))
-                .cloned()
-                .collect();
             token_cache.upsert_tokens(&updated);
         }
 

--- a/crates/tycho-storage/src/postgres/schema.rs
+++ b/crates/tycho-storage/src/postgres/schema.rs
@@ -345,6 +345,7 @@ diesel::table! {
         inserted_ts -> Timestamptz,
         modified_ts -> Timestamptz,
         quality -> Int4,
+        metadata_pending -> Bool,
     }
 }
 

--- a/crates/tycho-storage/src/postgres/token_cache.rs
+++ b/crates/tycho-storage/src/postgres/token_cache.rs
@@ -56,10 +56,11 @@
 //!    insert/update methods), it applies the same change to the cache. New tokens indexed by the
 //!    extractor are queryable immediately.
 //! 3. **Delta refresh** — a background task polls every minute for token rows whose `modified_ts`
-//!    changed (see [`TokenCache::refresh`]). This picks up writers in *other* processes — in
-//!    practice the `analyze-tokens` cronjob updating quality — which write-through cannot see. This
-//!    is why the `token(modified_ts)` index migration exists: without it every poll would scan the
-//!    whole token table.
+//!    changed (see [`TokenCache::refresh`]). This picks up writers in *other* processes — the
+//!    `analyze-tokens` cronjob updating quality, and the indexer's token-metadata recovery worker
+//!    completing `Pending` rows — which write-through cannot see. This is why the
+//!    `token(modified_ts)` index migration exists: without it every poll would scan the whole token
+//!    table.
 //!
 //! Known limit: the delta refresh covers the token table only, so `last_traded`
 //! converges through write-through alone. A process that serves queries without
@@ -155,6 +156,10 @@ impl ChainTokenStore {
                     return;
                 }
                 let old = &self.tokens[idx as usize];
+                // A refresh may have read Pending just before recovery committed.
+                if old.metadata_status.is_ready() && !token.metadata_status.is_ready() {
+                    return;
+                }
                 if old.quality != token.quality {
                     if let Some(bitmap) = self
                         .quality_index
@@ -465,7 +470,9 @@ impl TokenCache {
     }
 
     /// Inserts tokens that are not yet cached; existing entries are left untouched,
-    /// mirroring the `ON CONFLICT DO NOTHING` insert semantics.
+    /// mirroring the `ON CONFLICT DO NOTHING` insert semantics. Every later block re-inserts
+    /// the tokens it references, so this is also what keeps a stale `Pending` identity from
+    /// overwriting a repaired entry.
     pub(crate) fn add_tokens(&self, tokens: &[Token]) {
         self.write_tokens(tokens, false);
     }
@@ -619,21 +626,28 @@ impl TokenCache {
     }
 }
 
-fn to_model_token(orm_token: &orm::Token, address: &Address, chain: Chain) -> Token {
+pub(super) fn to_model_token(orm_token: &orm::Token, address: &Address, chain: Chain) -> Token {
     let gas_usage: Vec<_> = orm_token
         .gas
         .iter()
         .map(|gas| gas.map(|value| value as u64))
         .collect();
-    Token::new(
-        address,
-        orm_token.symbol.as_str(),
-        orm_token.decimals as u32,
-        orm_token.tax as u64,
-        gas_usage.as_slice(),
-        chain,
-        orm_token.quality as u32,
-    )
+    Token {
+        metadata_status: if orm_token.metadata_pending {
+            tycho_common::models::token::TokenMetadataStatus::Pending
+        } else {
+            Default::default()
+        },
+        ..Token::new(
+            address,
+            orm_token.symbol.as_str(),
+            orm_token.decimals as u32,
+            orm_token.tax as u64,
+            gas_usage.as_slice(),
+            chain,
+            orm_token.quality as u32,
+        )
+    }
 }
 
 #[cfg(test)]
@@ -699,6 +713,33 @@ mod test {
 
         assert_eq!(result.total, Some(3));
         assert_eq!(result_symbols(&result), ["TOK0", "TOK1", "TOK2"]);
+    }
+
+    #[test]
+    fn repaired_metadata_survives_stale_refresh_and_block_insert() {
+        let cache = TokenCache::new_for_tests(&[Chain::Ethereum]);
+        let mut ready = make_token(0, 100);
+        ready.decimals = 6;
+        let pending = Token::pending(&ready.address, ready.chain);
+        cache.add_tokens(std::slice::from_ref(&pending));
+        cache.upsert_tokens(&[ready]);
+        cache.add_tokens(std::slice::from_ref(&pending));
+        cache.upsert_tokens(&[pending]);
+        let result = cache
+            .query_tokens(&base_query())
+            .unwrap();
+        assert!(result.entity[0]
+            .metadata_status
+            .is_ready());
+        assert_eq!(result.entity[0].decimals, 6);
+        assert_eq!(result.entity[0].quality, 100);
+        let high = cache
+            .query_tokens(&TokenQuery {
+                quality_range: QualityRange::min_only(100),
+                ..base_query()
+            })
+            .unwrap();
+        assert_eq!(high.entity.len(), 1);
     }
 
     #[test]

--- a/crates/tycho-storage/src/postgres/token_metadata_tests.rs
+++ b/crates/tycho-storage/src/postgres/token_metadata_tests.rs
@@ -1,0 +1,184 @@
+//! Focused SQL integration test. Uses its own schema inside the `DATABASE_URL` test database;
+//! no production fixtures or optional PostgreSQL extensions are needed.
+
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, SimpleAsyncConnection};
+use tycho_common::{models::token::Token, Bytes};
+
+use super::*;
+
+// Runs in the `serial_db` group like the other PostgreSQL tests, but inside its own schema so
+// it neither depends on nor disturbs the migrated fixtures those tests use.
+#[tokio::test]
+async fn test_metadata_recovery_is_durable_atomic_and_does_not_downgrade_ready_rows_serial_db() {
+    let url = std::env::var("DATABASE_URL").expect("Database URL must be set for testing");
+    let mut conn = AsyncPgConnection::establish(&url)
+        .await
+        .unwrap();
+    let schema_name = format!("metadata_recovery_{}", std::process::id());
+    conn.batch_execute(&format!("CREATE SCHEMA {schema_name}; SET search_path TO {schema_name};
+        CREATE TABLE account (
+            id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL, address BYTEA NOT NULL,
+            chain_id BIGINT NOT NULL, creation_tx BIGINT, created_at TIMESTAMP, deleted_at TIMESTAMP,
+            deletion_tx BIGINT, inserted_ts TIMESTAMP NOT NULL DEFAULT now(),
+            modified_ts TIMESTAMP NOT NULL DEFAULT now(), UNIQUE(address, chain_id));
+        CREATE TABLE token (
+            id BIGSERIAL PRIMARY KEY, account_id BIGINT NOT NULL UNIQUE REFERENCES account(id),
+            symbol TEXT NOT NULL, decimals INTEGER NOT NULL, tax BIGINT NOT NULL,
+            gas BIGINT[] NOT NULL, quality INTEGER NOT NULL,
+            inserted_ts TIMESTAMP NOT NULL DEFAULT now(), modified_ts TIMESTAMP NOT NULL DEFAULT now());
+        INSERT INTO account (title, address, chain_id) VALUES ('legacy', decode('00', 'hex'), 1);
+        INSERT INTO token (account_id, symbol, decimals, tax, gas, quality) VALUES (1, 'LEGACY', 18, 0, '{{}}', 100);
+    ")).await.unwrap();
+    conn.batch_execute(include_str!("../../migrations/2026-09-07_token_metadata_readiness/up.sql"))
+        .await
+        .unwrap();
+    let gateway = PostgresGateway::with_cache(
+        Arc::new(ChainEnumCache::from_tuples(vec![(1, "ethereum".into()), (2, "polygon".into())])),
+        Arc::new(NativeTokenEnumCache::from_tuples(vec![])),
+        Arc::new(ProtocolSystemEnumCache::from_tuples(vec![])),
+        None,
+        chrono::DateTime::UNIX_EPOCH.naive_utc(),
+    );
+    let legacy = gateway
+        .ready_token_metadata(Chain::Ethereum, &[Bytes::from("0x00")], &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(legacy[0].symbol, "LEGACY");
+    let pending: Vec<_> = (1u8..=3)
+        .map(|id| Token::pending(&Bytes::from(vec![id]), Chain::Ethereum))
+        .collect();
+    gateway
+        .add_tokens(&pending, &mut conn)
+        .await
+        .unwrap();
+    assert!(gateway
+        .update_tokens(&pending, &mut conn)
+        .await
+        .is_err());
+    let premature = Token::new(&pending[1].address, "PREMATURE", 18, 0, &[], Chain::Ethereum, 100);
+    gateway
+        .update_tokens(&[premature], &mut conn)
+        .await
+        .unwrap();
+    let stats = gateway
+        .pending_token_metadata_stats(Chain::Ethereum, &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(stats.0, 3);
+    assert!(stats.1.is_some());
+    gateway
+        .add_tokens(&[Token::pending(&pending[0].address, Chain::Polygon)], &mut conn)
+        .await
+        .unwrap();
+    let first_page = gateway
+        .pending_token_metadata(Chain::Ethereum, 0, 1, &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(first_page.len(), 1);
+    assert_eq!(first_page[0].1.address, pending[0].address);
+    let ready =
+        Token::new(&pending[0].address, "REPAIRED", 6, 25, &[Some(30_000)], Chain::Ethereum, 50);
+    let tokens = vec![ready.clone()];
+    let rollback = conn
+        .transaction::<(), diesel::result::Error, _>(|conn| {
+            async {
+                gateway
+                    .complete_token_metadata(&tokens, conn)
+                    .await
+                    .unwrap();
+                Err(diesel::result::Error::RollbackTransaction)
+            }
+            .scope_boxed()
+        })
+        .await;
+    assert!(rollback.is_err());
+    assert!(gateway
+        .ready_token_metadata(Chain::Ethereum, std::slice::from_ref(&ready.address), &mut conn)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        gateway
+            .pending_token_metadata(Chain::Ethereum, 0, 32, &mut conn)
+            .await
+            .unwrap()
+            .len(),
+        3
+    );
+
+    conn.transaction::<_, diesel::result::Error, _>(|conn| {
+        async {
+            Ok(gateway
+                .complete_token_metadata(&tokens, conn)
+                .await
+                .unwrap())
+        }
+        .scope_boxed()
+    })
+    .await
+    .unwrap();
+    // Both stale creation writes and a competing recovery result must preserve the committed row.
+    gateway
+        .add_tokens(&pending, &mut conn)
+        .await
+        .unwrap();
+    let competing = Token::new(&ready.address, "STALE", 18, 0, &[], Chain::Ethereum, 100);
+    assert!(gateway
+        .complete_token_metadata(&[competing], &mut conn)
+        .await
+        .unwrap()
+        .is_empty());
+    let next_page = gateway
+        .pending_token_metadata(Chain::Ethereum, first_page[0].0, 32, &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        next_page
+            .iter()
+            .map(|row| row.1.address.clone())
+            .collect::<Vec<_>>(),
+        vec![pending[1].address.clone(), pending[2].address.clone()]
+    );
+    assert_eq!(
+        gateway
+            .pending_token_metadata(Chain::Polygon, 0, 32, &mut conn)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    drop(conn);
+
+    // A new connection sees the repair and the unfinished queue, without either in-memory cache.
+    let mut conn = AsyncPgConnection::establish(&url)
+        .await
+        .unwrap();
+    conn.batch_execute(&format!("SET search_path TO {schema_name}"))
+        .await
+        .unwrap();
+    let restored = gateway
+        .ready_token_metadata(Chain::Ethereum, &[ready.address], &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        (restored[0].symbol.as_str(), restored[0].decimals, restored[0].tax, restored[0].quality),
+        ("REPAIRED", 6, 25, 50)
+    );
+    assert_eq!(restored[0].gas, vec![Some(30_000)]);
+    assert_eq!(
+        gateway
+            .pending_token_metadata(Chain::Ethereum, 0, 32, &mut conn)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    conn.batch_execute(include_str!(
+        "../../migrations/2026-09-07_token_metadata_readiness/down.sql"
+    ))
+    .await
+    .unwrap();
+    conn.batch_execute(&format!("DROP SCHEMA {schema_name} CASCADE"))
+        .await
+        .unwrap();
+}

--- a/crates/tycho-storage/src/postgres/token_metadata_tests.rs
+++ b/crates/tycho-storage/src/postgres/token_metadata_tests.rs
@@ -15,7 +15,8 @@ async fn test_metadata_recovery_is_durable_atomic_and_does_not_downgrade_ready_r
         .await
         .unwrap();
     let schema_name = format!("metadata_recovery_{}", std::process::id());
-    conn.batch_execute(&format!("CREATE SCHEMA {schema_name}; SET search_path TO {schema_name};
+    conn.batch_execute(&format!("DROP SCHEMA IF EXISTS {schema_name} CASCADE;
+        CREATE SCHEMA {schema_name}; SET search_path TO {schema_name};
         CREATE TABLE account (
             id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL, address BYTEA NOT NULL,
             chain_id BIGINT NOT NULL, creation_tx BIGINT, created_at TIMESTAMP, deleted_at TIMESTAMP,
@@ -105,6 +106,18 @@ async fn test_metadata_recovery_is_durable_atomic_and_does_not_downgrade_ready_r
             .len(),
         3
     );
+    // The id cursor resumes strictly after the last row of the previous page.
+    let next_page = gateway
+        .pending_token_metadata(Chain::Ethereum, first_page[0].0, 32, &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        next_page
+            .iter()
+            .map(|row| row.1.address.clone())
+            .collect::<Vec<_>>(),
+        vec![pending[1].address.clone(), pending[2].address.clone()]
+    );
 
     conn.transaction::<_, diesel::result::Error, _>(|conn| {
         async {
@@ -128,17 +141,6 @@ async fn test_metadata_recovery_is_durable_atomic_and_does_not_downgrade_ready_r
         .await
         .unwrap()
         .is_empty());
-    let next_page = gateway
-        .pending_token_metadata(Chain::Ethereum, first_page[0].0, 32, &mut conn)
-        .await
-        .unwrap();
-    assert_eq!(
-        next_page
-            .iter()
-            .map(|row| row.1.address.clone())
-            .collect::<Vec<_>>(),
-        vec![pending[1].address.clone(), pending[2].address.clone()]
-    );
     assert_eq!(
         gateway
             .pending_token_metadata(Chain::Polygon, 0, 32, &mut conn)

--- a/docs/token-metadata-recovery.md
+++ b/docs/token-metadata-recovery.md
@@ -1,0 +1,113 @@
+# Token metadata deadlines and recovery
+
+Issue #1317: one slow metadata RPC could hold the extractor's block publication open,
+even with concurrent token processing. The deadline now covers the entire enrichment
+collection, including queued tokens, metadata, transfer analysis, and RPC retries.
+
+```text
+Block discovers tokens
+  -> enrich up to four tokens concurrently
+  -> deadline reached: keep completed results, cancel unfinished requests
+  -> persist unresolved identities as Pending through normal finalization
+  -> publish the block; existing pools continue updating
+
+Recovery worker reads finalized Pending rows
+  -> retry metadata and transfer analysis
+  -> commit complete metadata, then refresh caches
+  -> client retries the affected pool's snapshot
+  -> attach ready token metadata and apply intervening deltas
+  -> decoder admits the pool if its quality meets the configured threshold
+```
+
+## Behavior and tradeoffs
+
+- `Pending` is separate from quality. Its numeric fields are placeholders and must not
+  be used for simulation. The decoder enforces readiness even at minimum quality zero.
+- Only an RPC that does not answer produces `Pending`. A `symbol`/`decimals` call that
+  reverts or returns undecodable data is a property of the token: it receives the same
+  address/18-decimals fallbacks as before, and analysis decides the quality. A token with
+  no funded owner gets the usual Bad verdict (quality 10) on both the hot path and in
+  recovery, so a token deferred by a slow RPC ends up in the same state as one fetched
+  on a fast RPC.
+- Completed analysis retains the existing quality rules: good 100, fee token 50,
+  bad 10. Infrastructure failures do not become an optimistic quality-100 verdict.
+- New pools can be unavailable until finality, persistence, worker retries and snapshot
+  acquisition finish. Tokens whose RPC keeps failing remain pending; their backlog is
+  observable. Existing pools keep receiving blocks.
+- One worker runs per indexer process, on the first configured chain, like the existing
+  token pre-processor. It uses pages of 32, four concurrent attempts, a ten-second attempt
+  timeout, and five seconds between pages; with nothing pending it checks once a minute.
+  An ID cursor avoids starving later rows when earlier attempts fail or completed rows
+  leave the queue. Each token that fails waits twice as long before its next attempt,
+  from five seconds up to one hour, so a persistently failing token bounds its RPC cost
+  without ever being given up on. The backoff is in memory and resets on restart; the
+  worker resumes from durable rows.
+- Repair writes only affect pending rows. Old creation inserts cannot overwrite repairs.
+  Cache reconciliation also picks up repairs from another process or a lost commit response.
+- Client retries run in the existing background snapshot path. A parked pool is re-checked
+  after five seconds, then with the wait doubling up to five minutes, so a pool the server
+  never repairs costs a bounded number of requests. Removals, explicit deletions and
+  reverted creations cancel staged work; reorgs cancel old snapshots and refetch surviving
+  pools. Partial blocks retain the existing completed-block snapshot boundary and delta
+  catch-up.
+- Metadata still uses `latest`; hot-path analysis uses the incoming block and recovery
+  analysis uses `latest`. This does not introduce historical token-metadata versioning.
+
+This bounds token enrichment, **not the whole block pipeline**. Database writes, DCI,
+gRPC/WebSocket outages and runtime scheduling can still delay publication. A universal
+“every block under three seconds” guarantee has not been established.
+
+## Rollout
+
+The default `TOKEN_ENRICHMENT_BUDGET_MS=0` preserves legacy enrichment behavior. Deferral
+must be enabled explicitly; setting a deadline before upgrading consumers is unsafe.
+
+1. Apply `2026-09-07_token_metadata_readiness` before starting the updated storage code.
+   Existing rows default to ready; this does not repair previously stored fallback values.
+2. Upgrade Rust clients/simulation and the Python client bundle. Custom consumers must check
+   `metadata_status` and support refreshed `snapshots.tokens` before server deferral is enabled.
+3. Deploy the indexer with the budget disabled, then enable a measured canary budget. For
+   example, `TOKEN_ENRICHMENT_BUDGET_MS=1000` provides a one-second enrichment budget;
+   one second is a provisional setting, not a production sizing result.
+4. Measure unknown-token counts, enrichment latency, pending backlog/age and publication age.
+   Standalone RPC processes refresh their token cache periodically, so they can add delay
+   before clients observe a repair.
+
+Setting the budget back to zero stops creating deadline-related pending rows. The recovery
+worker continues processing existing rows. Keep the readiness-aware binaries and schema until
+the pending queue is drained; dropping the column would discard unresolved recovery state.
+
+## Observability
+
+| Metric | Meaning |
+| --- | --- |
+| `token_enrichment_unknown_tokens` | Unique unknown tokens per enrichment invocation. |
+| `token_enrichment_seconds` | Time spent collecting enrichment results. |
+| `token_metadata_deferred` | Newly fetched tokens returned pending, excluding previously cached pending tokens. |
+| `token_metadata_pending_count` | Finalized pending rows, sampled at the start of each worker sweep. |
+| `token_metadata_pending_age_seconds` | Age of the oldest finalized pending row at that sample. |
+| `token_metadata_recovery_attempts` | Recovery outcomes by `outcome`: `completed` (row repaired by this process), `already_complete` (repaired elsewhere first), `deferred` (RPC did not answer, retried with backoff), `commit_failed` (database write failed, retried). |
+| `extractor_last_published_block_timestamp_seconds` | Block timestamp after extractor message fan-out completes. |
+
+For Robinhood publication age, use
+`time() - extractor_last_published_block_timestamp_seconds{chain="robinhood"}`.
+Combine this with backlog age and process health; a heartbeat alone does not establish freshness.
+These metrics do not install a production alert or dashboard. Endpoint round-trip latency and
+production `new_tokens_count` distributions still need to be measured.
+
+## Reading order
+
+1. `protocol_extractor.rs`: `construct_currency_tokens`, called from `handle_tick_scoped_data`.
+2. `token_pre_processor.rs`: `get_tokens`, then `fetch_token` and `call_metadata`.
+3. `models/token.rs`: readiness contract; storage migration and `complete_token_metadata`.
+4. `token_metadata_recovery.rs`: retries, commit and cache reconciliation.
+5. Client `synchronizer.rs`: `fetch_snapshot`, `WaitingForTokens`, retry and delta catch-up.
+6. Simulation `evm/decoder.rs`: readiness check before token admission and snapshot decoding.
+
+Validation uses deterministic local RPC stalls, focused PostgreSQL transaction tests in an
+isolated schema, cache tests, client lifecycle tests and decoder tests. The SQL fixture tests
+the new migration and recovery queries; it does not reproduce every production extension or
+the complete indexer deployment. Production incident replay and a full deployed end-to-end
+test remain rollout work. The public-RPC benchmark numbers in the pull request measure the
+concurrency and batching change on one endpoint; they do not validate the deadline or the
+production workload.

--- a/docs/token-metadata-recovery.md
+++ b/docs/token-metadata-recovery.md
@@ -22,7 +22,8 @@ Recovery worker reads finalized Pending rows
 ## Behavior and tradeoffs
 
 - `Pending` is separate from quality. Its numeric fields are placeholders and must not
-  be used for simulation. The decoder enforces readiness even at minimum quality zero.
+  be used for simulation. The decoder enforces readiness even at minimum quality zero, and
+  the extractor leaves pending tokens out of component TVL until they are repaired.
 - Only an RPC that does not answer produces `Pending`. A `symbol`/`decimals` call that
   reverts or returns undecodable data is a property of the token: it receives the same
   address/18-decimals fallbacks as before, and analysis decides the quality. A token with


### PR DESCRIPTION
## feat(indexer): bound token metadata fetch and recover deferred tokens

Fixes #1317.

### Problem

`ProtocolExtractor::handle_tick_scoped_data` awaits `construct_currency_tokens` before it caches, buffers, commits and publishes a block. `EthereumTokenPreProcessor::get_tokens` fetched each unknown token sequentially: `symbol`, `decimals`, then a transfer simulation. One slow RPC call held every pool on the chain. On Robinhood a single `symbol()` call was measured at 3.38 s.

### Approach

1. **Make the common case fast.** Fetch up to four tokens concurrently and send `symbol` + `decimals` as one batched `eth_call`.
2. **Bound the worst case.** With `TOKEN_ENRICHMENT_BUDGET_MS > 0`, one deadline covers the whole batch, including queue time, analysis and retry backoff. Tokens that miss it are stored as `Pending` and the block is published. Existing pools keep updating.
3. **Repair in the background.** A per-process worker retries pending tokens after finality, commits, and refreshes both caches.
4. **Keep consumers correct.** The client parks pools whose tokens are pending and refetches a snapshot once they are ready. The decoder treats `Pending` as "not yet", not "failed".

Option A from the issue is steps 1 and 2 without the deadline. This PR is A plus an explicit pending state, because concurrency cannot shorten a single stalled request (see benchmark below), and a timeout with guessed metadata would persist wrong decimals.

### Reading order

1. `crates/tycho-indexer/src/extractor/protocol_extractor.rs` — `construct_currency_tokens`
2. `crates/tycho-ethereum/src/services/token_pre_processor.rs` — `get_tokens`, `fetch_token`, `call_metadata`; `rpc/mod.rs` — `eth_call_pair`
3. `crates/tycho-common/src/models/token.rs` — `TokenMetadataStatus`, `Token::pending`
4. `crates/tycho-storage/migrations/2026-09-07_token_metadata_readiness/`, `postgres/protocol.rs` — `complete_token_metadata`, pending queries
5. `crates/tycho-indexer/src/extractor/token_metadata_recovery.rs` — the worker
6. `crates/tycho-client/src/feed/synchronizer.rs` — `fetch_snapshot`, `WaitingForTokens`, `park_for_tokens`
7. `crates/tycho-simulation/src/evm/decoder.rs` — readiness check before admission
8. `docs/token-metadata-recovery.md` — behaviour, tradeoffs, rollout, metrics

### What changes

**tycho-ethereum**
- `get_tokens`: deduplicates input, enriches 4 tokens concurrently, preserves input order, optional whole-batch deadline. Cancelled requests are dropped, not orphaned.
- `eth_call_pair`: two calls in one JSON-RPC batch; per-item retry with a retry budget shared with the transport retries.
- Strict mode (recovery): only an RPC that does not answer keeps a token pending. A reverting `symbol`/`decimals` gets the same fallbacks as before, and a token without a funded owner gets the usual Bad verdict, so a token deferred by a slow RPC ends in the same state as one fetched on a fast RPC.

**tycho-common / tycho-storage**
- `Token.metadata_status: Ready | Pending`. Serialized only when pending, so existing clients parse unchanged responses.
- `token.metadata_pending BOOLEAN NOT NULL DEFAULT FALSE` plus a partial index. Legacy rows read as ready.
- Repairs only update rows still pending. Block re-inserts (`ON CONFLICT DO NOTHING`), the in-memory `TokenCache`, and the indexer's `ProtocolMemoryCache` all refuse to replace a ready entry with a pending one.
- `update_tokens` rejects pending input and writes through only rows it actually updated.

**tycho-indexer**
- `TOKEN_ENRICHMENT_BUDGET_MS` (default 0 = previous blocking behaviour).
- Recovery worker: pages of 32 by id cursor, 4 concurrent attempts, 10 s attempt timeout, per-token exponential backoff 5 s → 1 h, 60 s idle interval when nothing is pending. One worker per process, on the first configured chain, like the existing token pre-processor.
- Metrics: `token_enrichment_unknown_tokens`, `token_enrichment_seconds`, `token_metadata_deferred`, `token_metadata_pending_count`, `token_metadata_pending_age_seconds`, `token_metadata_recovery_attempts{outcome}`, `extractor_last_published_block_timestamp_seconds`.
- Analysis cron: owner lookup shared with the worker; pending rows skipped; only tokens with a verdict are written back.
- OpenAPI: `TokenMetadataStatus` registered.

**tycho-client / tycho-simulation / tycho-client-py**
- `fetch_snapshot` partitions pools by token readiness. Pending pools are parked (`WaitingForTokens`) and re-checked with backoff 5 s → 5 min; removals, deletions and reverted creations cancel parked work.
- `Snapshot.tokens` carries the tokens the snapshot was built with (omitted when empty).
- Decoder inserts snapshot tokens before decoding and never adds a pending pool to the permanent failure set.
- Python DTOs: `ResponseToken.metadata_status` (default `ready`), `Snapshot.tokens` (default empty).

### Compatibility and rollout

- Wire format is additive. Old Rust and Python clients ignore the new fields.
- Deploy order: apply the migration, upgrade consumers, deploy the indexer with the budget at 0, then enable a measured canary budget. Enabling the budget before consumers are upgraded is unsafe: an old client would admit a pending token's placeholder decimals.
- Setting the budget back to 0 stops deferring; the worker drains what is already pending. Do not drop the column while rows are pending.

### Benchmark (Robinhood public RPC, 2026-09-06)

Harness: `crates/tycho-ethereum/benchmarks/token-metadata/` (ignored test, real read-only calls, output checked against a fixture; a fallback invalidates the sample). Ten rounds, 2 s pause between samples, unoptimized build, laptop. Sequential = original code path; concurrent = this PR without batching; batched = this PR.

Total `get_tokens` duration, median over 10 samples:

| Tokens | Sequential | Concurrent | Samples > 3 s (seq / conc) |
|---:|---:|---:|:---:|
| 1 | 1,199.8 ms | 418.8 ms | 0 / 0 |
| 2 | 2,393.8 ms | 402.0 ms | 2 / 0 |

Batching run, 6 samples per cell:

| Tokens | Sequential | Concurrent | Concurrent + batching |
|---:|---:|---:|---:|
| 1 | 1,193.8 ms | 389.9 ms | 368.3 ms |
| 2 | 2,147.5 ms | 358.4 ms | 361.9 ms |

Individual calls in the sequential samples (n = 30): symbol median 391.7 ms, **max 3,382.6 ms**; decimals median 390.4 ms, max 502.3 ms; transfer analysis median 404.3 ms, max 1,783.2 ms.

What this shows: concurrency removes the linear cost, and batching cuts one HTTP request per token. What it does not show: a latency bound. The 3.38 s symbol call is why the deadline exists. These are selected workloads on a public endpoint, not production `new_tokens_count` or tail latency.

### Testing

- Deterministic stall tests via a socket that accepts and never answers, and a mock RPC with retryable/non-retryable/revert errors: deadline keeps completed tokens and cancels queued work, all-pending above the concurrency limit, deadline cuts through retry backoff, revert falls back, non-answer stays pending.
- Storage: guarded repair, rollback, stale insert, competing repair, cursor paging (`token_metadata_tests.rs`, `serial_db` group); `TokenCache` refresh race.
- Client: metadata deferral, retry without a new TVL event, partial-block catch-up, revert/removal cancellation, backoff.
- Decoder: pending at quality 0 deferred and admitted after recovery.
- Cron: pending rows skipped, failed analyses not written back.
- Python: DTO defaults and pending decode.
- Workspace clippy with `-D warnings` and the pinned-nightly fmt are clean. Unit suite: 2245 passed locally. The migrated-schema DB suite and bench targets were not run locally (need the extended Postgres image / `RPC_URL`); CI is the first full run of those.

### Not in this PR

- Production sizing of the budget. `TOKEN_ENRICHMENT_BUDGET_MS=1000` is a starting point, not a measured value.
- Alerts. `time() - extractor_last_published_block_timestamp_seconds{chain="robinhood"}` is the intended freshness signal.
- Unit tests for the worker loop itself; it takes the concrete gateway and pre-processor. Its backoff bookkeeping is tested.
