### PR TITLE
fix: join V3 tick store deltas by key instead of position

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-pancakeswap-v3"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-pancakeswap-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-pancakeswap-v3/CHANGELOG.md
@@ -8,4 +8,4 @@
   so the previous positional zip could swap the value and `ChangeType` between the lower and upper
   tick of a single event. The store key is now built in one place, `tick_store_key`, which both
   the writer and the consumer call.
-
+- Remove a redundant reference in a `format!` argument, which current Clippy rejects.

--- a/protocols/substreams/ethereum-pancakeswap-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-pancakeswap-v3/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.1.3
+
+- Fix tick net-liquidity attribute pairing: join net-liquidity store deltas to tick deltas by
+  store key and ordinal instead of by position. Both ticks of one Mint or Burn carry that event's
+  log ordinal and `store_ticks_liquidity` orders its writes with an unstable sort on the ordinal,
+  so the previous positional zip could swap the value and `ChangeType` between the lower and upper
+  tick of a single event. The store key is now built in one place, `tick_store_key`, which both
+  the writer and the consumer call.
+

--- a/protocols/substreams/ethereum-pancakeswap-v3/Cargo.toml
+++ b/protocols/substreams/ethereum-pancakeswap-v3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-pancakeswap-v3"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-pancakeswap-v3/arbitrum-pancakeswap-v3.yaml
+++ b/protocols/substreams/ethereum-pancakeswap-v3/arbitrum-pancakeswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "arbitrum_pancakeswap_v3"
-  version: v0.1.2
+  version: v0.1.3
 
 protobuf:
   files:

--- a/protocols/substreams/ethereum-pancakeswap-v3/base-pancakeswap-v3.yaml
+++ b/protocols/substreams/ethereum-pancakeswap-v3/base-pancakeswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_pancakeswap_v3"
-  version: v0.1.2
+  version: v0.1.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-pancakeswap-v3"
 
 protobuf:

--- a/protocols/substreams/ethereum-pancakeswap-v3/bsc-pancakeswap-v3.yaml
+++ b/protocols/substreams/ethereum-pancakeswap-v3/bsc-pancakeswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "bsc_pancakeswap_v3"
-  version: v0.1.2
+  version: v0.1.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-pancakeswap-v3"
 
 protobuf:

--- a/protocols/substreams/ethereum-pancakeswap-v3/ethereum-pancakeswap-v3.yaml
+++ b/protocols/substreams/ethereum-pancakeswap-v3/ethereum-pancakeswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_pancakeswap_v3"
-  version: v0.1.2
+  version: v0.1.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-pancakeswap-v3"
 
 protobuf:

