### PR TITLE
feat(integration-test): test ekubo_v3 and up_v3 on Robinhood Chain

### DIFF
--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -275,6 +275,7 @@ impl ProtocolStreamProcessor {
                     "robinswap_v3".to_string(),
                     "ramses_v3".to_string(),
                     "ekubo_v3".to_string(),
+                    "up_v3".to_string(),
                 ]
             }
             Chain::Arbitrum => {
@@ -391,6 +392,12 @@ impl ProtocolStreamProcessor {
                     tvl_filter.clone(),
                     None,
                 );
+            }
+            // UP on Robinhood Chain deploys the Slipstream contracts verbatim, so it decodes
+            // with the same state as Aerodrome.
+            "up_v3" => {
+                stream =
+                    stream.exchange::<AerodromeSlipstreamsState>("up_v3", tvl_filter.clone(), None);
             }
             "ramses_v3" => {
                 stream = stream.exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None);

--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -274,6 +274,7 @@ impl ProtocolStreamProcessor {
                     "sushiswap_v3".to_string(),
                     "robinswap_v3".to_string(),
                     "ramses_v3".to_string(),
+                    "ekubo_v3".to_string(),
                 ]
             }
             Chain::Arbitrum => {


### PR DESCRIPTION
Adds `ekubo_v3` and `up_v3` to the default protocol list for Robinhood Chain in the live integration test, so the binary streams and validates both there.

## ekubo_v3

One line in the protocol list. The supporting pieces were already in place:

- `add_protocol_to_stream` already has a chain-agnostic `ekubo_v3` arm.
- `extension_type` maps the Ve33 extension on `Chain::Robinhood`, and `ekubo_v3_extension_filter` keeps those pools (it only drops SignedExclusiveSwap and unknown extensions).
- The `EkuboV3RobinhoodExecutor` address landed in #1425.

## up_v3

This one also needs a stream arm, since `add_protocol_to_stream` returns `Unknown protocol` for anything it does not match, which would fail the Robinhood run at startup.

UP deploys the Slipstream contracts verbatim, so the arm uses `AerodromeSlipstreamsState` with no filter. That matches how `up_v3` is already wired elsewhere: `protocols/testing/src/state_registry.rs`, the `price_printer` and `quickstart` examples, and the `SlipstreamsSwapEncoder` arm in the swap encoder registry. Its executor address and gas estimate entry are already on main.

## Testing

`cargo nextest run -p tycho-integration-test`: 33 passed. `cargo clippy -p tycho-integration-test --all-targets` is clean apart from a pre-existing `proc-macro-error2` future-incompat warning.

The live run itself is not covered here. It needs a Tycho instance indexing both protocols on Robinhood plus a Robinhood RPC endpoint, so they have to be indexed on the target deployment before this takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)