### PR TITLE
test: skip untradable swap directions and price the tradable ones

### DIFF
--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -1161,12 +1161,6 @@ impl TestRunner {
                 .ok_or_else(|| miette!("Couldn't find protocol component {id}"))?;
 
             let tokens = component.tokens.clone();
-            let formatted_token_str = format!("{:}/{:}", tokens[0].symbol, tokens[1].symbol);
-            state
-                .spot_price(&tokens[0], &tokens[1])
-                .map(|price| info!("[{}] Spot price {:?}: {:?}", id, formatted_token_str, price))
-                .into_diagnostic()
-                .wrap_err(format!("Error calculating spot price for Pool {id:?}."))?;
 
             // Test get_amount_out with different percentages of limits. The reserves or limits
             // are relevant because we need to know how much to test with. We
@@ -1211,6 +1205,23 @@ impl TestRunner {
                     );
                     continue;
                 }
+
+                // Priced per direction rather than once per component: consumers key their
+                // price data by swap direction, so a venue that quotes only one ordering
+                // leaves them without a price for a direction that does trade. Asked after
+                // the zero-limit skip, so a direction the venue does not trade is not
+                // required to have a price either.
+                let spot_price = state
+                    .spot_price(token_in, token_out)
+                    .into_diagnostic()
+                    .wrap_err(format!(
+                        "Error calculating spot price for Pool {id:?} for in token: {}, and out token: {}",
+                        token_in.address, token_out.address
+                    ))?;
+                info!(
+                    "[{}] Spot price {}/{}: {:?}",
+                    id, token_in.symbol, token_out.symbol, spot_price
+                );
 
                 for percentage in percentages.iter() {
                     // For precision, multiply by 1000 then divide by 1000

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -1183,6 +1183,8 @@ impl TestRunner {
                 .map(|perm| (perm[0], perm[1]))
                 .collect();
 
+            let mut quoted_any_direction = false;
+
             for (token_in, token_out) in &swap_directions {
                 let (max_input, max_output) = state
                     .get_limits(token_in.address.clone(), token_out.address.clone())
@@ -1196,6 +1198,19 @@ impl TestRunner {
                     "[{}] Retrieved limits. | Max input: {max_input} {} | Max output: {max_output} {}",
                     id, token_in.symbol, token_out.symbol
                 );
+
+                // A zero limit means the venue does not quote this direction at all - a
+                // one-directional component such as ETH -> stETH staking, or a redemption
+                // rate limit with no capacity at this block. Skip the direction instead of
+                // failing the component; the guard below still requires that at least one
+                // direction was exercised.
+                if max_input.is_zero() {
+                    warn!(
+                        "[{}] Zero limit for {} -> {}, skipping direction",
+                        id, token_in.symbol, token_out.symbol
+                    );
+                    continue;
+                }
 
                 for percentage in percentages.iter() {
                     // For precision, multiply by 1000 then divide by 1000
@@ -1229,6 +1244,8 @@ impl TestRunner {
                             token_out.symbol,
                             amount_out_result.gas
                         );
+
+                    quoted_any_direction = true;
 
                     if skip_execution.contains(id) {
                         info!("Skipping execution for component {id}");
@@ -1273,6 +1290,12 @@ impl TestRunner {
                         },
                     );
                 }
+            }
+
+            if !quoted_any_direction {
+                return Err(miette!(
+                    "No tradable direction for pool {id}: every swap direction reported a zero limit."
+                ));
             }
         }
 


### PR DESCRIPTION
Two changes to `run_simulation`, which quotes every token permutation of a component.

**A zero limit skips that direction instead of failing the component.** A zero limit is the
correct answer for a one-directional venue (Lido staking has no synchronous unstake) and for a
rate-limited redemption with no capacity at the tested block (EtherFi's `eETH -> ETH` before
the RedemptionManager existed). Such a component previously had to be excluded from simulation
entirely via `skip_simulation`, which also dropped its working directions. A component whose
every direction reports a zero limit still fails.

**The spot price is asked per direction rather than once per component.** It used to be probed
for `tokens[0] -> tokens[1]` only, so a venue quoting one ordering and not the other went
unnoticed. Consumers key price data by swap direction — fynd drops an edge whose price is
missing — so this matters. Asked after the zero-limit skip, so untradable directions are
exempt. Also drops the assumption that a component has exactly two tokens.

The second change immediately caught a real defect in #929, where Lido priced `stETH -> ETH`
(untradable) but not `ETH -> stETH` (tradable).

#929 and #1427 stack on this branch.
