### PR TITLE
feat(indexer): count extractor restarts in extractor_restarts_total

### DIFF
--- a/crates/tycho-indexer/CLAUDE.md
+++ b/crates/tycho-indexer/CLAUDE.md
@@ -14,7 +14,7 @@ testing.rs                  Test utilities
 extractor/
   protocol_extractor.rs     ProtocolExtractor — core message processor (see below)
   runner.rs                 ExtractorRunner: drives the Substreams stream; ExtractorHandle for control
-  supervisor.rs             ExtractorSupervisor: restart lifecycle with exponential backoff; owns the subscription map
+  supervisor.rs             ExtractorSupervisor: restart lifecycle with exponential backoff; owns the subscription map; counts rebuilds in `extractor_restarts_total` (registered at zero)
   factory.rs                ExtractorFactory: builds a fresh extractor + runner per (re)start; extractor config types
   reorg_buffer.rs           ReorgBuffer — finality-aware block queue; chain-reorg purge
   models.rs                 Re-exports the block types (defined in tycho-common's models/blockchain.rs); merge helpers + test fixtures

--- a/crates/tycho-indexer/src/extractor/supervisor.rs
+++ b/crates/tycho-indexer/src/extractor/supervisor.rs
@@ -30,6 +30,18 @@ fn restart_backoff() -> ExponentialBackoff {
         .max_delay(MAX_RESTART_BACKOFF)
 }
 
+/// Registers the counter at zero. A series born at one looks flat to `increase()` on Prometheus,
+/// so the first restart would raise no alert.
+fn restart_counter(id: &ExtractorIdentity) -> metrics::Counter {
+    let restarts = metrics::counter!(
+        "extractor_restarts_total",
+        "extractor" => id.name.clone(),
+        "chain" => id.chain.to_string()
+    );
+    restarts.increment(0);
+    restarts
+}
+
 /// Long-lived per-extractor task that owns the factory and manages restart lifecycle.
 ///
 /// The supervisor:
@@ -37,6 +49,8 @@ fn restart_backoff() -> ExponentialBackoff {
 /// - Runs the runner and waits for it to exit.
 /// - On failure: sends `DeltaCommand::ExtractorRestarted` to all subscribers, applies exponential
 ///   backoff, then rebuilds from scratch. Each subscriber decides how to handle the restart.
+/// - Counts every rebuild in `extractor_restarts_total`, registered at zero when supervision
+///   starts.
 /// - Forwards `ControlMessage::Subscribe` from the `ExtractorHandle` to the subscription map.
 /// - Forwards `ControlMessage::Stop` by signalling the runner's stop channel.
 pub struct ExtractorSupervisor {
@@ -104,6 +118,7 @@ impl ExtractorSupervisor {
     pub async fn run(mut self) -> Result<(), ExtractionError> {
         let mut restart_count: u32 = 0;
         let mut backoff_strategy = restart_backoff();
+        let restarts = restart_counter(&self.id);
 
         loop {
             let (stop_tx, stop_rx) = oneshot::channel();
@@ -294,6 +309,67 @@ impl ExtractorSupervisor {
                 "Restarting extractor after backoff"
             );
             restart_count += 1;
+            restarts.increment(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use metrics_util::{
+        debugging::{DebugValue, DebuggingRecorder, Snapshotter},
+        MetricKind,
+    };
+    use tycho_common::models::Chain;
+
+    use super::*;
+
+    fn restarts_series(snapshotter: &Snapshotter) -> Vec<(BTreeMap<String, String>, u64)> {
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter(|(key, _, _, _)| {
+                key.kind() == MetricKind::Counter && key.key().name() == "extractor_restarts_total"
+            })
+            .map(|(key, _, _, value)| {
+                let labels = key
+                    .key()
+                    .labels()
+                    .map(|l| (l.key().to_string(), l.value().to_string()))
+                    .collect();
+                let DebugValue::Counter(count) = value else {
+                    panic!("extractor_restarts_total must be a counter");
+                };
+                (labels, count)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn restart_counter_exists_at_zero_and_counts_restarts() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let id = ExtractorIdentity::new(Chain::Ethereum, "uniswap_v2");
+        let labels = BTreeMap::from([
+            ("extractor".to_string(), "uniswap_v2".to_string()),
+            ("chain".to_string(), "ethereum".to_string()),
+        ]);
+
+        metrics::with_local_recorder(&recorder, || {
+            let restarts = restart_counter(&id);
+            assert_eq!(
+                restarts_series(&snapshotter),
+                vec![(labels.clone(), 0)],
+                "the series must exist at zero before the first restart"
+            );
+
+            restarts.increment(1);
+            restarts.increment(1);
+        });
+
+        assert_eq!(restarts_series(&snapshotter), vec![(labels, 2)]);
     }
 }


### PR DESCRIPTION
## Problem

An extractor restart is invisible. On 2026-09-10 the retired `robinhood-tycho-indexer` pod stopped
advancing `uniswap_v2`, `uniswap_v3` and `uniswap_v4` for 40 minutes before it went away. No alert
fired. `ExtractorSupervisor` already emits `extractor_stopped`, `extractor_permanently_stopped` and
`extractor_restart_failed`, but no alert rule selects any of them.

## Root cause

`extractor_stopped` counts runner exits, not restarts. A permanent stop increments it too, and its
`reason` label has 16 values, so an alert on it needs a hand-maintained series list. The supervisor
restart is in-process: the pod stays up, so the cluster-wide `KubePodCrashLoopBackOff` and
`KubernetesContainerOomKiller` rules never see it.

## Fix

A dedicated counter `extractor_restarts_total{extractor,chain}`, incremented where the supervisor
rebuilds the extractor. One series per extractor, so an alert needs no label enumeration.

The counter is registered at zero when supervision starts. A series born at one looks flat to
`increase()` on Prometheus, so the first restart would raise no alert. This matches the existing
`extractor_revert_attr_miss` pattern.

Nothing else changed: the runner-exit branches, the `Stop` during backoff and the `max_restarts`
exit keep their current metrics.

## Notes for reviewers

The alert rules that consume this metric live in `helm-configuration` and ship separately, prod and
dev in their own PRs:

- prod: propeller-heads/helm-configuration#1064
- dev: propeller-heads/helm-configuration#1065

Both add an `Extractor Restarted` rule on `increase(extractor_restarts_total[1h]) > 0`. It produces
no data until an image with this commit runs. They also add an `Extractor Stalled` rule, which needs
no new metric and works against today's images.

No end-to-end supervisor test: `ExtractorSupervisor::new` takes an `ExtractorFactory`, which needs a
`CachedGateway`, an `EthereumTokenPreProcessor` and an `EthereumRpcClient`, and makes an RPC call in
`create`. There is no test scaffolding for that. The unit test pins the metric name, the labels, the
zero registration and the increment semantics — the parts the alert depends on.

## Follow-ups

A Grafana panel on `extractor_restarts_total` and on `extractor_stopped` by reason.
