### PR TITLE
fix: set fee calculator receiver at deployment time

### DIFF
--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -100,6 +100,11 @@ Three fee layers, deducted from swap output:
 3. **Router fee on client fee** (stored): `_routerFeeOnClientFeeBps` -- Tycho's cut of the client fee (deducted from the
    client's portion, not from the user).
 
+**Fee receiver**: `FeeCalculator(routerFeeSetter, routerFeeReceiver)` takes the receiver as a constructor argument
+and emits `RouterFeeReceiverUpdated(address(0), routerFeeReceiver)` at deployment; `setRouterFeeReceiver` changes it
+later. It is explicit rather than defaulted to `msg.sender` because deployment goes through the CREATE2 factory
+(`0x4e59b448…`), which can never call `withdraw` on the router — fees credited to it are lost.
+
 **Per-client overrides**: Both router fees can be overridden per client address via `_customRouterFees`
 mapping (`CustomFees` struct, single storage slot). If set, the custom rate replaces the default for that client. Can be
 removed to revert to defaults.

--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -119,7 +119,8 @@ queryable via RPC:
 - `MAX_BPS_SQUARED = 10_000_000_000_000_000` — `MAX_BPS²`; the combined denominator when both fees use the
   sub-BPS scale
 
-**Positive slippage** (`_positiveSlippageEnabled`, toggled via `setPositiveSlippageEnabled`): when enabled, the router
+**Positive slippage** (`_positiveSlippageEnabled`, enabled from the constructor — which emits
+`PositiveSlippageToggled(true)` — and toggled afterwards via `setPositiveSlippageEnabled`): when enabled, the router
 takes the entire surplus (`actualAmountOut - expectedAmountOut`) before fees, and the remaining fees compute on
 `expectedAmountOut`. When disabled, fees compute on `actualAmountOut` and the surplus stays in the swap output. The flag
 also forces `mustOutputThroughRouter` to return true, since slippage direction is unknown before the swap. Per-client

--- a/crates/tycho-execution/contracts/scripts/README.md
+++ b/crates/tycho-execution/contracts/scripts/README.md
@@ -40,8 +40,12 @@ The FeeCalculator must be deployed **before** the TychoRouterV3, as the router r
 
 1. Define the `ROUTER_FEE_SETTER` address for your network in `scripts/roles.json`. The first
    address receives `ROUTER_FEE_SETTER_ROLE` to manage fee configuration.
-2. Deploy: `npx hardhat run scripts/deploy-fee-calculator.js --network NETWORK`
-3. Note the deployed address — you will need it in the next step.
+2. Define `ROUTER_FEE_RECEIVER` for your network in the same file. The first address is passed to
+   the constructor and owns the vault balance every router fee is credited to, so it must be an
+   address that can call `withdraw()` on the router. It is a constructor argument because the
+   deployment goes through the CREATE2 factory, which can never withdraw.
+3. Deploy: `npx hardhat run scripts/deploy-fee-calculator.js --network NETWORK`
+4. Note the deployed address — you will need it in the next step.
 
 ### Deploy executors
 
@@ -63,7 +67,7 @@ The FeeCalculator must be deployed **before** the TychoRouterV3, as the router r
 Via the safe wallet UI:
 
 5. Set the executors addresses
-6. Set fee amounts and router fee receiver in FeeCalculator
+6. Set fee amounts in FeeCalculator
 7. Set the pauser wallets
 ### Revoke roles
 