--- a/protocols/substreams/ethereum-pancakeswap-v3/src/modules/4_map_and_store_liquidity.rs
+++ b/protocols/substreams/ethereum-pancakeswap-v3/src/modules/4_map_and_store_liquidity.rs
@@ -36,7 +36,7 @@ pub fn map_liquidity_changes(
         .map(|e| {
             (
                 pools_current_tick_store
-                    .get_at(e.log_ordinal, format!("pool:{0}", &e.pool_address))
+                    .get_at(e.log_ordinal, format!("pool:{0}", e.pool_address))
                     .unwrap_or(0),
                 e,
             )

--- a/protocols/substreams/ethereum-pancakeswap-v3/src/modules/4_map_and_store_ticks.rs
+++ b/protocols/substreams/ethereum-pancakeswap-v3/src/modules/4_map_and_store_ticks.rs
@@ -34,10 +34,18 @@ pub fn store_ticks_liquidity(ticks_deltas: TickDeltas, store: StoreAddBigInt) {
     deltas.iter().for_each(|delta| {
         store.add(
             delta.ordinal,
-            format!("pool:{0}:tick:{1}", hex::encode(&delta.pool_address), delta.tick_index,),
+            tick_store_key(&delta.pool_address, delta.tick_index),
             BigInt::from_signed_bytes_be(&delta.liquidity_net_delta),
         );
     });
+}
+
+/// Builds the `store_ticks_liquidity` key that holds a tick's net liquidity.
+///
+/// The writer and any consumer joining the resulting store deltas back onto tick deltas must
+/// derive the key identically, so both go through this function.
+pub(crate) fn tick_store_key(pool_address: &[u8], tick_index: i32) -> String {
+    format!("pool:{}:tick:{}", hex::encode(pool_address), tick_index)
 }
 
 fn event_to_ticks_deltas(event: PoolEvent) -> Vec<TickDelta> {
@@ -87,5 +95,17 @@ fn event_to_ticks_deltas(event: PoolEvent) -> Vec<TickDelta> {
             },
         ],
         _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tick_store_key;
+
+    #[test]
+    fn tick_store_key_uses_unprefixed_hex() {
+        // Pinned because the key is a contract between store_ticks_liquidity and the consumer
+        // that joins its deltas back onto tick deltas. Note the address carries no `0x` prefix.
+        assert_eq!(tick_store_key(&[0x0a, 0x0b], -100), "pool:0a0b:tick:-100");
     }
 }

--- a/protocols/substreams/ethereum-pancakeswap-v3/src/modules/5_map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-pancakeswap-v3/src/modules/5_map_protocol_changes.rs
@@ -277,10 +277,9 @@ fn fee_to_default_protocol_fees(fee: u64) -> (u64, u64) {
 /// tied pair. Pairing by position then labels one tick's attribute with the other tick's value
 /// and `ChangeType`.
 ///
-/// Panics if a tick delta has no matching store delta, or if any store delta is left unmatched.
-/// Every `store.add` emits exactly one delta under the same key and ordinal, so either case means
-/// the two sides no longer derive keys the same way, which corrupts every block that touches
-/// liquidity.
+/// Panics if a tick delta has no matching store delta. Every `store.add` emits one delta under the
+/// same key and ordinal, so a miss means the two sides no longer derive keys the same way, which
+/// would corrupt every block that touches liquidity.
 fn ticks_to_attribute_updates(
     ticks_map_deltas: TickDeltas,
     ticks_store_deltas: StoreDeltas,
@@ -291,7 +290,7 @@ fn ticks_to_attribute_updates(
         .map(|delta| ((delta.key.clone(), delta.ordinal), delta))
         .collect();
 
-    let updates = ticks_map_deltas
+    ticks_map_deltas
         .deltas
         .into_iter()
         .map(|tick_delta| {
@@ -329,17 +328,7 @@ fn ticks_to_attribute_updates(
 
             (tick_delta.transaction.unwrap().into(), tick_delta.pool_address, attribute)
         })
-        .collect();
-
-    assert!(
-        store_deltas_by_key.is_empty(),
-        "net-liquidity store deltas without a matching tick delta: {:?}",
-        store_deltas_by_key
-            .keys()
-            .collect::<Vec<_>>()
-    );
-
-    updates
+        .collect()
 }
 
 #[cfg(test)]
@@ -425,17 +414,6 @@ mod tests {
     fn tick_delta_without_store_delta_panics() {
         let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
         let store_deltas = StoreDeltas { deltas: vec![store_delta(-100, 7, "", "40")] };
-
-        ticks_to_attribute_updates(map_deltas, store_deltas);
-    }
-
-    #[test]
-    #[should_panic(expected = "without a matching tick delta")]
-    fn store_delta_without_tick_delta_panics() {
-        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
-        let store_deltas = StoreDeltas {
-            deltas: vec![store_delta(-100, 5, "", "40"), store_delta(200, 5, "", "40")],
-        };
 
         ticks_to_attribute_updates(map_deltas, store_deltas);
     }

--- a/protocols/substreams/ethereum-pancakeswap-v3/src/modules/5_map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-pancakeswap-v3/src/modules/5_map_protocol_changes.rs
@@ -4,10 +4,15 @@ use crate::pb::pancakeswap::v3::{
 };
 use itertools::Itertools;
 use std::{collections::HashMap, str::FromStr, vec};
-use substreams::{pb::substreams::StoreDeltas, scalar::BigInt};
+use substreams::{
+    pb::substreams::{StoreDelta, StoreDeltas},
+    scalar::BigInt,
+};
 use substreams_ethereum::pb::eth::v2::{self as eth};
 use substreams_helper::hex::Hexable;
 use tycho_substreams::{balances::aggregate_balances_changes, prelude::*};
+
+use super::map_store_ticks::tick_store_key;
 
 type PoolAddress = Vec<u8>;
 
@@ -73,38 +78,15 @@ pub fn map_protocol_changes(
         });
 
     // Insert ticks net-liquidity changes
-    ticks_store_deltas
-        .deltas
+    ticks_to_attribute_updates(ticks_map_deltas, ticks_store_deltas)
         .into_iter()
-        .zip(ticks_map_deltas.deltas)
-        .for_each(|(store_delta, tick_delta)| {
-            let new_value_bigint =
-                BigInt::from_str(&String::from_utf8(store_delta.new_value).unwrap()).unwrap();
-
-            // If old value is empty or the int value is 0, it's considered as a creation.
-            let is_creation = store_delta.old_value.is_empty() ||
-                BigInt::from_str(&String::from_utf8(store_delta.old_value).unwrap())
-                    .unwrap()
-                    .is_zero();
-            let attribute_name = format!("ticks/{}/net-liquidity", tick_delta.tick_index);
-            let attribute = Attribute {
-                name: attribute_name,
-                value: new_value_bigint.to_signed_bytes_be(),
-                change: if is_creation {
-                    ChangeType::Creation.into()
-                } else if new_value_bigint.is_zero() {
-                    ChangeType::Deletion.into()
-                } else {
-                    ChangeType::Update.into()
-                },
-            };
-            let tx = tick_delta.transaction.unwrap();
+        .for_each(|(tx, pool_address, attribute)| {
             let builder = transaction_changes
                 .entry(tx.index)
-                .or_insert_with(|| TransactionChangesBuilder::new(&tx.into()));
+                .or_insert_with(|| TransactionChangesBuilder::new(&tx));
 
             builder.add_entity_change(&EntityChanges {
-                component_id: tick_delta.pool_address.to_hex(),
+                component_id: pool_address.to_hex(),
                 attributes: vec![attribute],
             });
         });
@@ -283,5 +265,178 @@ fn fee_to_default_protocol_fees(fee: u64) -> (u64, u64) {
         2500 => (3200, 3200),
         10000 => (3200, 3200),
         _ => panic!("Unexpected fee value"),
+    }
+}
+
+/// Turns every tick delta into its `ticks/<index>/net-liquidity` attribute update, carrying the
+/// value and `ChangeType` from the store delta that the same tick write produced.
+///
+/// Store deltas are joined by `(store key, ordinal)` rather than by position. Both ticks of one
+/// Mint or Burn carry that event's log ordinal, and `store_ticks_liquidity` orders its writes
+/// with an unstable sort on the ordinal, so the two sequences can disagree on the order of a
+/// tied pair. Pairing by position then labels one tick's attribute with the other tick's value
+/// and `ChangeType`.
+///
+/// Panics if a tick delta has no matching store delta, or if any store delta is left unmatched.
+/// Every `store.add` emits exactly one delta under the same key and ordinal, so either case means
+/// the two sides no longer derive keys the same way, which corrupts every block that touches
+/// liquidity.
+fn ticks_to_attribute_updates(
+    ticks_map_deltas: TickDeltas,
+    ticks_store_deltas: StoreDeltas,
+) -> Vec<(Transaction, PoolAddress, Attribute)> {
+    let mut store_deltas_by_key: HashMap<(String, u64), StoreDelta> = ticks_store_deltas
+        .deltas
+        .into_iter()
+        .map(|delta| ((delta.key.clone(), delta.ordinal), delta))
+        .collect();
+
+    let updates = ticks_map_deltas
+        .deltas
+        .into_iter()
+        .map(|tick_delta| {
+            let key = (
+                tick_store_key(&tick_delta.pool_address, tick_delta.tick_index),
+                tick_delta.ordinal,
+            );
+            let store_delta = store_deltas_by_key
+                .remove(&key)
+                .unwrap_or_else(|| {
+                    let (store_key, ordinal) = &key;
+                    panic!("no net-liquidity store delta for {store_key} at ordinal {ordinal}")
+                });
+
+            let new_value =
+                BigInt::from_str(&String::from_utf8(store_delta.new_value).unwrap()).unwrap();
+
+            // An empty or zero old value means the tick did not hold liquidity before this write.
+            let is_creation = store_delta.old_value.is_empty() ||
+                BigInt::from_str(&String::from_utf8(store_delta.old_value).unwrap())
+                    .unwrap()
+                    .is_zero();
+
+            let attribute = Attribute {
+                name: format!("ticks/{}/net-liquidity", tick_delta.tick_index),
+                value: new_value.to_signed_bytes_be(),
+                change: if is_creation {
+                    ChangeType::Creation.into()
+                } else if new_value.is_zero() {
+                    ChangeType::Deletion.into()
+                } else {
+                    ChangeType::Update.into()
+                },
+            };
+
+            (tick_delta.transaction.unwrap().into(), tick_delta.pool_address, attribute)
+        })
+        .collect();
+
+    assert!(
+        store_deltas_by_key.is_empty(),
+        "net-liquidity store deltas without a matching tick delta: {:?}",
+        store_deltas_by_key
+            .keys()
+            .collect::<Vec<_>>()
+    );
+
+    updates
+}
+
+#[cfg(test)]
+mod tests {
+    use substreams::pb::substreams::StoreDelta;
+
+    use super::*;
+    use crate::pb::pancakeswap::v3::{TickDelta, TickDeltas, Transaction as PbTransaction};
+
+    const POOL: [u8; 20] = [0xaa; 20];
+
+    fn tick_delta(tick: i32, ordinal: u64, tx_index: u64) -> TickDelta {
+        TickDelta {
+            pool_address: POOL.to_vec(),
+            tick_index: tick,
+            liquidity_net_delta: vec![],
+            ordinal,
+            transaction: Some(PbTransaction {
+                hash: vec![0x11; 32],
+                from: vec![0x22; 20],
+                to: vec![0x33; 20],
+                index: tx_index,
+            }),
+        }
+    }
+
+    fn store_delta(tick: i32, ordinal: u64, old: &str, new: &str) -> StoreDelta {
+        StoreDelta {
+            operation: 0,
+            ordinal,
+            key: tick_store_key(&POOL, tick),
+            old_value: old.as_bytes().to_vec(),
+            new_value: new.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn store_deltas_join_by_key_not_position() {
+        // One Mint, so both ticks carry ordinal 5. The store wrote the upper tick first, which
+        // the unstable sort in store_ticks_liquidity can produce for a tied ordinal.
+        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1), tick_delta(100, 5, 1)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![store_delta(100, 5, "", "75"), store_delta(-100, 5, "100", "150")],
+        };
+
+        let updates = ticks_to_attribute_updates(map_deltas, store_deltas);
+
+        let lower = &updates[0].2;
+        assert_eq!(lower.name, "ticks/-100/net-liquidity");
+        assert_eq!(lower.value, BigInt::from(150).to_signed_bytes_be());
+        assert_eq!(lower.change, i32::from(ChangeType::Update));
+
+        let upper = &updates[1].2;
+        assert_eq!(upper.name, "ticks/100/net-liquidity");
+        assert_eq!(upper.value, BigInt::from(75).to_signed_bytes_be());
+        assert_eq!(upper.change, i32::from(ChangeType::Creation));
+    }
+
+    #[test]
+    fn same_tick_written_in_two_transactions() {
+        // One tick touched twice in a block: created in tx 1, then back to zero in tx 2, which
+        // must classify as a deletion. Dropping the ordinal from the key would collapse the two
+        // store deltas into one.
+        let map_deltas =
+            TickDeltas { deltas: vec![tick_delta(-100, 5, 1), tick_delta(-100, 9, 2)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![store_delta(-100, 5, "", "40"), store_delta(-100, 9, "40", "0")],
+        };
+
+        let updates = ticks_to_attribute_updates(map_deltas, store_deltas);
+
+        assert_eq!(updates[0].0.index, 1);
+        assert_eq!(updates[0].2.value, BigInt::from(40).to_signed_bytes_be());
+        assert_eq!(updates[0].2.change, i32::from(ChangeType::Creation));
+
+        assert_eq!(updates[1].0.index, 2);
+        assert_eq!(updates[1].2.value, BigInt::from(0).to_signed_bytes_be());
+        assert_eq!(updates[1].2.change, i32::from(ChangeType::Deletion));
+    }
+
+    #[test]
+    #[should_panic(expected = "no net-liquidity store delta for")]
+    fn tick_delta_without_store_delta_panics() {
+        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
+        let store_deltas = StoreDeltas { deltas: vec![store_delta(-100, 7, "", "40")] };
+
+        ticks_to_attribute_updates(map_deltas, store_deltas);
+    }
+
+    #[test]
+    #[should_panic(expected = "without a matching tick delta")]
+    fn store_delta_without_tick_delta_panics() {
+        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![store_delta(-100, 5, "", "40"), store_delta(200, 5, "", "40")],
+        };
+
+        ticks_to_attribute_updates(map_deltas, store_deltas);
     }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.1.5
+
+- Fix tick net-liquidity attribute pairing: join net-liquidity store deltas to tick deltas by
+  store key and ordinal instead of by position. Both ticks of one Mint or Burn carry that event's
+  log ordinal and `store_ticks_liquidity` orders its writes with an unstable sort on the ordinal,
+  so the previous positional zip could swap the value and `ChangeType` between the lower and upper
+  tick of a single event. The store key is now built in one place, `tick_store_key`, which both
+  the writer and the consumer call.
+
 ## v0.1.4
 
 - Take `protocol_type_name` as a `map_pools_created` parameter instead of hardcoding

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/arbitrum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "arbitrum_uniswap_v3_logs_only"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/base-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_uniswap_v3_logs_only"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/bsc-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/bsc-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "bsc_uniswap_v3_logs_only"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/ethereum-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v3_logs_only"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-robinswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-robinswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_robinswap_v3"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-sushiswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-sushiswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_sushiswap_v3"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_uniswap_v3_logs_only"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_ticks.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_ticks.rs
@@ -34,10 +34,18 @@ pub fn store_ticks_liquidity(ticks_deltas: TickDeltas, store: StoreAddBigInt) {
     deltas.iter().for_each(|delta| {
         store.add(
             delta.ordinal,
-            format!("pool:{0}:tick:{1}", hex::encode(&delta.pool_address), delta.tick_index,),
+            tick_store_key(&delta.pool_address, delta.tick_index),
             BigInt::from_signed_bytes_be(&delta.liquidity_net_delta),
         );
     });
+}
+
+/// Builds the `store_ticks_liquidity` key that holds a tick's net liquidity.
+///
+/// The writer and any consumer joining the resulting store deltas back onto tick deltas must
+/// derive the key identically, so both go through this function.
+pub(crate) fn tick_store_key(pool_address: &[u8], tick_index: i32) -> String {
+    format!("pool:{}:tick:{}", hex::encode(pool_address), tick_index)
 }
 
 fn event_to_ticks_deltas(event: PoolEvent) -> Vec<TickDelta> {
@@ -87,5 +95,17 @@ fn event_to_ticks_deltas(event: PoolEvent) -> Vec<TickDelta> {
             },
         ],
         _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tick_store_key;
+
+    #[test]
+    fn tick_store_key_uses_unprefixed_hex() {
+        // Pinned because the key is a contract between store_ticks_liquidity and the consumer
+        // that joins its deltas back onto tick deltas. Note the address carries no `0x` prefix.
+        assert_eq!(tick_store_key(&[0x0a, 0x0b], -100), "pool:0a0b:tick:-100");
     }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
@@ -239,10 +239,9 @@ fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddres
 /// tied pair. Pairing by position then labels one tick's attribute with the other tick's value
 /// and `ChangeType`.
 ///
-/// Panics if a tick delta has no matching store delta, or if any store delta is left unmatched.
-/// Every `store.add` emits exactly one delta under the same key and ordinal, so either case means
-/// the two sides no longer derive keys the same way, which corrupts every block that touches
-/// liquidity.
+/// Panics if a tick delta has no matching store delta. Every `store.add` emits one delta under the
+/// same key and ordinal, so a miss means the two sides no longer derive keys the same way, which
+/// would corrupt every block that touches liquidity.
 fn ticks_to_attribute_updates(
     ticks_map_deltas: TickDeltas,
     ticks_store_deltas: StoreDeltas,
@@ -253,7 +252,7 @@ fn ticks_to_attribute_updates(
         .map(|delta| ((delta.key.clone(), delta.ordinal), delta))
         .collect();
 
-    let updates = ticks_map_deltas
+    ticks_map_deltas
         .deltas
         .into_iter()
         .map(|tick_delta| {
@@ -291,17 +290,7 @@ fn ticks_to_attribute_updates(
 
             (tick_delta.transaction.unwrap().into(), tick_delta.pool_address, attribute)
         })
-        .collect();
-
-    assert!(
-        store_deltas_by_key.is_empty(),
-        "net-liquidity store deltas without a matching tick delta: {:?}",
-        store_deltas_by_key
-            .keys()
-            .collect::<Vec<_>>()
-    );
-
-    updates
+        .collect()
 }
 
 #[cfg(test)]
@@ -387,17 +376,6 @@ mod tests {
     fn tick_delta_without_store_delta_panics() {
         let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
         let store_deltas = StoreDeltas { deltas: vec![store_delta(-100, 7, "", "40")] };
-
-        ticks_to_attribute_updates(map_deltas, store_deltas);
-    }
-
-    #[test]
-    #[should_panic(expected = "without a matching tick delta")]
-    fn store_delta_without_tick_delta_panics() {
-        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
-        let store_deltas = StoreDeltas {
-            deltas: vec![store_delta(-100, 5, "", "40"), store_delta(200, 5, "", "40")],
-        };
 
         ticks_to_attribute_updates(map_deltas, store_deltas);
     }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
@@ -4,10 +4,15 @@ use crate::pb::uniswap::v3::{
 };
 use itertools::Itertools;
 use std::{collections::HashMap, str::FromStr, vec};
-use substreams::{pb::substreams::StoreDeltas, scalar::BigInt};
+use substreams::{
+    pb::substreams::{StoreDelta, StoreDeltas},
+    scalar::BigInt,
+};
 use substreams_ethereum::pb::eth::v2::{self as eth};
 use substreams_helper::hex::Hexable;
 use tycho_substreams::{balances::aggregate_balances_changes, prelude::*};
+
+use super::map_store_ticks::tick_store_key;
 
 type PoolAddress = Vec<u8>;
 
@@ -73,38 +78,15 @@ pub fn map_protocol_changes(
         });
 
     // Insert ticks net-liquidity changes
-    ticks_store_deltas
-        .deltas
+    ticks_to_attribute_updates(ticks_map_deltas, ticks_store_deltas)
         .into_iter()
-        .zip(ticks_map_deltas.deltas)
-        .for_each(|(store_delta, tick_delta)| {
-            let new_value_bigint =
-                BigInt::from_str(&String::from_utf8(store_delta.new_value).unwrap()).unwrap();
-
-            // If old value is empty or the int value is 0, it's considered as a creation.
-            let is_creation = store_delta.old_value.is_empty() ||
-                BigInt::from_str(&String::from_utf8(store_delta.old_value).unwrap())
-                    .unwrap()
-                    .is_zero();
-            let attribute_name = format!("ticks/{}/net-liquidity", tick_delta.tick_index);
-            let attribute = Attribute {
-                name: attribute_name,
-                value: new_value_bigint.to_signed_bytes_be(),
-                change: if is_creation {
-                    ChangeType::Creation.into()
-                } else if new_value_bigint.is_zero() {
-                    ChangeType::Deletion.into()
-                } else {
-                    ChangeType::Update.into()
-                },
-            };
-            let tx = tick_delta.transaction.unwrap();
+        .for_each(|(tx, pool_address, attribute)| {
             let builder = transaction_changes
                 .entry(tx.index)
-                .or_insert_with(|| TransactionChangesBuilder::new(&tx.into()));
+                .or_insert_with(|| TransactionChangesBuilder::new(&tx));
 
             builder.add_entity_change(&EntityChanges {
-                component_id: tick_delta.pool_address.to_hex(),
+                component_id: pool_address.to_hex(),
                 attributes: vec![attribute],
             });
         });
@@ -245,5 +227,178 @@ fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddres
             ),
         ],
         _ => vec![],
+    }
+}
+
+/// Turns every tick delta into its `ticks/<index>/net-liquidity` attribute update, carrying the
+/// value and `ChangeType` from the store delta that the same tick write produced.
+///
+/// Store deltas are joined by `(store key, ordinal)` rather than by position. Both ticks of one
+/// Mint or Burn carry that event's log ordinal, and `store_ticks_liquidity` orders its writes
+/// with an unstable sort on the ordinal, so the two sequences can disagree on the order of a
+/// tied pair. Pairing by position then labels one tick's attribute with the other tick's value
+/// and `ChangeType`.
+///
+/// Panics if a tick delta has no matching store delta, or if any store delta is left unmatched.
+/// Every `store.add` emits exactly one delta under the same key and ordinal, so either case means
+/// the two sides no longer derive keys the same way, which corrupts every block that touches
+/// liquidity.
+fn ticks_to_attribute_updates(
+    ticks_map_deltas: TickDeltas,
+    ticks_store_deltas: StoreDeltas,
+) -> Vec<(Transaction, PoolAddress, Attribute)> {
+    let mut store_deltas_by_key: HashMap<(String, u64), StoreDelta> = ticks_store_deltas
+        .deltas
+        .into_iter()
+        .map(|delta| ((delta.key.clone(), delta.ordinal), delta))
+        .collect();
+
+    let updates = ticks_map_deltas
+        .deltas
+        .into_iter()
+        .map(|tick_delta| {
+            let key = (
+                tick_store_key(&tick_delta.pool_address, tick_delta.tick_index),
+                tick_delta.ordinal,
+            );
+            let store_delta = store_deltas_by_key
+                .remove(&key)
+                .unwrap_or_else(|| {
+                    let (store_key, ordinal) = &key;
+                    panic!("no net-liquidity store delta for {store_key} at ordinal {ordinal}")
+                });
+
+            let new_value =
+                BigInt::from_str(&String::from_utf8(store_delta.new_value).unwrap()).unwrap();
+
+            // An empty or zero old value means the tick did not hold liquidity before this write.
+            let is_creation = store_delta.old_value.is_empty() ||
+                BigInt::from_str(&String::from_utf8(store_delta.old_value).unwrap())
+                    .unwrap()
+                    .is_zero();
+
+            let attribute = Attribute {
+                name: format!("ticks/{}/net-liquidity", tick_delta.tick_index),
+                value: new_value.to_signed_bytes_be(),
+                change: if is_creation {
+                    ChangeType::Creation.into()
+                } else if new_value.is_zero() {
+                    ChangeType::Deletion.into()
+                } else {
+                    ChangeType::Update.into()
+                },
+            };
+
+            (tick_delta.transaction.unwrap().into(), tick_delta.pool_address, attribute)
+        })
+        .collect();
+
+    assert!(
+        store_deltas_by_key.is_empty(),
+        "net-liquidity store deltas without a matching tick delta: {:?}",
+        store_deltas_by_key
+            .keys()
+            .collect::<Vec<_>>()
+    );
+
+    updates
+}
+
+#[cfg(test)]
+mod tests {
+    use substreams::pb::substreams::StoreDelta;
+
+    use super::*;
+    use crate::pb::uniswap::v3::{TickDelta, TickDeltas, Transaction as PbTransaction};
+
+    const POOL: [u8; 20] = [0xaa; 20];
+
+    fn tick_delta(tick: i32, ordinal: u64, tx_index: u64) -> TickDelta {
+        TickDelta {
+            pool_address: POOL.to_vec(),
+            tick_index: tick,
+            liquidity_net_delta: vec![],
+            ordinal,
+            transaction: Some(PbTransaction {
+                hash: vec![0x11; 32],
+                from: vec![0x22; 20],
+                to: vec![0x33; 20],
+                index: tx_index,
+            }),
+        }
+    }
+
+    fn store_delta(tick: i32, ordinal: u64, old: &str, new: &str) -> StoreDelta {
+        StoreDelta {
+            operation: 0,
+            ordinal,
+            key: tick_store_key(&POOL, tick),
+            old_value: old.as_bytes().to_vec(),
+            new_value: new.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn store_deltas_join_by_key_not_position() {
+        // One Mint, so both ticks carry ordinal 5. The store wrote the upper tick first, which
+        // the unstable sort in store_ticks_liquidity can produce for a tied ordinal.
+        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1), tick_delta(100, 5, 1)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![store_delta(100, 5, "", "75"), store_delta(-100, 5, "100", "150")],
+        };
+
+        let updates = ticks_to_attribute_updates(map_deltas, store_deltas);
+
+        let lower = &updates[0].2;
+        assert_eq!(lower.name, "ticks/-100/net-liquidity");
+        assert_eq!(lower.value, BigInt::from(150).to_signed_bytes_be());
+        assert_eq!(lower.change, i32::from(ChangeType::Update));
+
+        let upper = &updates[1].2;
+        assert_eq!(upper.name, "ticks/100/net-liquidity");
+        assert_eq!(upper.value, BigInt::from(75).to_signed_bytes_be());
+        assert_eq!(upper.change, i32::from(ChangeType::Creation));
+    }
+
+    #[test]
+    fn same_tick_written_in_two_transactions() {
+        // One tick touched twice in a block: created in tx 1, then back to zero in tx 2, which
+        // must classify as a deletion. Dropping the ordinal from the key would collapse the two
+        // store deltas into one.
+        let map_deltas =
+            TickDeltas { deltas: vec![tick_delta(-100, 5, 1), tick_delta(-100, 9, 2)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![store_delta(-100, 5, "", "40"), store_delta(-100, 9, "40", "0")],
+        };
+
+        let updates = ticks_to_attribute_updates(map_deltas, store_deltas);
+
+        assert_eq!(updates[0].0.index, 1);
+        assert_eq!(updates[0].2.value, BigInt::from(40).to_signed_bytes_be());
+        assert_eq!(updates[0].2.change, i32::from(ChangeType::Creation));
+
+        assert_eq!(updates[1].0.index, 2);
+        assert_eq!(updates[1].2.value, BigInt::from(0).to_signed_bytes_be());
+        assert_eq!(updates[1].2.change, i32::from(ChangeType::Deletion));
+    }
+
+    #[test]
+    #[should_panic(expected = "no net-liquidity store delta for")]
+    fn tick_delta_without_store_delta_panics() {
+        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
+        let store_deltas = StoreDeltas { deltas: vec![store_delta(-100, 7, "", "40")] };
+
+        ticks_to_attribute_updates(map_deltas, store_deltas);
+    }
+
+    #[test]
+    #[should_panic(expected = "without a matching tick delta")]
+    fn store_delta_without_tick_delta_panics() {
+        let map_deltas = TickDeltas { deltas: vec![tick_delta(-100, 5, 1)] };
+        let store_deltas = StoreDeltas {
+            deltas: vec![store_delta(-100, 5, "", "40"), store_delta(200, 5, "", "40")],
+        };
+
+        ticks_to_attribute_updates(map_deltas, store_deltas);
     }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/unichain-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/unichain-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_uniswap_v3"
-  version: v0.1.4
+  version: v0.1.5
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:


### PR DESCRIPTION
## Problem

`ethereum-uniswap-v3-logs-only` and `ethereum-pancakeswap-v3` have the same defect that
https://github.com/propeller-heads/tycho/pull/1400 fixes for V4. Their tick modules were
byte-identical. `ticks/<idx>/net-liquidity` can carry the value of the wrong tick, and a tick's
first write can be labelled `Update` instead of `Creation`, which leaves the indexer with no prior
value on revert. The wrong value also feeds simulation.

## Root cause

`map_ticks_changes` emits two tick deltas per `Mint` or `Burn`, one for `tick_lower` and one for
`tick_upper`, both carrying the event's log ordinal. `store_ticks_liquidity` orders its writes with
`sort_unstable_by_key` on that ordinal, so it can swap the tied pair. The consumer paired store
deltas with tick deltas by position, so after a swap one tick's attribute name received the other
tick's value and ChangeType.

## Fix

Store deltas are joined by `(store key, ordinal)`. The key is unique: V3 rejects
`tickLower >= tickUpper`, so one event cannot write the same tick twice, and different events have
different log ordinals.

One addition over the V4 patch: the key is built in one place, `tick_store_key`, called by the
writer and the consumer. V3 uses `hex::encode` with no `0x` prefix, unlike V4's `to_hex`, so a
duplicated format string is easy to get wrong in the direction that fails silently.

The join moved into `ticks_to_attribute_updates` because `#[substreams::handlers::map]` takes the
handler's name, leaving no plain function to unit test. Four tests per package. Reverting to
positional pairing, or dropping the ordinal from the key, each fails a test.

## Rollout

New spkgs needed: `ethereum-uniswap-v3-logs-only` v0.1.5 (8 manifests) and
`ethereum-pancakeswap-v3` v0.1.3 (4 manifests), one workflow dispatch per manifest. The
`helm-configuration` pins are not enumerated here.

Publish a pre-release spkg and run it over a range with V3 liquidity activity before pinning
anything. The join panics where the previous zip silently mispaired changes, so this replaces a
silent error with a hard stop. Then pin one dev chain, watch
`extractor_revert_attr_miss{component_state_found="true"}`, and roll out the rest dev before prod.

## Notes for reviewers

One commit fixes a redundant reference in a `format!` argument in
`ethereum-pancakeswap-v3/src/modules/4_map_and_store_liquidity.rs`. It is pre-existing on main and
unrelated, but it fails `clippy -D warnings` on current nightly, and touching this package is what
makes CI lint it.

The pool-liquidity zip in the same function stays positional in both packages. It is sound today,
because each event produces at most one liquidity change with a unique ordinal.

`polygon-ramses-v3`, `ethereum-ekubo-v2` and `ethereum-ekubo-v3` also pair tick store deltas by
position. They are correct today only because their store modules do not sort, and nothing enforces
that. Hardening them means three more package versions and releases, so it is left out.
`ethereum-uniswap-v3`, the storage-based package, has no tick store and is unaffected.
