### PR TITLE
feat(integration-test): cover up_v3 on Robinhood Chain

### DIFF
--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -274,6 +274,7 @@ impl ProtocolStreamProcessor {
                     "sushiswap_v3".to_string(),
                     "robinswap_v3".to_string(),
                     "ramses_v3".to_string(),
+                    "up_v3".to_string(),
                 ]
             }
             Chain::Arbitrum => {
@@ -376,6 +377,10 @@ impl ProtocolStreamProcessor {
                     tvl_filter.clone(),
                     None,
                 );
+            }
+            "up_v3" => {
+                stream =
+                    stream.exchange::<AerodromeSlipstreamsState>("up_v3", tvl_filter.clone(), None);
             }
             "erc4626" => {
                 stream = stream.exchange::<ERC4626State>(


### PR DESCRIPTION
`up_v3` is indexed and released (#1426, spkg `robinhood-up-v3-v0.1.5`), but
`ProtocolStreamProcessor` never streams it, so the continuous integration test would not notice a
decode or quote regression on UP pools.

## What

- add `up_v3` to `Chain::Robinhood`'s protocol systems, next to `sushiswap_v3`, `robinswap_v3` and
  `ramses_v3`;
- register it against `AerodromeSlipstreamsState` in `add_protocol_to_stream` — UP deploys the
  Aerodrome Slipstream contracts verbatim, so its pools decode and quote through the same state
  Base's `aerodrome_slipstreams` uses, dynamic swap fee included.

## Sequencing

This takes effect once the `up_v3` extractor is registered in helm-configuration and has caught up
from block 6,184,096. Until then the stream yields no components for it, which is harmless — the
processor simply has nothing to check.

## Test

`cargo test -p tycho-integration-test` (33 passed), clippy with `-D warnings` and nightly fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