--- a/crates/tycho-execution/contracts/scripts/deploy-fee-calculator.js
+++ b/crates/tycho-execution/contracts/scripts/deploy-fee-calculator.js
@@ -8,10 +8,17 @@ async function main() {
 
     // The routerFeeSetter is the address that will be granted
     // ROUTER_FEE_SETTER_ROLE to manage fee configuration.
-    const routerFeeSetter = resolveRolesNetwork(network).ROUTER_FEE_SETTER[0];
+    const networkRoles = resolveRolesNetwork(network);
+    const routerFeeSetter = networkRoles.ROUTER_FEE_SETTER[0];
+    // The routerFeeReceiver owns the vault balance every router fee is credited
+    // to. It must be an address that can call withdraw() on the router — the
+    // CREATE2 factory below deploys the contract but cannot withdraw, which is
+    // why the receiver is a constructor argument rather than the deployer.
+    const routerFeeReceiver = networkRoles.ROUTER_FEE_RECEIVER[0];
 
     console.log(`Deploying FeeCalculator to ${network} with:`);
     console.log(`- routerFeeSetter: ${routerFeeSetter}`);
+    console.log(`- routerFeeReceiver: ${routerFeeReceiver}`);
 
     const [deployer] = await ethers.getSigners();
     console.log(`Deploying with account: ${deployer.address}`);
@@ -28,7 +35,7 @@ async function main() {
     const FeeCalculator =
         await ethers.getContractFactory("FeeCalculator");
     const deployTx =
-        FeeCalculator.getDeployTransaction(routerFeeSetter);
+        FeeCalculator.getDeployTransaction(routerFeeSetter, routerFeeReceiver);
     const bytecode = deployTx.data;
 
     const salt = ethers.utils.id(`FeeCalculator-${network}`);
@@ -83,7 +90,7 @@ async function main() {
             network,
             address: computedAddress,
             contractFqn: "src/FeeCalculator.sol:FeeCalculator",
-            constructorArgs: [routerFeeSetter],
+            constructorArgs: [routerFeeSetter, routerFeeReceiver],
         });
         console.log(
             "FeeCalculator verified successfully on blockchain explorer!"

--- a/crates/tycho-execution/contracts/scripts/roles.json
+++ b/crates/tycho-execution/contracts/scripts/roles.json
@@ -8,6 +8,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "base": {
@@ -19,6 +22,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "unichain": {
@@ -30,6 +36,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "arbitrum": {
@@ -41,6 +50,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "bsc": {
@@ -52,6 +64,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "polygon": {
@@ -63,6 +78,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "plasma": {
@@ -74,6 +92,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   },
   "robinhood": {
@@ -85,6 +106,9 @@
     ],
     "ROUTER_FEE_SETTER": [
       "0x109ff346BbfD47fDf7CD0dDCa207e19bA5fd601D"
+    ],
+    "ROUTER_FEE_RECEIVER": [
+      "0xA5503D92EE16a78E602996AD362674Dc49034A14"
     ]
   }
 }

--- a/crates/tycho-execution/contracts/src/FeeCalculator.sol
+++ b/crates/tycho-execution/contracts/src/FeeCalculator.sol
@@ -74,16 +74,20 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
      * @dev The receiver is explicit rather than defaulted to `msg.sender`: when
      *      the calculator is deployed through a CREATE2 factory, the factory is
      *      the sender, and fees credited to it can never be withdrawn.
+     *      Positive slippage capture starts enabled, since that is how every
+     *      deployment is operated; `setPositiveSlippageEnabled` turns it off.
      */
     constructor(address routerFeeSetter, address routerFeeReceiver) {
         if (routerFeeReceiver == address(0)) {
             revert FeeCalculator__AddressZero();
         }
         _routerFeeReceiver = routerFeeReceiver;
+        _positiveSlippageEnabled = true;
         // Make the role its own admin so role holders can manage their own role
         _setRoleAdmin(ROUTER_FEE_SETTER_ROLE, ROUTER_FEE_SETTER_ROLE);
         _grantRole(ROUTER_FEE_SETTER_ROLE, routerFeeSetter);
         emit RouterFeeReceiverUpdated(address(0), routerFeeReceiver);
+        emit PositiveSlippageToggled(true);
     }
 
     /**

--- a/crates/tycho-execution/contracts/src/FeeCalculator.sol
+++ b/crates/tycho-execution/contracts/src/FeeCalculator.sol
@@ -68,11 +68,22 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
     event PositiveSlippageToggled(bool enabled);
     event PositiveSlippageExemptionSet(address indexed client, bool exempt);
 
-    constructor(address routerFeeSetter) {
-        _routerFeeReceiver = msg.sender;
+    /**
+     * @param routerFeeSetter Address granted ROUTER_FEE_SETTER_ROLE
+     * @param routerFeeReceiver Address whose vault balance receives router fees
+     * @dev The receiver is explicit rather than defaulted to `msg.sender`: when
+     *      the calculator is deployed through a CREATE2 factory, the factory is
+     *      the sender, and fees credited to it can never be withdrawn.
+     */
+    constructor(address routerFeeSetter, address routerFeeReceiver) {
+        if (routerFeeReceiver == address(0)) {
+            revert FeeCalculator__AddressZero();
+        }
+        _routerFeeReceiver = routerFeeReceiver;
         // Make the role its own admin so role holders can manage their own role
         _setRoleAdmin(ROUTER_FEE_SETTER_ROLE, ROUTER_FEE_SETTER_ROLE);
         _grantRole(ROUTER_FEE_SETTER_ROLE, routerFeeSetter);
+        emit RouterFeeReceiverUpdated(address(0), routerFeeReceiver);
     }
 
     /**

--- a/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
+++ b/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
@@ -850,7 +850,8 @@ contract FeeCalculatorConfigTest is Constants {
         assertEq(feeCalculator.getRouterFeeOnClientFee(), 0);
         // The fee receiver is whatever the constructor was given
         assertEq(feeCalculator.getRouterFeeReceiver(), _ROUTER_FEE_RECEIVER);
-        assertFalse(feeCalculator.getPositiveSlippageEnabled());
+        // Positive slippage capture starts enabled
+        assertTrue(feeCalculator.getPositiveSlippageEnabled());
     }
 
     function testMaximumFee() public {
@@ -1033,9 +1034,8 @@ contract FeeCalculatorSlippageTest is Constants {
     FeeCalculator feeCalculator;
 
     function setUp() public {
+        // Positive slippage capture is enabled from the constructor
         feeCalculator = new FeeCalculator(FEE_SETTER, ADMIN);
-        vm.prank(FEE_SETTER);
-        feeCalculator.setPositiveSlippageEnabled(true);
     }
 
     function testRouterKeepsAllPositiveSlippage() public view {

--- a/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
+++ b/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
@@ -15,6 +15,9 @@ uint32 constant _10_PCT = 10_000_000; // 10%
 uint32 constant _50_PCT = 50_000_000; // 50%
 uint32 constant _100_PCT = 100_000_000; // 100%
 
+// Router fee receiver passed to the constructor by every test contract here.
+address constant _ROUTER_FEE_RECEIVER = address(0xFEE);
+
 /// @dev Helper to sum all fee amounts from the returned array
 function _sumFees(FeeRecipient[] memory fees) pure returns (uint256 total) {
     for (uint256 i = 0; i < fees.length; i++) {
@@ -26,7 +29,7 @@ contract FeeCalculatorTest is Constants {
     FeeCalculator feeCalculator;
 
     function setUp() public {
-        feeCalculator = new FeeCalculator(FEE_SETTER);
+        feeCalculator = new FeeCalculator(FEE_SETTER, _ROUTER_FEE_RECEIVER);
     }
 
     function testCalculateOnlyRouterFeeOnOutput() public {
@@ -95,7 +98,7 @@ contract FeeCalculatorTest is Constants {
         // amountOut = 1 ether - 0.02 ether = 0.98 ether
         assertEq(amountOut, 0.98 ether);
         // Router fee
-        assertEq(feeRecipients[0].recipient, address(this));
+        assertEq(feeRecipients[0].recipient, _ROUTER_FEE_RECEIVER);
         assertEq(feeRecipients[0].feeAmount, 0.002 ether);
         // Client fee
         assertEq(feeRecipients[1].recipient, BOB);
@@ -218,7 +221,7 @@ contract FeeCalculatorTest is Constants {
 
         assertEq(amountOut, 1 ether);
         // Router fee
-        assertEq(feeRecipients[0].recipient, address(this));
+        assertEq(feeRecipients[0].recipient, _ROUTER_FEE_RECEIVER);
         assertEq(feeRecipients[0].feeAmount, 0);
         // Client fee
         assertEq(feeRecipients[1].recipient, ALICE);
@@ -250,7 +253,7 @@ contract FeeCalculatorTest is Constants {
         // amountOut = 1 ether - 0.015 ether = 0.985 ether
         assertEq(amountOut, 0.985 ether);
         // Router fee
-        assertEq(feeRecipients[0].recipient, address(this));
+        assertEq(feeRecipients[0].recipient, _ROUTER_FEE_RECEIVER);
         assertEq(feeRecipients[0].feeAmount, 0);
         // Client fee
         assertEq(feeRecipients[1].recipient, BOB);
@@ -289,7 +292,7 @@ contract FeeCalculatorTest is Constants {
         //    amountOut = 1 ether - 0.019 ether - 0.006 ether= 0.975 ether
         assertEq(amountOut, 0.975 ether);
         // Router fee
-        assertEq(feeRecipients[0].recipient, address(this));
+        assertEq(feeRecipients[0].recipient, _ROUTER_FEE_RECEIVER);
         assertEq(feeRecipients[0].feeAmount, 0.006 ether);
         // Client fee
         assertEq(feeRecipients[1].recipient, BOB);
@@ -459,7 +462,7 @@ contract FeeCalculatorTest is Constants {
         //    amountOut = 1 - 0.019 - 0.006 = 0.975 ether
         assertEq(amountOut, 0.975 ether);
         // Router fee
-        assertEq(feeRecipients[0].recipient, address(this));
+        assertEq(feeRecipients[0].recipient, _ROUTER_FEE_RECEIVER);
         assertEq(feeRecipients[0].feeAmount, 0.006 ether);
         // Client fee
         assertEq(feeRecipients[1].recipient, ALICE);
@@ -562,7 +565,7 @@ contract FeeCalculatorConfigTest is Constants {
     FeeCalculator feeCalculator;
 
     function setUp() public {
-        feeCalculator = new FeeCalculator(FEE_SETTER);
+        feeCalculator = new FeeCalculator(FEE_SETTER, _ROUTER_FEE_RECEIVER);
     }
 
     // ROUTER FEE ON OUTPUT TESTS
@@ -745,6 +748,19 @@ contract FeeCalculatorConfigTest is Constants {
     }
 
     // FEE RECEIVER TESTS
+    function testConstructorSetsFeeReceiver() public {
+        vm.expectEmit(true, true, false, false);
+        emit FeeCalculator.RouterFeeReceiverUpdated(address(0), BOB);
+        FeeCalculator calculator = new FeeCalculator(FEE_SETTER, BOB);
+
+        assertEq(calculator.getRouterFeeReceiver(), BOB);
+    }
+
+    function testConstructorRejectsZeroFeeReceiver() public {
+        vm.expectRevert(FeeCalculator__AddressZero.selector);
+        new FeeCalculator(FEE_SETTER, address(0));
+    }
+
     function testSetRouterFeeReceiver() public {
         vm.prank(FEE_SETTER);
         feeCalculator.setRouterFeeReceiver(BOB);
@@ -832,8 +848,8 @@ contract FeeCalculatorConfigTest is Constants {
         // Default fees should be zero
         assertEq(feeCalculator.getRouterFeeOnOutput(), 0);
         assertEq(feeCalculator.getRouterFeeOnClientFee(), 0);
-        // Default fee receiver should be the contract deployer
-        assertEq(feeCalculator.getRouterFeeReceiver(), address(this));
+        // The fee receiver is whatever the constructor was given
+        assertEq(feeCalculator.getRouterFeeReceiver(), _ROUTER_FEE_RECEIVER);
         assertFalse(feeCalculator.getPositiveSlippageEnabled());
     }
 
@@ -1017,11 +1033,9 @@ contract FeeCalculatorSlippageTest is Constants {
     FeeCalculator feeCalculator;
 
     function setUp() public {
-        feeCalculator = new FeeCalculator(FEE_SETTER);
-        vm.startPrank(FEE_SETTER);
-        feeCalculator.setRouterFeeReceiver(ADMIN);
+        feeCalculator = new FeeCalculator(FEE_SETTER, ADMIN);
+        vm.prank(FEE_SETTER);
         feeCalculator.setPositiveSlippageEnabled(true);
-        vm.stopPrank();
     }
 
     function testRouterKeepsAllPositiveSlippage() public view {

--- a/crates/tycho-execution/contracts/test/TychoRouter.t.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouter.t.sol
@@ -98,7 +98,7 @@ contract TychoRouterTest is TychoRouterTestSetup {
 
     // FEE CALCULATOR TESTS
     function testSetFeeCalculatorQueuesPending() public {
-        FeeCalculator newCalc = new FeeCalculator(FEE_SETTER);
+        FeeCalculator newCalc = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
         vm.prank(FEE_SETTER);
         tychoRouter.setFeeCalculator(address(newCalc));
 
@@ -114,7 +114,7 @@ contract TychoRouterTest is TychoRouterTestSetup {
     }
 
     function testActivationAfterTimelock() public {
-        FeeCalculator newCalc = new FeeCalculator(FEE_SETTER);
+        FeeCalculator newCalc = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
         vm.prank(FEE_SETTER);
         tychoRouter.setFeeCalculator(address(newCalc));
 
@@ -128,7 +128,7 @@ contract TychoRouterTest is TychoRouterTestSetup {
     }
 
     function testActivationRevertsWhenTimelocked() public {
-        FeeCalculator newCalc = new FeeCalculator(FEE_SETTER);
+        FeeCalculator newCalc = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
         vm.prank(FEE_SETTER);
         tychoRouter.setFeeCalculator(address(newCalc));
 
@@ -161,8 +161,8 @@ contract TychoRouterTest is TychoRouterTestSetup {
     }
 
     function testSetFeeCalculatorOverwritesPending() public {
-        FeeCalculator calc1 = new FeeCalculator(FEE_SETTER);
-        FeeCalculator calc2 = new FeeCalculator(FEE_SETTER);
+        FeeCalculator calc1 = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
+        FeeCalculator calc2 = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
 
         vm.startPrank(FEE_SETTER);
         tychoRouter.setFeeCalculator(address(calc1));
@@ -192,7 +192,8 @@ contract TychoRouterTest is TychoRouterTestSetup {
 
     function testConstructorNonContractPermit2() public {
         // Deploy a new FeeCalculator contract
-        FeeCalculator newFeeCalculator = new FeeCalculator(FEE_SETTER);
+        FeeCalculator newFeeCalculator =
+            new FeeCalculator(FEE_SETTER, routerFeeReceiver);
         address nonContract = address(0x999);
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/crates/tycho-execution/contracts/test/TychoRouterFees.t.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterFees.t.sol
@@ -206,6 +206,48 @@ contract TychoRouterFeesTest is TychoRouterTestSetup {
         assertEq(clientFeeReceiverBalance, expectedFeeAmount);
     }
 
+    /// The constructor default, which the shared setup switches off: the router
+    /// keeps everything the pool produced above the quote.
+    function testSingleSwapCapturesPositiveSlippage() public {
+        vm.prank(FEE_SETTER);
+        feeCalculator.setPositiveSlippageEnabled(true);
+
+        uint256 amountIn = 1 ether;
+        // 1 WETH buys 2018.8 DAI on the USV2 pool, quoted at a round 2000
+        uint256 quotedAmountOut = 2000 ether;
+        uint256 poolAmountOut = 2018817438608734439722;
+
+        deal(WETH_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(WETH_ADDR).approve(tychoRouterAddr, amountIn);
+
+        bytes memory swap = encodeSingleSwap(
+            address(usv2Executor),
+            encodeUniswapV2Swap(DAI_WETH_UNIV2_POOL, WETH_ADDR, DAI_ADDR)
+        );
+        uint256 amountOut = tychoRouter.singleSwap(
+            amountIn,
+            WETH_ADDR,
+            DAI_ADDR,
+            quotedAmountOut,
+            quotedAmountOut,
+            ALICE,
+            noClientFee(),
+            swap
+        );
+        vm.stopPrank();
+
+        // ALICE receives the quote, the surplus is credited to the router
+        assertEq(amountOut, quotedAmountOut);
+        assertEq(IERC20(DAI_ADDR).balanceOf(ALICE), quotedAmountOut);
+        assertEq(
+            tychoRouter.balanceOf(
+                routerFeeReceiver, uint256(uint160(DAI_ADDR))
+            ),
+            poolAmountOut - quotedAmountOut
+        );
+    }
+
     function testSingleSwapWithFeesAndContribution() public {
         // Tests swapping WETH -> DAI on a USV2 pool with fees and client contribution
         // Swap is 1 WETH for      2018.8 DAI (2018817438608734439722, gross output)

--- a/crates/tycho-execution/contracts/test/TychoRouterFees.t.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterFees.t.sol
@@ -68,7 +68,6 @@ contract TychoRouterFeesTest is TychoRouterTestSetup {
     function testSingleSwapWithAllFeeTypes() public {
         // Set up fees: 1% router fee on output, 2% client fee, 10% router fee on client fee
         vm.startPrank(FEE_SETTER);
-        feeCalculator.setRouterFeeReceiver(routerFeeReceiver);
         feeCalculator.setRouterFeeOnOutput(1_000_000); // 1%
         feeCalculator.setRouterFeeOnClientFee(10_000_000); // 10%
         vm.stopPrank();
@@ -216,7 +215,6 @@ contract TychoRouterFeesTest is TychoRouterTestSetup {
         // Remaining = 2018.8 - 40.38 = 1978.42 < 2000 so client contributes ~21.56 DAI (max 22)
 
         vm.startPrank(FEE_SETTER);
-        feeCalculator.setRouterFeeReceiver(routerFeeReceiver);
         feeCalculator.setRouterFeeOnOutput(1_000_000); // 1%
         vm.stopPrank();
 
@@ -714,7 +712,6 @@ contract TychoRouterFeesTest is TychoRouterTestSetup {
         // ALICE (tx.origin) has a custom 1% router fee that overrides the 2% default.
         // No client signature is provided, so tx.origin is used for the fee lookup.
         vm.startPrank(FEE_SETTER);
-        feeCalculator.setRouterFeeReceiver(routerFeeReceiver);
         feeCalculator.setRouterFeeOnOutput(2_000_000); // 2% default
         feeCalculator.setCustomRouterFeeOnOutput(ALICE, 1_000_000); // 1% override for ALICE
         vm.stopPrank();
@@ -770,7 +767,6 @@ contract TychoRouterFeesTest is TychoRouterTestSetup {
         // A signed client fee for clientFeeReceiver is also provided.
         // The signed clientFeeReceiver's fee (default, 0%) should be used, not ALICE's 2%.
         vm.startPrank(FEE_SETTER);
-        feeCalculator.setRouterFeeReceiver(routerFeeReceiver);
         feeCalculator.setCustomRouterFeeOnOutput(ALICE, 2_000_000); // 2% for tx.origin
         vm.stopPrank();
 

--- a/crates/tycho-execution/contracts/test/TychoRouterTestSetup.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterTestSetup.sol
@@ -340,7 +340,7 @@ contract TychoRouterTestSetup is
         routerFeeReceiver = makeAddr("routerFeeReceiver");
         // clientFeeReceiver is the address corresponding to CLIENT_FEE_RECEIVER_PK
         clientFeeReceiver = vm.addr(CLIENT_FEE_RECEIVER_PK);
-        feeCalculator = new FeeCalculator(FEE_SETTER);
+        feeCalculator = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
     }
 
     function pleEncode(bytes[] memory data)

--- a/crates/tycho-execution/contracts/test/TychoRouterTestSetup.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterTestSetup.sol
@@ -341,6 +341,12 @@ contract TychoRouterTestSetup is
         // clientFeeReceiver is the address corresponding to CLIENT_FEE_RECEIVER_PK
         clientFeeReceiver = vm.addr(CLIENT_FEE_RECEIVER_PK);
         feeCalculator = new FeeCalculator(FEE_SETTER, routerFeeReceiver);
+        // The calculator enables positive slippage capture in its constructor.
+        // The swap tests quote a round `expectedAmountOut` below the real pool
+        // output and assert the receiver gets that whole output, so capture is
+        // switched off here and exercised by the tests that opt back in.
+        vm.prank(FEE_SETTER);
+        feeCalculator.setPositiveSlippageEnabled(false);
     }
 
     function pleEncode(bytes[] memory data)

--- a/crates/tycho-execution/contracts/test/protocols/PropAMMFallback.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/PropAMMFallback.t.sol
@@ -315,7 +315,6 @@ contract PropAMMFallbackRouterTest is TychoRouterTestSetup {
     /// With fees active the leg's output lands at the router first, then the fee path pays out.
     function testSingleSwapWithRouterFee() public {
         vm.startPrank(FEE_SETTER);
-        feeCalculator.setRouterFeeReceiver(routerFeeReceiver);
         feeCalculator.setRouterFeeOnOutput(1_000_000); // 1%
         vm.stopPrank();
 

--- a/protocols/testing/scripts/update_runtime_bytecode.sh
+++ b/protocols/testing/scripts/update_runtime_bytecode.sh
@@ -65,9 +65,13 @@ ADMIN="0x0000000000000000000000000000000000000001"
 #   - feeCalculator only needs deployed code (constructor reverts otherwise), so
 #     Permit2 is reused; the real one is set via storage at simulation time.
 #   - the four admins are role grants (storage), so any placeholder works.
+#
+# FeeCalculator(routerFeeSetter, routerFeeReceiver): both land in storage rather
+#   than in an immutable, so placeholders work — but the receiver may not be the
+#   zero address.
 NON_EXECUTOR_FIXTURES=(
     "TychoRouterV3|TychoRouterV3|$PERMIT2 $PERMIT2 $ADMIN $ADMIN $ADMIN $ADMIN"
-    "FeeCalculator|FeeCalculator|$ADMIN"
+    "FeeCalculator|FeeCalculator|$ADMIN $ADMIN"
 )
 
 # Executor fixtures protocol-testing plants, mirroring EXECUTOR_MAPPING in


### PR DESCRIPTION
  `FeeCalculator` takes the router fee receiver as a constructor argument instead of
  defaulting to `msg.sender`, and starts with positive slippage capture enabled.

  ## Why

  Deployment goes through the CREATE2 factory `0x4e59b448…`, so `msg.sender` in the
  constructor was the factory, and it became the router fee receiver until someone called
  `setRouterFeeReceiver`. The factory only performs `create2` and can never call
  `withdraw`, so every fee credited to it in that window is stuck. This happened on
  ethereum, base, arbitrum, bsc, polygon and robinhood; the largest amount is 386.75 USDG
  + 0.003 ETH on robinhood, where the receiver was corrected six days after deployment.

  All eight deployed calculators have positive slippage capture switched on, so a fresh
  deployment now matches that rather than passing the surplus on until it is toggled.